### PR TITLE
Change d'Évry Val d'Essonne to Paris-Saclay

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -5444,7 +5444,7 @@
     "url": "http://ezproxy.univ-artois.fr/login?url=$@"
   },
   {
-    "name": "Université d'Évry Val d'Essonne",
+    "name": "Université Paris-Saclay",
     "url": "http://ezproxy.universite-paris-saclay.fr/login?url=$@"
   },
   {


### PR DESCRIPTION
This link works for all universities attached to University Paris Saclay not just Evry Val d'Essone