### PR TITLE
Update proxies.json

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -2592,6 +2592,10 @@
     "url": "https://ezproxy.waterfield.murraystate.edu/login?url=$@"
   },
   {
+    "name": "Mälardalens universitet",
+    "url": "https://ep.bib.mdh.se/login?url=$@"
+  },
+  {
     "name": "Médiathèques FM6",
     "url": "http://proxy.mediatheque-fm6.ma/login?url=$@"
   },


### PR DESCRIPTION
Adding Mälardalen University (Mälardalens universitet) in Sweden so that students there can use the EZProxy Extensions.