### PR TITLE
Update Swinburne University

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -3837,7 +3837,7 @@
   },
   {
     "name": "Swinburne University",
-    "url": "http://ezproxy.lib.swin.edu.au/login?url=$@"
+    "url": "https://go.openathens.net/redirector/swin.edu.au?url=$@"
   },
   {
     "name": "Syracuse",


### PR DESCRIPTION
Recent switch from ezProxy to OpenAthens at Swinburne broke the existing URLs. This commit updates the entry to use the updated URL (following similar instruction from [here](https://commons.swinburne.edu.au/items/c63a56f0-be1f-4596-bd5b-4bed4bd48358/1/)).