### PR TITLE
Update Yonsei University Link

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -5853,7 +5853,7 @@
   },
   {
     "name": "Yonsei",
-    "url": "http://openlink.access.yonsei.ac.kr/link.n2s?url=$@"
+    "url": "https://access.yonsei.ac.kr/link.n2s?url=$@"
   },
   {
     "name": "York College",


### PR DESCRIPTION
Update Link of Yonsei University Library
The previous link is broken with "Request Canceled. It is Embedded HTTPD functions disabled." response.
link of school library usage: https://library.yonsei.ac.kr/local/html/off-campusAccess