### PR TITLE
Add The Wikipedia Library

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -3956,6 +3956,10 @@
     "url": "http://manchester.idm.oclc.org/login?url=$@"
   },
   {
+    "name": "The Wikipedia Library",
+    "url": "https://wikipedialibrary.idm.oclc.org/login?auth=production&url=$@"
+  },
+  {
     "name": "Thomas More",
     "url": "http://library.thomasmore.edu:2048/login?url=$@"
   },


### PR DESCRIPTION
Added [The Wikipedia Library](https://wikipedialibrary.wmflabs.org/), a ezproxy instance for cleared Wikipedia editors.