### PR TITLE
Update EZProxy URL of HKUST

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -1673,7 +1673,7 @@
   },
   {
     "name": "Hong Kong University of Science and Technology",
-    "url": "http://ezproxy.ust.hk/login?url=$@"
+    "url": "https://lib.ezproxy.ust.hk/login?url=$@"
   },
   {
     "name": "Hood",


### PR DESCRIPTION
Following the [recent update](https://library.hkust.edu.hk/collections-resources/databases/ezproxy/) from the Library of the Hong Kong University of Science and Technology, the EZProxy URL format is changed accordingly in this commit.