### PR TITLE
Updated Proxy for University of Queensland

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -5033,7 +5033,7 @@
   },
   {
     "name": "University of Queensland",
-    "url": "http://ezproxy.library.uq.edu.au/login?url=$@"
+    "url": "https://resolver.library.uq.edu.au/openathens/redir?url=$@"
   },
   {
     "name": "University of Regina",


### PR DESCRIPTION
UQ has migrated from ezproxy to openathens and we have a custom redirection endpoint that mimics the ezproxy prefix url