### PR TITLE
proxies: Update entry for Sheba Medical Center Library

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -3545,7 +3545,7 @@
   },
   {
     "name": "Sheba Medical Center Library",
-    "url": "https://sheba-tdnetdiscover-com.sheba-ez.medlcp.tau.ac.il/logging/outgoing?url=$@"
+    "url": "https://sheba-tdnetdiscover-com.sheba.idm.oclc.org/logging/outgoing?url=$@"
   },
   {
     "name": "Sheffield Hallam University",


### PR DESCRIPTION
Base domain was changed around 04/2022.

[https://library.sheba.co.il/158357](https://library.sheba.co.il/158357)

> כניסה לאתר הספרייה ממחשב פרטי אפשרית גם עם https://sheba.idm.oclc.org .
לאחר login - מוצג שוב אתר הספריה - להקליק על מקורות מקוונים כדי לעבור לדף קישורים