### PR TITLE
Propose to add two new fields: location and country.

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -3006,6 +3006,15 @@
     "country": "United States"
   },
   {
+    "name": "Evergreen Valley College",
+    "url": "https://login.evcezproxy.evc.edu/login?url=",
+    "location": {
+      "lng": -121.76504700699878,
+      "lat": 37.301315100042586
+    },
+    "country": "United States"
+  },
+  {
     "name": "Fachhochschule Munster",
     "url": "https://www.hb.fh-muenster.de:2443/login?url=",
     "location": {
@@ -7659,6 +7668,15 @@
     "country": "United States"
   },
   {
+    "name": "San Jose City College",
+    "url": "https://login.sjccezproxy.sjcc.edu/login?url=",
+    "location": {
+      "lng": -121.92723079518598,
+      "lat": 37.31480350267728
+    },
+    "country": "United States"
+  },
+  {
     "name": "San Jose State University",
     "url": "http://libaccess.sjlibrary.org/login?url=",
     "location": {
@@ -11791,7 +11809,7 @@
   },
   {
     "name": "University of Tokyo (UTOKYO)",
-    "url": "https://login.ezoris.lib.u-tokyo.ac.jp/login?url=",
+    "url": "https://utokyo.idm.oclc.org/login?url=",
     "location": {
       "lng": 139.761989,
       "lat": 35.7126775

--- a/static/proxies.json
+++ b/static/proxies.json
@@ -4,18 +4,6 @@
     "url": "http://p.atsu.edu/login?url=$@"
   },
   {
-    "name": "AFIT D'Azzo Research Library",
-    "url": "https://login.afit.idm.oclc.org/login?url=$@"
-  },
-  {
-    "name": "AFRL D'Azzo Research Library",
-    "url": "http://wrs.idm.oclc.org/login?url=$@"
-  },
-  {
-    "name": "ANZCA",
-    "url": "http://ezproxy.anzca.edu.au/login?url=$@"
-  },
-  {
     "name": "Aalborg Universitet",
     "url": "http://zorac.aub.aau.dk/login?qurl=$@"
   },
@@ -44,12 +32,24 @@
     "url": "http://ezproxy.adler.edu/login?url=$@"
   },
   {
+    "name": "AFIT D'Azzo Research Library",
+    "url": "https://login.afit.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "AFRL D'Azzo Research Library",
+    "url": "http://wrs.idm.oclc.org/login?url=$@"
+  },
+  {
     "name": "Agency for Science Technology and Research",
     "url": "http://ejproxy.a-star.edu.sg/login?url=$@"
   },
   {
     "name": "Aichi Shukutoku University Library",
     "url": "https://aasa.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "Air University",
+    "url": "http://aufric.idm.oclc.org/login?url=$@"
   },
   {
     "name": "Akademie ved Ceske republiky",
@@ -92,14 +92,6 @@
     "url": "http://ezproxy1.allegheny.edu:2048/login?url=$@"
   },
   {
-    "name": "American University, Washington, D.C.",
-    "url": "http://proxyau.wrlc.org/login?url=$@"
-  },
-  {
-    "name": "The American College of Greece",
-    "url": "https://acg.idm.oclc.org/login?url=$@"
-  },
-  {
     "name": "American Institutes for Research",
     "url": "https://air.idm.oclc.org/login?url=$@"
   },
@@ -113,19 +105,15 @@
   },
   {
     "name": "American Public University System",
-    "url": "https://login.ezproxy1.apus.edu/login?url=$@"
+    "url": "http://ezproxy.apus.edu/login?url=$@"
   },
   {
     "name": "American Public University System",
-    "url": "http://ezproxy.apus.edu/login?url=$@"
+    "url": "https://login.ezproxy1.apus.edu/login?url=$@"
   },
   {
     "name": "American University",
     "url": "https://myau.american.edu/my.policy?url=$@"
-  },
-  {
-    "name": "American University Washington College of Law",
-    "url": "http://proxy.wcl.american.edu/login?url=$@"
   },
   {
     "name": "American University in Cairo",
@@ -134,6 +122,14 @@
   {
     "name": "American University of Beirut",
     "url": "https://ezproxy.aub.edu.lb/login?url=$@"
+  },
+  {
+    "name": "American University Washington College of Law",
+    "url": "http://proxy.wcl.american.edu/login?url=$@"
+  },
+  {
+    "name": "American University, Washington, D.C.",
+    "url": "http://proxyau.wrlc.org/login?url=$@"
   },
   {
     "name": "Amherst College",
@@ -158,6 +154,10 @@
   {
     "name": "Antioch",
     "url": "https://antioch.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "ANZCA",
+    "url": "http://ezproxy.anzca.edu.au/login?url=$@"
   },
   {
     "name": "Arcadia",
@@ -252,10 +252,6 @@
     "url": "http://ezproxy.averett.edu/login?url=$@"
   },
   {
-    "name": "BI Norwegian Business School",
-    "url": "http://ezproxy.library.bi.no/login?url=$@"
-  },
-  {
     "name": "Baden State Library",
     "url": "https://login.ezproxy.blb-karlsruhe.de/login?url=$@"
   },
@@ -342,6 +338,10 @@
   {
     "name": "Bethel",
     "url": "http://ezproxy.bethel.edu/login?url=$@"
+  },
+  {
+    "name": "BI Norwegian Business School",
+    "url": "http://ezproxy.library.bi.no/login?url=$@"
   },
   {
     "name": "BiblioPl@nets - CNRS INIST",
@@ -500,110 +500,6 @@
     "url": "http://ez119.periodicos.capes.gov.br/login?url=$@"
   },
   {
-    "name": "CERN",
-    "url": "https://ezproxy.cern.ch/login?url=$@"
-  },
-  {
-    "name": "CETYS University",
-    "url": "https://ebiblio.cetys.mx/login?url=$@"
-  },
-  {
-    "name": "CIAP, NSW Health",
-    "url": "http://acs.hcn.com.au/?acc=36422&url=$@"
-  },
-  {
-    "name": "CNRS INEE",
-    "url": "http://inee.bib.cnrs.fr/login?url=$@"
-  },
-  {
-    "name": "CNRS INSB",
-    "url": "http://insb.bib.cnrs.fr/login?url=$@"
-  },
-  {
-    "name": "CQUniversity Australia",
-    "url": "https://ezproxy.cqu.edu.au/login?url=$@"
-  },
-  {
-    "name": "CSU Chico",
-    "url": "http://mantis.csuchico.edu/login?url=$@"
-  },
-  {
-    "name": "CSU East Bay",
-    "url": "http://proxylib.csueastbay.edu/login?url=$@"
-  },
-  {
-    "name": "CSU Fresno",
-    "url": "http://hmlproxy.lib.csufresno.edu/login?url=$@"
-  },
-  {
-    "name": "CSU Sacramento",
-    "url": "http://proxy.lib.csus.edu/login?url=$@"
-  },
-  {
-    "name": "CSU San Bernardino",
-    "url": "http://libproxy.lib.csusb.edu/login?url=$@"
-  },
-  {
-    "name": "CUNY Baruch",
-    "url": "http://remote.baruch.cuny.edu/login?url=$@"
-  },
-  {
-    "name": "CUNY Central Office",
-    "url": "http://central.ezproxy.cuny.edu:2048/login?url=$@"
-  },
-  {
-    "name": "CUNY City College of New York",
-    "url": "http://ccny-proxy1.libr.ccny.cuny.edu/login?url=$@"
-  },
-  {
-    "name": "CUNY College of Staten Island",
-    "url": "http://proxy.library.csi.cuny.edu/login?url=$@"
-  },
-  {
-    "name": "CUNY Graduate School of Journalism",
-    "url": "http://journalism.ezproxy.cuny.edu:2048/login?url=$@"
-  },
-  {
-    "name": "CUNY Hostos",
-    "url": "http://hostos.ezproxy.cuny.edu:2048/login?url=$@"
-  },
-  {
-    "name": "CUNY Hunter",
-    "url": "http://proxy.wexler.hunter.cuny.edu/login?url=$@"
-  },
-  {
-    "name": "CUNY John Jay College of Criminal Justice",
-    "url": "http://ez.lib.jjay.cuny.edu/login?url=$@"
-  },
-  {
-    "name": "CUNY Kingsborough",
-    "url": "http://kbcc.ezproxy.cuny.edu:2048/login?url=$@"
-  },
-  {
-    "name": "CUNY Law School",
-    "url": "http://law.ezproxy.cuny.edu:2048/login?url=$@"
-  },
-  {
-    "name": "CUNY Medgar Evers",
-    "url": "http://mec.ezproxy.cuny.edu:2048/login?url=$@"
-  },
-  {
-    "name": "CUNY New York City College of Technology",
-    "url": "http://citytech.ezproxy.cuny.edu:2048/login?url=$@"
-  },
-  {
-    "name": "CUNY Queens",
-    "url": "http://queens.ezproxy.cuny.edu:2048/login?url=$@"
-  },
-  {
-    "name": "CUNY Queensborough",
-    "url": "http://qbcc.ezproxy.cuny.edu:2048/login?url=$@"
-  },
-  {
-    "name": "CUNY York",
-    "url": "http://york.ezproxy.cuny.edu:2048/login?url=$@"
-  },
-  {
     "name": "Cal Poly Pomona",
     "url": "https://login.proxy.library.cpp.edu/login?url=$@"
   },
@@ -632,6 +528,10 @@
     "url": "https://calpoly.idm.oclc.org/login?url=$@"
   },
   {
+    "name": "California State University Long Beach",
+    "url": "https://csulb.idm.oclc.org/login?url=$@"
+  },
+  {
     "name": "California State University San Marcos",
     "url": "https://ezproxy.csusm.edu/login?url=$@"
   },
@@ -642,10 +542,6 @@
   {
     "name": "California State University, Fullerton",
     "url": "http://lib-proxy.fullerton.edu/login?url=$@"
-  },
-  {
-    "name": "California State University Long Beach",
-    "url": "https://csulb.idm.oclc.org/login?url=$@"
   },
   {
     "name": "California State University, Los Angeles",
@@ -744,10 +640,6 @@
     "url": "http://ezproxy.cayuga-cc.edu:2048/login?url=$@"
   },
   {
-    "name": "CeRA - Indian Agricultural Research Institute",
-    "url": "http://14.139.56.75/login?url=$@"
-  },
-  {
     "name": "Cedars-Sinai Medical Center",
     "url": "http://mlprox.csmc.edu/login?url=$@"
   },
@@ -780,20 +672,32 @@
     "url": "https://ezproxy.centre.edu/login?url=$@"
   },
   {
+    "name": "CeRA - Indian Agricultural Research Institute",
+    "url": "http://14.139.56.75/login?url=$@"
+  },
+  {
+    "name": "CERN",
+    "url": "https://ezproxy.cern.ch/login?url=$@"
+  },
+  {
     "name": "Cerro Coso",
     "url": "http://ezproxy.cerrocoso.edu:2048/login?url=$@"
+  },
+  {
+    "name": "CETYS University",
+    "url": "https://ebiblio.cetys.mx/login?url=$@"
   },
   {
     "name": "Chadli Bendjedid University",
     "url": "http://ezproxy.univ-eltarf.dz/login?url=$@"
   },
   {
-    "name": "Chalmers University of Technology",
-    "url": "https://login.proxy.lib.chalmers.se/login?url=$@"
-  },
-  {
     "name": "Chalmers tekniska hogskola AB",
     "url": "http://proxy.lib.chalmers.se/login?url=$@"
+  },
+  {
+    "name": "Chalmers University of Technology",
+    "url": "https://login.proxy.lib.chalmers.se/login?url=$@"
   },
   {
     "name": "Champlain College Online",
@@ -834,6 +738,10 @@
   {
     "name": "Chinese University of Hong Kong",
     "url": "https://easylogin1.lib.cuhk.edu.hk/login?url=$@"
+  },
+  {
+    "name": "CIAP, NSW Health",
+    "url": "http://acs.hcn.com.au/?acc=36422&url=$@"
   },
   {
     "name": "Cincinnati State Technical and",
@@ -900,6 +808,14 @@
     "url": "http://ezproxy.clinton.edu:2048/login?url=$@"
   },
   {
+    "name": "CNRS INEE",
+    "url": "http://inee.bib.cnrs.fr/login?url=$@"
+  },
+  {
+    "name": "CNRS INSB",
+    "url": "http://insb.bib.cnrs.fr/login?url=$@"
+  },
+  {
     "name": "Coastal Carolina",
     "url": "http://login.library.coastal.edu:2048/login?url=$@"
   },
@@ -928,10 +844,6 @@
     "url": "http://ezproxy.library.csn.edu/login?url=$@"
   },
   {
-    "name": "College of William and Mary",
-    "url": "https://proxy.wm.edu/login?url=$@"
-  },
-  {
     "name": "College of the Canyons",
     "url": "http://ezproxy.canyons.edu:2048/login?url=$@"
   },
@@ -946,6 +858,10 @@
   {
     "name": "College of the Sequoias",
     "url": "http://cos.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "College of William and Mary",
+    "url": "https://proxy.wm.edu/login?url=$@"
   },
   {
     "name": "Colorado Mountain",
@@ -1040,10 +956,6 @@
     "url": "http://encompass.library.cornell.edu/cgi-bin/checkIP.cgi?access=gateway_standard&url=$@"
   },
   {
-    "name": "SUNY Corning Community College",
-    "url": "http://ezproxy.corning-cc.edu:2048/login?url=$@"
-  },
-  {
     "name": "County College of Morris",
     "url": "http://skynet.ccm.edu:2048/login?url=$@"
   },
@@ -1052,8 +964,92 @@
     "url": "https://search.covenantseminary.edu/login?url=$@"
   },
   {
+    "name": "CQUniversity Australia",
+    "url": "https://ezproxy.cqu.edu.au/login?url=$@"
+  },
+  {
     "name": "Creighton University",
     "url": "https://login.cuhsl.creighton.edu/login?url=$@"
+  },
+  {
+    "name": "CSU Chico",
+    "url": "http://mantis.csuchico.edu/login?url=$@"
+  },
+  {
+    "name": "CSU East Bay",
+    "url": "http://proxylib.csueastbay.edu/login?url=$@"
+  },
+  {
+    "name": "CSU Fresno",
+    "url": "http://hmlproxy.lib.csufresno.edu/login?url=$@"
+  },
+  {
+    "name": "CSU Sacramento",
+    "url": "http://proxy.lib.csus.edu/login?url=$@"
+  },
+  {
+    "name": "CSU San Bernardino",
+    "url": "http://libproxy.lib.csusb.edu/login?url=$@"
+  },
+  {
+    "name": "CUNY Baruch",
+    "url": "http://remote.baruch.cuny.edu/login?url=$@"
+  },
+  {
+    "name": "CUNY Central Office",
+    "url": "http://central.ezproxy.cuny.edu:2048/login?url=$@"
+  },
+  {
+    "name": "CUNY City College of New York",
+    "url": "http://ccny-proxy1.libr.ccny.cuny.edu/login?url=$@"
+  },
+  {
+    "name": "CUNY College of Staten Island",
+    "url": "http://proxy.library.csi.cuny.edu/login?url=$@"
+  },
+  {
+    "name": "CUNY Graduate School of Journalism",
+    "url": "http://journalism.ezproxy.cuny.edu:2048/login?url=$@"
+  },
+  {
+    "name": "CUNY Hostos",
+    "url": "http://hostos.ezproxy.cuny.edu:2048/login?url=$@"
+  },
+  {
+    "name": "CUNY Hunter",
+    "url": "http://proxy.wexler.hunter.cuny.edu/login?url=$@"
+  },
+  {
+    "name": "CUNY John Jay College of Criminal Justice",
+    "url": "http://ez.lib.jjay.cuny.edu/login?url=$@"
+  },
+  {
+    "name": "CUNY Kingsborough",
+    "url": "http://kbcc.ezproxy.cuny.edu:2048/login?url=$@"
+  },
+  {
+    "name": "CUNY Law School",
+    "url": "http://law.ezproxy.cuny.edu:2048/login?url=$@"
+  },
+  {
+    "name": "CUNY Medgar Evers",
+    "url": "http://mec.ezproxy.cuny.edu:2048/login?url=$@"
+  },
+  {
+    "name": "CUNY New York City College of Technology",
+    "url": "http://citytech.ezproxy.cuny.edu:2048/login?url=$@"
+  },
+  {
+    "name": "CUNY Queens",
+    "url": "http://queens.ezproxy.cuny.edu:2048/login?url=$@"
+  },
+  {
+    "name": "CUNY Queensborough",
+    "url": "http://qbcc.ezproxy.cuny.edu:2048/login?url=$@"
+  },
+  {
+    "name": "CUNY York",
+    "url": "http://york.ezproxy.cuny.edu:2048/login?url=$@"
   },
   {
     "name": "Curry College",
@@ -1066,10 +1062,6 @@
   {
     "name": "Curtin University",
     "url": "https://link.library.curtin.edu.au/gw?url=$@"
-  },
-  {
-    "name": "DYouville",
-    "url": "https://dyc.idm.oclc.org/login?url=$@"
   },
   {
     "name": "Dakota Wesleyan",
@@ -1097,11 +1089,11 @@
   },
   {
     "name": "Davidson College",
-    "url": "http://ezproxy.lib.davidson.edu/login?url=$@"
+    "url": "https://login.proxy048.nclive.org/login?url=$@"
   },
   {
     "name": "Davidson College",
-    "url": "https://login.proxy048.nclive.org/login?url=$@"
+    "url": "http://ezproxy.lib.davidson.edu/login?url=$@"
   },
   {
     "name": "Daviess County Public Library",
@@ -1114,10 +1106,6 @@
   {
     "name": "De Montfort University",
     "url": "http://proxy.library.dmu.ac.uk/login?url=$@"
-  },
-  {
-    "name": "DeVry",
-    "url": "http://proxy.devry.edu/login?url=$@"
   },
   {
     "name": "Deakin University",
@@ -1134,6 +1122,10 @@
   {
     "name": "Delta College",
     "url": "http://ezproxy.delta.edu:2048/login?url=$@"
+  },
+  {
+    "name": "DeVry",
+    "url": "http://proxy.devry.edu/login?url=$@"
   },
   {
     "name": "Dickinson College",
@@ -1184,20 +1176,8 @@
     "url": "http://ezproxy.dscc.edu:2048/login?url=$@"
   },
   {
-    "name": "ENCG Settat",
-    "url": "https://www.ezproxy.uh1.ac.ma/login?url=$@"
-  },
-  {
-    "name": "ERDC",
-    "url": "http://erdclibrary.idm.oclc.org/login?url=$@"
-  },
-  {
-    "name": "ESSEC Business School",
-    "url": "https://login.ezp.essec.fr/login?url=$@"
-  },
-  {
-    "name": "ETH Zurich",
-    "url": "https://proxy.ethz.ch/cgi-bin/login.pl?url=$@"
+    "name": "DYouville",
+    "url": "https://dyc.idm.oclc.org/login?url=$@"
   },
   {
     "name": "Earlham College",
@@ -1324,12 +1304,28 @@
     "url": "https://proxy.library.emory.edu/login?url=$@"
   },
   {
+    "name": "ENCG Settat",
+    "url": "https://www.ezproxy.uh1.ac.ma/login?url=$@"
+  },
+  {
     "name": "Erasmus University Rotterdam",
     "url": "https://eur.idm.oclc.org/login?url=$@"
   },
   {
+    "name": "ERDC",
+    "url": "http://erdclibrary.idm.oclc.org/login?url=$@"
+  },
+  {
     "name": "Erie",
     "url": "https://ezproxy.ecc.edu:2443/login?url=$@"
+  },
+  {
+    "name": "ESSEC Business School",
+    "url": "https://login.ezp.essec.fr/login?url=$@"
+  },
+  {
+    "name": "ETH Zurich",
+    "url": "https://proxy.ethz.ch/cgi-bin/login.pl?url=$@"
   },
   {
     "name": "European University Institute",
@@ -1342,10 +1338,6 @@
   {
     "name": "Everett",
     "url": "http://ezproxy.everettcc.edu/login?url=$@"
-  },
-  {
-    "name": "Evergreen Valley College",
-    "url": "https://login.evcezproxy.evc.edu/login?url=$@"
   },
   {
     "name": "Fachhochschule Munster",
@@ -1548,18 +1540,6 @@
     "url": "http://ezproxy.gtcc.edu:2048/login?url=$@"
   },
   {
-    "name": "HEC Paris",
-    "url": "http://ezproxy.hec.fr/login?url=$@"
-  },
-  {
-    "name": "HEIG-VD",
-    "url": "https://biblioproxy.heig-vd.ch/login?url=$@"
-  },
-  {
-    "name": "HELP University",
-    "url": "https://ezproxy.help.edu.my/login?url=$@"
-  },
-  {
     "name": "Halmstad University",
     "url": "https://ezproxy.bib.hh.se/login?url=$@"
   },
@@ -1608,8 +1588,20 @@
     "url": "http://proxy2.hec.ca/login?url=$@"
   },
   {
+    "name": "HEC Paris",
+    "url": "http://ezproxy.hec.fr/login?url=$@"
+  },
+  {
+    "name": "HEIG-VD",
+    "url": "https://biblioproxy.heig-vd.ch/login?url=$@"
+  },
+  {
     "name": "Hellenic Open University (EAP)",
     "url": "http://proxy.eap.gr/login?url=$@"
+  },
+  {
+    "name": "HELP University",
+    "url": "https://ezproxy.help.edu.my/login?url=$@"
   },
   {
     "name": "Helsingin yliopisto",
@@ -1712,8 +1704,16 @@
     "url": "https://login.galanga.hvl.no/login?url=$@"
   },
   {
+    "name": "Ibn Haldun University Library",
+    "url": "https://offcampus.ihu.edu.tr/login?url=$@"
+  },
+  {
     "name": "Idaho College of Osteopathic Medicine",
     "url": "https://icom.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "Idaho State",
+    "url": "http://libpublic3.library.isu.edu/login?url=$@"
   },
   {
     "name": "IIT Chicago-Kent College of Law",
@@ -1722,30 +1722,6 @@
   {
     "name": "IIT Italian Institute of Technology",
     "url": "https://login.biblio.iit.it/login?url=$@"
-  },
-  {
-    "name": "INSA de Rennes",
-    "url": "http://rproxy.insa-rennes.fr/login?url=$@"
-  },
-  {
-    "name": "Institut de l'Information Scientifique et Technique (INSERM)",
-    "url": "https://proxy.insermbiblio.inist.fr/login?url=$@"
-  },
-  {
-    "name": "IT University of Copenhagen",
-    "url": "https://ep.ituproxy.kb.dk/login?url=$@"
-  },
-  {
-    "name": "IUCAA",
-    "url": "http://ezproxy.iucaa.ernet.in:2048/login?url=$@"
-  },
-  {
-    "name": "Ibn Haldun University Library",
-    "url": "https://offcampus.ihu.edu.tr/login?url=$@"
-  },
-  {
-    "name": "Idaho State",
-    "url": "http://libpublic3.library.isu.edu/login?url=$@"
   },
   {
     "name": "Illinois Institute of Technology",
@@ -1772,6 +1748,10 @@
     "url": "http://proxyiub.uits.iu.edu/login?url=$@"
   },
   {
+    "name": "Indiana University of Pennsylvania",
+    "url": "http://proxy-iup.klnpa.org/login?url=$@"
+  },
+  {
     "name": "Indiana University Purdue University Indianapolis",
     "url": "http://proxy.ulib.iupui.edu/login?url=$@"
   },
@@ -1780,20 +1760,28 @@
     "url": "https://proxy.medlib.iupui.edu/login?url=$@"
   },
   {
-    "name": "Indiana University of Pennsylvania",
-    "url": "http://proxy-iup.klnpa.org/login?url=$@"
+    "name": "INFLIBNET Centre (Information and Library Network Centre)",
+    "url": "http://nlist.inflibnet.ac.in:2048/login?url=$@"
   },
   {
-    "name": "Institut National Polytechnique - Toulouse",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
+    "name": "INSA de Rennes",
+    "url": "http://rproxy.insa-rennes.fr/login?url=$@"
+  },
+  {
+    "name": "Institut de l'Information Scientifique et Technique (INSERM)",
+    "url": "https://proxy.insermbiblio.inist.fr/login?url=$@"
+  },
+  {
+    "name": "Institut national de la recherche scientifique",
+    "url": "http://erable.inrs.ca:2048/login?url=$@"
   },
   {
     "name": "Institut National des Sciences Appliquées  - Toulouse",
     "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
   },
   {
-    "name": "Institut national de la recherche scientifique",
-    "url": "http://erable.inrs.ca:2048/login?url=$@"
+    "name": "Institut National Polytechnique - Toulouse",
+    "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
   },
   {
     "name": "Institut national universitaire Jean-François - Champollion",
@@ -1832,12 +1820,20 @@
     "url": "http://ezp.isikun.edu.tr/login?url=$@"
   },
   {
+    "name": "IT University of Copenhagen",
+    "url": "https://ep.ituproxy.kb.dk/login?url=$@"
+  },
+  {
     "name": "Ita-Suomen yliopisto",
     "url": "http://ezproxy.uef.fi:2048/login?url=$@"
   },
   {
     "name": "Ithaca",
     "url": "https://login.ezproxy.ithaca.edu/login?qurl=$@"
+  },
+  {
+    "name": "IUCAA",
+    "url": "http://ezproxy.iucaa.ernet.in:2048/login?url=$@"
   },
   {
     "name": "Ivy Tech",
@@ -1848,8 +1844,8 @@
     "url": "http://ej.iwate-med.ac.jp:2048/login?url=$@"
   },
   {
-    "name": "The Jackson Laboratory",
-    "url": "http://ezproxy.jax.org/login?url=$@"
+    "name": "İzmir Institute of Technology",
+    "url": "http://libezproxy.iyte.edu.tr:81/login?url=$@"
   },
   {
     "name": "Jackson State",
@@ -1904,10 +1900,6 @@
     "url": "http://ezproxy.jyu.fi/login?url=$@"
   },
   {
-    "name": "KULeuven",
-    "url": "https://kuleuven.e-bronnen.be/login?url=$@"
-  },
-  {
     "name": "Kadir Has University Library",
     "url": "https://icproxy.khas.edu.tr/login?url=$@"
   },
@@ -1942,10 +1934,6 @@
   {
     "name": "Keiser University",
     "url": "http://ezproxy.keiser.edu/login?url=$@"
-  },
-  {
-    "name": "National Louis University (Kendall)",
-    "url": "http://ezp.kendall.edu/login?url=$@"
   },
   {
     "name": "Kennesaw State",
@@ -2012,6 +2000,10 @@
     "url": "http://egms.idm.oclc.org/login?url=$@"
   },
   {
+    "name": "KULeuven",
+    "url": "https://kuleuven.e-bronnen.be/login?url=$@"
+  },
+  {
     "name": "Kungliga Tekniska Hogskolan",
     "url": "http://focus.lib.kth.se/login?url=$@"
   },
@@ -2038,10 +2030,6 @@
   {
     "name": "LA BioMed",
     "url": "http://journals.labiomed.org/login?url=$@"
-  },
-  {
-    "name": "LSU Health Sciences Center New Orleans",
-    "url": "https://ezproxy.lsuhsc.edu/login?url=$@"
   },
   {
     "name": "La Salle",
@@ -2100,16 +2088,12 @@
     "url": "https://login.librweb.laurentian.ca/login?url=$@"
   },
   {
-    "name": "Lawrence University",
-    "url": "http://proxy.lawrence.edu:2048/login?url=$@"
-  },
-  {
     "name": "Lawrence Technological",
     "url": "http://ezproxy.ltu.edu:8080/login?url=$@"
   },
   {
-    "name": "LeTourneau University",
-    "url": "http://research-db.letu.edu/login?url=$@"
+    "name": "Lawrence University",
+    "url": "http://proxy.lawrence.edu:2048/login?url=$@"
   },
   {
     "name": "Lebanese University",
@@ -2146,6 +2130,10 @@
   {
     "name": "Leiden University",
     "url": "https://ezproxy.leidenuniv.nl:2443/login?url=$@"
+  },
+  {
+    "name": "LeTourneau University",
+    "url": "http://research-db.letu.edu/login?url=$@"
   },
   {
     "name": "Lewis & Clark College",
@@ -2236,6 +2224,10 @@
     "url": "http://ezproxy.loyno.edu/login?url=$@"
   },
   {
+    "name": "LSU Health Sciences Center New Orleans",
+    "url": "https://ezproxy.lsuhsc.edu/login?url=$@"
+  },
+  {
     "name": "Ludwig-Maximilians-Universität München",
     "url": "http://emedien.ub.uni-muenchen.de/login?url=$@"
   },
@@ -2264,32 +2256,16 @@
     "url": "http://ezproxy.lynchburg.edu/login?url=$@"
   },
   {
-    "name": "MCPHS (Massachusetts College of Pharmacy and Health Science)",
-    "url": "https://ezproxymcp.flo.org/login?qurl=$@"
-  },
-  {
-    "name": "MEF University",
-    "url": "http://ezproxy.mef.edu.tr/login?url=$@"
-  },
-  {
-    "name": "MIT",
-    "url": "https://libproxy.mit.edu/cgi-bin/ezpauth?url=$@"
-  },
-  {
-    "name": "MPI for Human Development Berlin",
-    "url": "http://ezproxy.mpib-berlin.mpg.de/login?url=$@"
-  },
-  {
     "name": "Maastricht University",
     "url": "http://ezproxy.ub.unimaas.nl/login?url=$@"
   },
   {
-    "name": "MacEwan University",
-    "url": "http://ezproxy.macewan.ca/login?url=$@"
-  },
-  {
     "name": "Macalester",
     "url": "http://ezproxy.macalester.edu/login?url=$@"
+  },
+  {
+    "name": "MacEwan University",
+    "url": "http://ezproxy.macewan.ca/login?url=$@"
   },
   {
     "name": "Macquarie University",
@@ -2345,11 +2321,11 @@
   },
   {
     "name": "Marshall University",
-    "url": "http://ezproxy.marshall.edu:2048/login?url=$@"
+    "url": "http://marshall.idm.oclc.org/login?url=$@"
   },
   {
     "name": "Marshall University",
-    "url": "http://marshall.idm.oclc.org/login?url=$@"
+    "url": "http://ezproxy.marshall.edu:2048/login?url=$@"
   },
   {
     "name": "Marygrove",
@@ -2408,12 +2384,12 @@
     "url": "http://libaccess.lib.mcmaster.ca/login?url=$@"
   },
   {
-    "name": "Medical College of Wisconsin",
-    "url": "https://login.proxy.lib.mcw.edu/login?url=$@"
+    "name": "MCPHS (Massachusetts College of Pharmacy and Health Science)",
+    "url": "https://ezproxymcp.flo.org/login?qurl=$@"
   },
   {
-    "name": "Medical University Vienna",
-    "url": "http://ez.srv.meduniwien.ac.at/login?url=$@"
+    "name": "Medical College of Wisconsin",
+    "url": "https://login.proxy.lib.mcw.edu/login?url=$@"
   },
   {
     "name": "Medical University of Bialystok",
@@ -2422,6 +2398,14 @@
   {
     "name": "Medical University of South Carolina",
     "url": "http://ezproxy.musc.edu/login?url=$@"
+  },
+  {
+    "name": "Medical University Vienna",
+    "url": "http://ez.srv.meduniwien.ac.at/login?url=$@"
+  },
+  {
+    "name": "MEF University",
+    "url": "http://ezproxy.mef.edu.tr/login?url=$@"
   },
   {
     "name": "Memorial Sloan Kettering Cancer Center",
@@ -2516,6 +2500,10 @@
     "url": "http://libproxy.mst.edu:2048/login?url=$@"
   },
   {
+    "name": "MIT",
+    "url": "https://libproxy.mit.edu/cgi-bin/ezpauth?url=$@"
+  },
+  {
     "name": "Mohawk College",
     "url": "http://ezproxy.mohawkcollege.ca:2048/login?url=$@"
   },
@@ -2576,6 +2564,10 @@
     "url": "https://msm.idm.oclc.org/login?url=$@"
   },
   {
+    "name": "MPI for Human Development Berlin",
+    "url": "http://ezproxy.mpib-berlin.mpg.de/login?url=$@"
+  },
+  {
     "name": "Mt. Sinai School of Medicine (NYU)",
     "url": "http://eresources.library.mssm.edu:2048/login?url=$@"
   },
@@ -2602,22 +2594,6 @@
   {
     "name": "Médiathèques FM6",
     "url": "http://proxy.mediatheque-fm6.ma/login?url=$@"
-  },
-  {
-    "name": "INFLIBNET Centre (Information and Library Network Centre)",
-    "url": "http://nlist.inflibnet.ac.in:2048/login?url=$@"
-  },
-  {
-    "name": "NMIMS",
-    "url": "https://ezproxy.svkm.ac.in/login?url=$@"
-  },
-  {
-    "name": "NYU Alumni",
-    "url": "http://alumniproxy.library.nyu.edu/login?url=$@"
-  },
-  {
-    "name": "NYU Medical",
-    "url": "https://ezproxy.med.nyu.edu/login?url=$@"
   },
   {
     "name": "Nacionalna i sveucilisna knjiznica u Zagrebu",
@@ -2668,6 +2644,10 @@
     "url": "http://ezproxy.nihlibrary.nih.gov/login?url=$@"
   },
   {
+    "name": "National Louis University (Kendall)",
+    "url": "http://ezp.kendall.edu/login?url=$@"
+  },
+  {
     "name": "National Research Council Canada",
     "url": "https://login.pass.cisti-icist.nrc-cnrc.gc.ca/login?url=$@"
   },
@@ -2708,12 +2688,12 @@
     "url": "http://libproxy1.nus.edu.sg/login?url=$@"
   },
   {
-    "name": "National Yang-Ming",
-    "url": "http://ezproxy.lib.ym.edu.tw/login?url=$@"
-  },
-  {
     "name": "National Yang Ming Chiao Tung University",
     "url": "https://ezproxy.lib.nctu.edu.tw/login?url=$@"
+  },
+  {
+    "name": "National Yang-Ming",
+    "url": "http://ezproxy.lib.ym.edu.tw/login?url=$@"
   },
   {
     "name": "Naval Postgraduate School",
@@ -2804,6 +2784,10 @@
     "url": "http://roxy.nipissingu.ca/login?url=$@"
   },
   {
+    "name": "NMIMS",
+    "url": "https://ezproxy.svkm.ac.in/login?url=$@"
+  },
+  {
     "name": "Noble and Greenough School",
     "url": "https://ezproxy.nobles.edu/login?url=$@"
   },
@@ -2816,12 +2800,12 @@
     "url": "http://proxying.lib.ncsu.edu/index.php?url=$@"
   },
   {
-    "name": "North Central University",
-    "url": "https://ezproxy.northcentral.edu/login?url=$@"
-  },
-  {
     "name": "North Central Texas College",
     "url": "http://www.ezproxy.nctc.edu/login?url=$@"
+  },
+  {
+    "name": "North Central University",
+    "url": "https://ezproxy.northcentral.edu/login?url=$@"
   },
   {
     "name": "North Dakota State University",
@@ -2940,16 +2924,16 @@
     "url": "https://nunez.idm.oclc.org/login?url=$@"
   },
   {
+    "name": "NYU Alumni",
+    "url": "http://alumniproxy.library.nyu.edu/login?url=$@"
+  },
+  {
+    "name": "NYU Medical",
+    "url": "https://ezproxy.med.nyu.edu/login?url=$@"
+  },
+  {
     "name": "Národní technická knihovna",
     "url": "https://ezproxy.techlib.cz/login/?url=$@"
-  },
-  {
-    "name": "OCAD",
-    "url": "https://ocadu.idm.oclc.org/login?url=$@"
-  },
-  {
-    "name": "OSF HealthCare",
-    "url": "http://libproxy.osfhealthcare.org/login?url=$@"
   },
   {
     "name": "Oak Ridge National Laboratory",
@@ -2978,6 +2962,10 @@
   {
     "name": "Observatoire de Paris",
     "url": "http://ezproxy.obspm.fr/login?url=$@"
+  },
+  {
+    "name": "OCAD",
+    "url": "https://ocadu.idm.oclc.org/login?url=$@"
   },
   {
     "name": "Ohio",
@@ -3066,6 +3054,10 @@
   {
     "name": "Osaka",
     "url": "http://remote.library.osaka-u.ac.jp/login?url=$@"
+  },
+  {
+    "name": "OSF HealthCare",
+    "url": "http://libproxy.osfhealthcare.org/login?url=$@"
   },
   {
     "name": "Ottawa Public Library",
@@ -3164,12 +3156,12 @@
     "url": "https://plymouth.idm.oclc.org/login?url=$@"
   },
   {
-    "name": "Point University",
-    "url": "http://ezproxy.point.edu:2048/login?url=$@"
-  },
-  {
     "name": "Point Park",
     "url": "https://proxy.pointpark.edu/login?url=$@"
+  },
+  {
+    "name": "Point University",
+    "url": "http://ezproxy.point.edu:2048/login?url=$@"
   },
   {
     "name": "Politecnico di Torino",
@@ -3256,14 +3248,6 @@
     "url": "https://ezproxyqcc.helmlib.org/login?url=$@"
   },
   {
-    "name": "Rochester Institute of Technology",
-    "url": "http://ezproxy.rit.edu/login?url=$@"
-  },
-  {
-    "name": "RMIT University",
-    "url": "https://login.ezproxy.lib.rmit.edu.au/login?url=$@"
-  },
-  {
     "name": "Radboud University, Nijmegen",
     "url": "https://ru.idm.oclc.org/login?url=$@"
   },
@@ -3304,8 +3288,16 @@
     "url": "http://ezproxy.rcc.edu:2048/login?url=$@"
   },
   {
+    "name": "RMIT University",
+    "url": "https://login.ezproxy.lib.rmit.edu.au/login?url=$@"
+  },
+  {
     "name": "Robert Morris University",
     "url": "https://reddog.rmu.edu/login?url=$@"
+  },
+  {
+    "name": "Rochester Institute of Technology",
+    "url": "http://ezproxy.rit.edu/login?url=$@"
   },
   {
     "name": "Rollins",
@@ -3336,10 +3328,6 @@
     "url": "https://rcn.idm.oclc.org/login?url=$@"
   },
   {
-    "name": "The Royal College of Surgeons in Ireland",
-    "url": "https://login.proxy.library.rcsi.ie/login?url=$@"
-  },
-  {
     "name": "Royal College of Surgeons in Ireland - Medical University of Bahrain",
     "url": "https://login.ezproxy.rcsi.com/login?url=$@"
   },
@@ -3366,86 +3354,6 @@
   {
     "name": "Rutgers University",
     "url": "https://proxy.libraries.rutgers.edu/login?url=$@"
-  },
-  {
-    "name": "Salus University",
-    "url": "http://salus.idm.oclc.org/login?url=$@"
-  },
-  {
-    "name": "SHIRP (University of Saskatchewan)",
-    "url": "http://www.shirp.ca/doproxy?url=$@"
-  },
-  {
-    "name": "SNDL Systeme National de Documentation en Ligne",
-    "url": "http://www.sndl1.arn.dz/login?url=$@"
-  },
-  {
-    "name": "SUNY Buffalo State",
-    "url": "http://proxy.buffalostate.edu:2048/login?url=$@"
-  },
-  {
-    "name": "SUNY Cobleskill",
-    "url": "http://ezproxy.cobleskill.edu:2048/login?url=$@"
-  },
-  {
-    "name": "SUNY Cortland",
-    "url": "http://libproxy.cortland.edu/login?url=$@"
-  },
-  {
-    "name": "SUNY Downstate",
-    "url": "http://newproxy.downstate.edu/login?url=$@"
-  },
-  {
-    "name": "SUNY Dutchess",
-    "url": "http://is-ezproxy01.sunydutchess.edu:2048/login?url=$@"
-  },
-  {
-    "name": "SUNY Empire State",
-    "url": "http://library.esc.edu/login?url=$@"
-  },
-  {
-    "name": "SUNY Environmental Science and Forestry",
-    "url": "https://esf.idm.oclc.org/login?url=$@"
-  },
-  {
-    "name": "SUNY Farmingdale State",
-    "url": "http://hs1.farmingdale.edu:2048/login?url=$@"
-  },
-  {
-    "name": "SUNY Jefferson",
-    "url": "http://jccweb.sunyjefferson.edu:2048/login?url=$@"
-  },
-  {
-    "name": "SUNY New Paltz",
-    "url": "https://libdatabase.newpaltz.edu/login?url=$@"
-  },
-  {
-    "name": "SUNY Onondaga",
-    "url": "http://ezproxy.sunyocc.edu:2048/login?url=$@"
-  },
-  {
-    "name": "SUNY Polytechnic Institute",
-    "url": "http://ezproxy.sunyit.edu/login?url=$@"
-  },
-  {
-    "name": "SUNY Rockland",
-    "url": "http://ezproxy.sunyrockland.edu:2048/login?url=$@"
-  },
-  {
-    "name": "SUNY Schenectady County",
-    "url": "http://libproxy.sunysccc.edu/login?url=$@"
-  },
-  {
-    "name": "SUNY University at Albany",
-    "url": "https://libproxy.albany.edu/login?url=$@"
-  },
-  {
-    "name": "SUNY at Geneseo",
-    "url": "http://proxy.geneseo.edu:2048/login?url=$@"
-  },
-  {
-    "name": "SUNY at Oswego",
-    "url": "http://ezproxy.oswego.edu:2048/login?url=$@"
   },
   {
     "name": "Saint Louis",
@@ -3480,6 +3388,10 @@
     "url": "https://salford.idm.oclc.org/login?url=$@"
   },
   {
+    "name": "Salus University",
+    "url": "http://salus.idm.oclc.org/login?url=$@"
+  },
+  {
     "name": "Sam Houston State University",
     "url": "http://login.ezproxy.shsu.edu/login?url=$@"
   },
@@ -3494,10 +3406,6 @@
   {
     "name": "San Francisco State",
     "url": "http://jpllnet.sfsu.edu/login?url=$@"
-  },
-  {
-    "name": "San Jose City College",
-    "url": "https://login.sjccezproxy.sjcc.edu/login?url=$@"
   },
   {
     "name": "San Jose State University",
@@ -3532,10 +3440,6 @@
     "url": "http://ezproxy.scottsdalecc.edu:2048/login?url=$@"
   },
   {
-    "name": "Seattle University",
-    "url": "http://proxy.seattleu.edu/login?url=$@"
-  },
-  {
     "name": "Seattle Pacific University",
     "url": "http://ezproxy.spu.edu/login?url=$@"
   },
@@ -3544,16 +3448,20 @@
     "url": "https://ezproxy.spl.org/login?url=$@"
   },
   {
+    "name": "Seattle University",
+    "url": "http://proxy.seattleu.edu/login?url=$@"
+  },
+  {
     "name": "Seneca",
     "url": "http://lcweb.senecac.on.ca:2048/login?url=$@"
   },
   {
     "name": "Seoul National University",
-    "url": "https://lib.snu.ac.kr/user/login?proxyurl=$@"
+    "url": "https://ezproxy.snu.ac.kr/login?url=$@"
   },
   {
     "name": "Seoul National University",
-    "url": "https://ezproxy.snu.ac.kr/login?url=$@"
+    "url": "https://lib.snu.ac.kr/user/login?proxyurl=$@"
   },
   {
     "name": "Seton Hall University",
@@ -3588,6 +3496,10 @@
     "url": "http://proxy-ship.klnpa.org/login?url=$@"
   },
   {
+    "name": "SHIRP (University of Saskatchewan)",
+    "url": "http://www.shirp.ca/doproxy?url=$@"
+  },
+  {
     "name": "Siberian Federal University",
     "url": "https://libproxy.bik.sfu-kras.ru/login?url=$@"
   },
@@ -3620,6 +3532,10 @@
     "url": "http://libproxy.smith.edu:2048/login?url=$@"
   },
   {
+    "name": "SNDL Systeme National de Documentation en Ligne",
+    "url": "http://www.sndl1.arn.dz/login?url=$@"
+  },
+  {
     "name": "Sofia",
     "url": "http://ezproxy.sofia.edu:2048/login?url=$@"
   },
@@ -3644,12 +3560,16 @@
     "url": "http://ezproxy.sothebysinstitute.com:2048/login?url=$@"
   },
   {
-    "name": "South College",
-    "url": "http://proxy.southcollegetn.edu:2048/login?url=$@"
+    "name": "South and East Metropolitan Health Service",
+    "url": "https://login.smhslibresources.health.wa.gov.au/login?url=$@"
   },
   {
     "name": "South Asian University (SAU)",
     "url": "https://sau.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "South College",
+    "url": "http://proxy.southcollegetn.edu:2048/login?url=$@"
   },
   {
     "name": "South Dakota State University",
@@ -3662,10 +3582,6 @@
   {
     "name": "South Texas",
     "url": "http://ezproxy.southtexascollege.edu:2048/login?url=$@"
-  },
-  {
-    "name": "South and East Metropolitan Health Service",
-    "url": "https://login.smhslibresources.health.wa.gov.au/login?url=$@"
   },
   {
     "name": "Southern College of Optometry",
@@ -3756,12 +3672,12 @@
     "url": "https://stanford.idm.oclc.org/login?url=$@"
   },
   {
-    "name": "State Library of Pennsylvania",
-    "url": "http://proxy-stlib.klnpa.org/login?url=$@"
-  },
-  {
     "name": "State and University Library, Aarhus",
     "url": "http://ez.statsbiblioteket.dk:2048/login?url=$@"
+  },
+  {
+    "name": "State Library of Pennsylvania",
+    "url": "http://proxy-stlib.klnpa.org/login?url=$@"
   },
   {
     "name": "Stellenbosch University",
@@ -3818,6 +3734,78 @@
   {
     "name": "Sunway University",
     "url": "http://ezproxy.sunway.edu.my/login?url=$@"
+  },
+  {
+    "name": "SUNY at Geneseo",
+    "url": "http://proxy.geneseo.edu:2048/login?url=$@"
+  },
+  {
+    "name": "SUNY at Oswego",
+    "url": "http://ezproxy.oswego.edu:2048/login?url=$@"
+  },
+  {
+    "name": "SUNY Buffalo State",
+    "url": "http://proxy.buffalostate.edu:2048/login?url=$@"
+  },
+  {
+    "name": "SUNY Cobleskill",
+    "url": "http://ezproxy.cobleskill.edu:2048/login?url=$@"
+  },
+  {
+    "name": "SUNY Corning Community College",
+    "url": "http://ezproxy.corning-cc.edu:2048/login?url=$@"
+  },
+  {
+    "name": "SUNY Cortland",
+    "url": "http://libproxy.cortland.edu/login?url=$@"
+  },
+  {
+    "name": "SUNY Downstate",
+    "url": "http://newproxy.downstate.edu/login?url=$@"
+  },
+  {
+    "name": "SUNY Dutchess",
+    "url": "http://is-ezproxy01.sunydutchess.edu:2048/login?url=$@"
+  },
+  {
+    "name": "SUNY Empire State",
+    "url": "http://library.esc.edu/login?url=$@"
+  },
+  {
+    "name": "SUNY Environmental Science and Forestry",
+    "url": "https://esf.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "SUNY Farmingdale State",
+    "url": "http://hs1.farmingdale.edu:2048/login?url=$@"
+  },
+  {
+    "name": "SUNY Jefferson",
+    "url": "http://jccweb.sunyjefferson.edu:2048/login?url=$@"
+  },
+  {
+    "name": "SUNY New Paltz",
+    "url": "https://libdatabase.newpaltz.edu/login?url=$@"
+  },
+  {
+    "name": "SUNY Onondaga",
+    "url": "http://ezproxy.sunyocc.edu:2048/login?url=$@"
+  },
+  {
+    "name": "SUNY Polytechnic Institute",
+    "url": "http://ezproxy.sunyit.edu/login?url=$@"
+  },
+  {
+    "name": "SUNY Rockland",
+    "url": "http://ezproxy.sunyrockland.edu:2048/login?url=$@"
+  },
+  {
+    "name": "SUNY Schenectady County",
+    "url": "http://libproxy.sunysccc.edu/login?url=$@"
+  },
+  {
+    "name": "SUNY University at Albany",
+    "url": "https://libproxy.albany.edu/login?url=$@"
   },
   {
     "name": "Swarthmore",
@@ -3948,8 +3936,8 @@
     "url": "https://ezproxy.tulibs.net/login?url=$@"
   },
   {
-    "name": "Air University",
-    "url": "http://aufric.idm.oclc.org/login?url=$@"
+    "name": "The American College of Greece",
+    "url": "https://acg.idm.oclc.org/login?url=$@"
   },
   {
     "name": "The Chinese University of Hong Kong",
@@ -3972,6 +3960,10 @@
     "url": "https://ezproxy.lb.polyu.edu.hk/login?url=$@"
   },
   {
+    "name": "The Jackson Laboratory",
+    "url": "http://ezproxy.jax.org/login?url=$@"
+  },
+  {
     "name": "The Jackson Laboratory for Genomic Medicine",
     "url": "https://login.ezproxy.jax.org/login?url=$@"
   },
@@ -3982,6 +3974,10 @@
   {
     "name": "The New School",
     "url": "http://libproxy.newschool.edu/login?url=$@"
+  },
+  {
+    "name": "The Royal College of Surgeons in Ireland",
+    "url": "https://login.proxy.library.rcsi.ie/login?url=$@"
   },
   {
     "name": "The University at Buffalo",
@@ -4009,19 +4005,19 @@
   },
   {
     "name": "Trent University",
-    "url": "http://cat1.lib.trentu.ca:2048/login?url=$@"
-  },
-  {
-    "name": "Trent University",
     "url": "http://web2.trentu.ca:2048/login?url=$@"
   },
   {
-    "name": "Trinity University",
-    "url": "http://libproxy.trinity.edu/login?url=$@"
+    "name": "Trent University",
+    "url": "http://cat1.lib.trentu.ca:2048/login?url=$@"
   },
   {
     "name": "Trinity College Dublin, Ireland",
     "url": "http://elib.tcd.ie/login?url=$@"
+  },
+  {
+    "name": "Trinity University",
+    "url": "http://libproxy.trinity.edu/login?url=$@"
   },
   {
     "name": "Tufts University",
@@ -4068,20 +4064,12 @@
     "url": "https://proxy.cc.uic.edu/login?url=$@"
   },
   {
-    "name": "UNED",
-    "url": "http://ezproxy.uned.es/login?url=$@"
-  },
-  {
-    "name": "UT Health Center San Antonio",
-    "url": "http://libproxy.uthscsa.edu/login?url=$@"
-  },
-  {
-    "name": "UTCC",
-    "url": "https://login.ezproxy.utcc.ac.th/login?url=$@"
-  },
-  {
     "name": "Umea University",
     "url": "http://proxy.ub.umu.se/login?url=$@"
+  },
+  {
+    "name": "UNED",
+    "url": "http://ezproxy.uned.es/login?url=$@"
   },
   {
     "name": "Uni Heidelberg",
@@ -4112,10 +4100,6 @@
     "url": "http://lib-ezproxy.unog.ch/login?url=$@"
   },
   {
-    "name": "University of New Mexico",
-    "url": "http://libproxy.unm.edu/login?url=$@"
-  },
-  {
     "name": "Universal College of Learning",
     "url": "http://ezproxy.ucol.ac.nz/login?url=$@"
   },
@@ -4130,10 +4114,6 @@
   {
     "name": "Universidad Autónoma Metropolitana",
     "url": "https://bidi.uam.mx:2048/login?url=$@"
-  },
-  {
-    "name": "Universidad Nacional Autónoma de México",
-    "url": "http://pbidi.unam.mx:8080/login?url=$@"
   },
   {
     "name": "Universidad Carlos III de Madrid",
@@ -4152,6 +4132,42 @@
     "url": "http://bbibliograficas.ucc.edu.co/login?url=$@"
   },
   {
+    "name": "Universidad de Chile",
+    "url": "https://uchile.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "Universidad de Concepción",
+    "url": "http://ezproxy.udec.cl/login?url=$@"
+  },
+  {
+    "name": "Universidad de Costa Rica",
+    "url": "http://ezproxy.sibdi.ucr.ac.cr:2048/login?url=$@"
+  },
+  {
+    "name": "Universidad de Guadalajara",
+    "url": "https://login.wdg.biblio.udg.mx:8443/login?url=$@"
+  },
+  {
+    "name": "Universidad de Lleida",
+    "url": "http://proxy.alumnes.udl.cat:8080/log=$@"
+  },
+  {
+    "name": "Universidad de los Andes",
+    "url": "https://login.ezproxy.uniandes.edu.co:8443/login?url=$@"
+  },
+  {
+    "name": "Universidad de Navarra",
+    "url": "http://ezproxy.unav.es:2048/login?url=$@"
+  },
+  {
+    "name": "Universidad de Oviedo",
+    "url": "http://uniovi.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "Universidad del Valle",
+    "url": "http://bd.univalle.edu.co/login?url=$@"
+  },
+  {
     "name": "Universidad EAFIT",
     "url": "http://ezproxy.eafit.edu.co/login?url=$@"
   },
@@ -4162,6 +4178,10 @@
   {
     "name": "Universidad Interamericana de Puerto Rico Recinto de Arecibo",
     "url": "http://ezproxy.arecibo.inter.edu:2048/login?url=$@"
+  },
+  {
+    "name": "Universidad Nacional Autónoma de México",
+    "url": "http://pbidi.unam.mx:8080/login?url=$@"
   },
   {
     "name": "Universidad Nacional Autónoma de México Campus Morelos",
@@ -4176,44 +4196,8 @@
     "url": "http://ezproxy.unvm.edu.ar/login?url=$@"
   },
   {
-    "name": "Universidad de Chile",
-    "url": "https://uchile.idm.oclc.org/login?url=$@"
-  },
-  {
-    "name": "Universidad de Concepción",
-    "url": "http://ezproxy.udec.cl/login?url=$@"
-  },
-  {
-    "name": "Universidad de Costa Rica",
-    "url": "http://ezproxy.sibdi.ucr.ac.cr:2048/login?url=$@"
-  },
-  {
-    "name": "Universidad de Lleida",
-    "url": "http://proxy.alumnes.udl.cat:8080/log=$@"
-  },
-  {
-    "name": "Universidad de Navarra",
-    "url": "http://ezproxy.unav.es:2048/login?url=$@"
-  },
-  {
-    "name": "Universidad de Oviedo",
-    "url": "http://uniovi.idm.oclc.org/login?url=$@"
-  },
-  {
-    "name": "Universidad de los Andes",
-    "url": "https://login.ezproxy.uniandes.edu.co:8443/login?url=$@"
-  },
-  {
-    "name": "Universidad del Valle",
-    "url": "http://bd.univalle.edu.co/login?url=$@"
-  },
-  {
-    "name": "Universidade Federal do Rio Grande do Sul",
-    "url": "https://http://Ez45.periodicos.capes.gov.br/login?=$@"
-  },
-  {
-    "name": "Universidade Federal do Rio de Janeiro (UFRJ)",
-    "url": "http://ez29.periodicos.capes.gov.br/login?url=$@"
+    "name": "Universidad Técnica Federico Santa María (UTFSM)",
+    "url": "https://login.usm.idm.oclc.org/login?url=$@"
   },
   {
     "name": "Universidade da Coruña (UdC)",
@@ -4224,12 +4208,16 @@
     "url": "https://ezbusc.usc.gal/login?url=$@"
   },
   {
-    "name": "Universidad Técnica Federico Santa María (UTFSM)",
-    "url": "https://login.usm.idm.oclc.org/login?url=$@"
+    "name": "Universidade Federal do Rio de Janeiro (UFRJ)",
+    "url": "http://ez29.periodicos.capes.gov.br/login?url=$@"
   },
   {
-    "name": "Universita degli Studi G dAnnunzio Chieti",
-    "url": "http://biblioproxy.unich.it/login?url=$@"
+    "name": "Universidade Federal do Rio Grande do Sul",
+    "url": "https://http://Ez45.periodicos.capes.gov.br/login?=$@"
+  },
+  {
+    "name": "Universita degli studi di Milano",
+    "url": "http://ezproxy.pros.lib.unimi.it/login?url=$@"
   },
   {
     "name": "Universita degli Studi di Sassari",
@@ -4244,8 +4232,8 @@
     "url": "http://ezp.biblio.unitn.it/login?url=$@"
   },
   {
-    "name": "Universita degli studi di Milano",
-    "url": "http://ezproxy.pros.lib.unimi.it/login?url=$@"
+    "name": "Universita degli Studi G dAnnunzio Chieti",
+    "url": "http://biblioproxy.unich.it/login?url=$@"
   },
   {
     "name": "Universitas Indonesia",
@@ -4264,26 +4252,6 @@
     "url": "http://am.e-nformation.ro/login?url=$@"
   },
   {
-    "name": "Universite Lille 2",
-    "url": "http://doc-distant.univ-lille2.fr/login?url=$@"
-  },
-  {
-    "name": "Universite Ouest Nanterre La Defense",
-    "url": "http://faraway.u-paris10.fr/login?url=$@"
-  },
-  {
-    "name": "Universite Paris 1 Pantheon-Sorbonne",
-    "url": "http://ezproxy.univ-paris1.fr/login?url=$@"
-  },
-  {
-    "name": "Universite Paris Diderot",
-    "url": "http://rproxy.sc.univ-paris-diderot.fr:80/login?url=$@"
-  },
-  {
-    "name": "Universite Rennes 2",
-    "url": "http://distant.bu.univ-rennes2.fr/login?url=$@"
-  },
-  {
     "name": "Universite catholique de Louvain",
     "url": "http://proxy.bib.ucl.ac.be:888/login?url=$@"
   },
@@ -4294,6 +4262,10 @@
   {
     "name": "Universite de Bourgogne",
     "url": "http://proxy-scd.u-bourgogne.fr/login?url=$@"
+  },
+  {
+    "name": "Universite de la Reunion",
+    "url": "http://elgebar.univ-reunion.fr/login?url=$@"
   },
   {
     "name": "Universite de Lille 1",
@@ -4316,10 +4288,6 @@
     "url": "http://proxy.unice.fr/login?url=$@"
   },
   {
-    "name": "Universite de la Reunion",
-    "url": "http://elgebar.univ-reunion.fr/login?url=$@"
-  },
-  {
     "name": "Universite de technologie de Troyes",
     "url": "http://proxy.utt.fr/login?url=$@"
   },
@@ -4330,6 +4298,26 @@
   {
     "name": "Universite du Quebec a Montreal",
     "url": "http://proxy.bibliotheques.uqam.ca:2048/login?url=$@"
+  },
+  {
+    "name": "Universite Lille 2",
+    "url": "http://doc-distant.univ-lille2.fr/login?url=$@"
+  },
+  {
+    "name": "Universite Ouest Nanterre La Defense",
+    "url": "http://faraway.u-paris10.fr/login?url=$@"
+  },
+  {
+    "name": "Universite Paris 1 Pantheon-Sorbonne",
+    "url": "http://ezproxy.univ-paris1.fr/login?url=$@"
+  },
+  {
+    "name": "Universite Paris Diderot",
+    "url": "http://rproxy.sc.univ-paris-diderot.fr:80/login?url=$@"
+  },
+  {
+    "name": "Universite Rennes 2",
+    "url": "http://distant.bu.univ-rennes2.fr/login?url=$@"
   },
   {
     "name": "Universiteit Hasselt",
@@ -4380,6 +4368,10 @@
     "url": "https://libezp.utar.edu.my/login?url=$@"
   },
   {
+    "name": "University at Albany, State University of New York (SUNY)",
+    "url": "https://libproxy.albany.edu/login?url=$@"
+  },
+  {
     "name": "University College Cork",
     "url": "http://ucc.idm.oclc.org/login?url=$@"
   },
@@ -4388,28 +4380,12 @@
     "url": "https://libproxy.ucl.ac.uk/login?url=$@"
   },
   {
-    "name": "University Giessen",
-    "url": "https://ezproxy.uni-giessen.de/login?url=$@"
-  },
-  {
-    "name": "University Rennes 1",
-    "url": "http://passerelle.univ-rennes1.fr/login?url=$@"
-  },
-  {
-    "name": "University Teknologi Malaysia",
-    "url": "http://ezproxy.psz.utm.my/login?url=$@"
-  },
-  {
-    "name": "University West",
-    "url": "http://ezproxy.server.hv.se/login?url=$@"
-  },
-  {
-    "name": "University at Albany, State University of New York (SUNY)",
-    "url": "https://libproxy.albany.edu/login?url=$@"
-  },
-  {
     "name": "University for the Creative Arts",
     "url": "https://ucreative.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "University Giessen",
+    "url": "https://ezproxy.uni-giessen.de/login?url=$@"
   },
   {
     "name": "University of Adelaide",
@@ -4628,10 +4604,6 @@
     "url": "https://login.proxy-ub.rug.nl/login?url=$@"
   },
   {
-    "name": "Universidad de Guadalajara",
-    "url": "https://login.wdg.biblio.udg.mx:8443/login?url=$@"
-  },
-  {
     "name": "University of Guelph",
     "url": "http://subzero.lib.uoguelph.ca/login?url=$@"
   },
@@ -4668,16 +4640,16 @@
     "url": "http://ida.lib.uidaho.edu:2048/login?url=$@"
   },
   {
-    "name": "University of Illinois Springfield",
-    "url": "http://login.ezproxy.uis.edu/login?url=$@"
-  },
-  {
     "name": "University of Illinois at Chicago",
     "url": "http://proxy.cc.uic.edu/login?url=$@"
   },
   {
     "name": "University of Illinois at Urbana-Champaign",
     "url": "https://proxy2.library.illinois.edu/login?url=$@"
+  },
+  {
+    "name": "University of Illinois Springfield",
+    "url": "http://login.ezproxy.uis.edu/login?url=$@"
   },
   {
     "name": "University of Indiaia",
@@ -4892,6 +4864,10 @@
     "url": "http://unh-proxy.newhaven.edu:2048/login?url=$@"
   },
   {
+    "name": "University of New Mexico",
+    "url": "http://libproxy.unm.edu/login?url=$@"
+  },
+  {
     "name": "University of New Orleans",
     "url": "http://ezproxy.uno.edu/login?url=$@"
   },
@@ -4916,10 +4892,6 @@
     "url": "https://ezproxy.una.edu/login?url=$@"
   },
   {
-    "name": "University of North Carolina Wilmington",
-    "url": "http://liblink.uncw.edu/login?url=$@"
-  },
-  {
     "name": "University of North Carolina at Chapel Hill",
     "url": "http://libproxy.lib.unc.edu/login?url=$@"
   },
@@ -4930,6 +4902,10 @@
   {
     "name": "University of North Carolina at Greensboro",
     "url": "http://login.libproxy.uncg.edu/login?url=$@"
+  },
+  {
+    "name": "University of North Carolina Wilmington",
+    "url": "http://liblink.uncw.edu/login?url=$@"
   },
   {
     "name": "University of North Dakota",
@@ -5085,11 +5061,11 @@
   },
   {
     "name": "University of South Australia",
-    "url": "https://login.ezlibproxy.unisa.edu.au/login?url=$@"
+    "url": "https://access.library.unisa.edu.au/login?url=$@"
   },
   {
     "name": "University of South Australia",
-    "url": "https://access.library.unisa.edu.au/login?url=$@"
+    "url": "https://login.ezlibproxy.unisa.edu.au/login?url=$@"
   },
   {
     "name": "University of South Carolina",
@@ -5176,6 +5152,10 @@
     "url": "http://ezproxy.lib.uts.edu.au/login?url=$@"
   },
   {
+    "name": "University of Tennessee at Martin",
+    "url": "http://ezproxy.utm.edu/login?url=$@"
+  },
+  {
     "name": "University of Tennessee Chattanooga",
     "url": "http://proxy.lib.utc.edu/login?url=$@"
   },
@@ -5192,28 +5172,12 @@
     "url": "https://login.proxy.lib.utk.edu:2050/login?url=$@"
   },
   {
-    "name": "University of Tennessee at Martin",
-    "url": "http://ezproxy.utm.edu/login?url=$@"
-  },
-  {
-    "name": "University of Tennessee, Knoxville",
-    "url": "https://utk.idm.oclc.org/login?url=$@"
-  },
-  {
     "name": "University of Tennessee, Knoxville",
     "url": "https://login.proxy.lib.utk.edu/login?qurl=$@"
   },
   {
-    "name": "University of Texas Medical Branch",
-    "url": "http://libux.utmb.edu/login?url=$@"
-  },
-  {
-    "name": "University of Texas Pan American",
-    "url": "http://ezhost.panam.edu:2048/login?url=$@"
-  },
-  {
-    "name": "University of Texas Rio Grande Valley",
-    "url": "http://ezhost.utrgv.edu:2048/login?url=$@"
+    "name": "University of Tennessee, Knoxville",
+    "url": "https://utk.idm.oclc.org/login?url=$@"
   },
   {
     "name": "University of Texas at Austin",
@@ -5236,8 +5200,52 @@
     "url": "http://ezproxy.uttyler.edu:2048/login?url=$@"
   },
   {
+    "name": "University of Texas Medical Branch",
+    "url": "http://libux.utmb.edu/login?url=$@"
+  },
+  {
+    "name": "University of Texas Pan American",
+    "url": "http://ezhost.panam.edu:2048/login?url=$@"
+  },
+  {
+    "name": "University of Texas Rio Grande Valley",
+    "url": "http://ezhost.utrgv.edu:2048/login?url=$@"
+  },
+  {
+    "name": "University of the Cumberlands",
+    "url": "http://uc2.ucumberlands.edu:2048/login?url=$@"
+  },
+  {
+    "name": "University of the Fraser Valley",
+    "url": "http://proxy.ufv.ca:2048/login?url=$@"
+  },
+  {
+    "name": "University of the Incarnate Word",
+    "url": "https://uiwtx.idm.oclc.org/login?url=$@"
+  },
+  {
+    "name": "University of the Pacific",
+    "url": "http://ezproxy.pacific.edu/login?url=$@"
+  },
+  {
+    "name": "University of the Philippines College of Engineering",
+    "url": "http://ezproxy.engglib.upd.edu.ph/login?url=$@"
+  },
+  {
+    "name": "University of the West Indies at Mona",
+    "url": "http://rproxy.uwimona.edu.jm/login?url=$@"
+  },
+  {
+    "name": "University of the West of England",
+    "url": "http://ezproxy.uwe.ac.uk/login?url=$@"
+  },
+  {
+    "name": "University of the Witwatersrand",
+    "url": "https://innopac.wits.ac.za/validate?url=$@"
+  },
+  {
     "name": "University of Tokyo (UTOKYO)",
-    "url": "https://utokyo.idm.oclc.org/login?url=$@"
+    "url": "https://login.ezoris.lib.u-tokyo.ac.jp/login?url=$@"
   },
   {
     "name": "University of Toronto",
@@ -5388,36 +5396,16 @@
     "url": "http://roble.unizar.es:9090/login?url=$@"
   },
   {
-    "name": "University of the Cumberlands",
-    "url": "http://uc2.ucumberlands.edu:2048/login?url=$@"
+    "name": "University Rennes 1",
+    "url": "http://passerelle.univ-rennes1.fr/login?url=$@"
   },
   {
-    "name": "University of the Fraser Valley",
-    "url": "http://proxy.ufv.ca:2048/login?url=$@"
+    "name": "University Teknologi Malaysia",
+    "url": "http://ezproxy.psz.utm.my/login?url=$@"
   },
   {
-    "name": "University of the Incarnate Word",
-    "url": "https://uiwtx.idm.oclc.org/login?url=$@"
-  },
-  {
-    "name": "University of the Pacific",
-    "url": "http://ezproxy.pacific.edu/login?url=$@"
-  },
-  {
-    "name": "University of the Philippines College of Engineering",
-    "url": "http://ezproxy.engglib.upd.edu.ph/login?url=$@"
-  },
-  {
-    "name": "University of the West Indies at Mona",
-    "url": "http://rproxy.uwimona.edu.jm/login?url=$@"
-  },
-  {
-    "name": "University of the West of England",
-    "url": "http://ezproxy.uwe.ac.uk/login?url=$@"
-  },
-  {
-    "name": "University of the Witwatersrand",
-    "url": "https://innopac.wits.ac.za/validate?url=$@"
+    "name": "University West",
+    "url": "http://ezproxy.server.hv.se/login?url=$@"
   },
   {
     "name": "Università degli Studi dell'Aquila",
@@ -5456,52 +5444,8 @@
     "url": "https://www.ezproxy.uca.fr/login?url=$@"
   },
   {
-    "name": "Université Grenoble Alpes",
-    "url": "https://login.sid2nomade-1.grenet.fr/login?url=$@"
-  },
-  {
-    "name": "Université Laval",
-    "url": "http://acces.bibl.ulaval.ca/login?url=$@"
-  },
-  {
-    "name": "Université Libre de Bruxelles",
-    "url": "https://ezproxy.ulb.ac.be/login?url=$@"
-  },
-  {
-    "name": "Université Libre de Bruxelles (ULB)",
-    "url": "https://www.ezproxy.ulb.ac.be/login?url=$@"
-  },
-  {
-    "name": "Université Lille 1",
-    "url": "http://buproxy.univ-lille1.fr/login?url=$@"
-  },
-  {
-    "name": "Université Paris 6 et 7 - Mathématiques Informatique Recherche",
-    "url": "http://ezproxy.math-info-paris.cnrs.fr/login?url=$@"
-  },
-  {
-    "name": "Université Pierre et Marie Curie - Paris 6",
-    "url": "http://accesdistant.upmc.fr/login?url=$@"
-  },
-  {
-    "name": "Université Polytechnique Hauts-de-France",
-    "url": "https://login.ezproxy.uphf.fr/login?url=$@"
-  },
-  {
-    "name": "Université Saint Jospeh Beirut",
-    "url": "https://ezproxy.usj.edu.lb/login?url=$@"
-  },
-  {
-    "name": "Université Toulouse II Jean Jaurès",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
-  },
-  {
     "name": "Université d'Artois",
     "url": "http://ezproxy.univ-artois.fr/login?url=$@"
-  },
-  {
-    "name": "Université Paris-Saclay",
-    "url": "http://ezproxy.universite-paris-saclay.fr/login?url=$@"
   },
   {
     "name": "Université de Bordeaux",
@@ -5532,12 +5476,56 @@
     "url": "https://scd-rproxy.u-strasbg.fr/login?url=$@"
   },
   {
+    "name": "Université Grenoble Alpes",
+    "url": "https://login.sid2nomade-1.grenet.fr/login?url=$@"
+  },
+  {
     "name": "Université Gustave Eiffel (GHU-Paris)",
     "url": "https://univ-eiffel.idm.oclc.org/login?url=$@"
   },
   {
+    "name": "Université Laval",
+    "url": "http://acces.bibl.ulaval.ca/login?url=$@"
+  },
+  {
+    "name": "Université Libre de Bruxelles",
+    "url": "https://ezproxy.ulb.ac.be/login?url=$@"
+  },
+  {
+    "name": "Université Libre de Bruxelles (ULB)",
+    "url": "https://www.ezproxy.ulb.ac.be/login?url=$@"
+  },
+  {
+    "name": "Université Lille 1",
+    "url": "http://buproxy.univ-lille1.fr/login?url=$@"
+  },
+  {
+    "name": "Université Paris 6 et 7 - Mathématiques Informatique Recherche",
+    "url": "http://ezproxy.math-info-paris.cnrs.fr/login?url=$@"
+  },
+  {
     "name": "Université Paris Cité",
     "url": "https://ezproxy.u-paris.fr/login?url=$@"
+  },
+  {
+    "name": "Université Paris-Saclay",
+    "url": "http://ezproxy.universite-paris-saclay.fr/login?url=$@"
+  },
+  {
+    "name": "Université Pierre et Marie Curie - Paris 6",
+    "url": "http://accesdistant.upmc.fr/login?url=$@"
+  },
+  {
+    "name": "Université Polytechnique Hauts-de-France",
+    "url": "https://login.ezproxy.uphf.fr/login?url=$@"
+  },
+  {
+    "name": "Université Saint Jospeh Beirut",
+    "url": "https://ezproxy.usj.edu.lb/login?url=$@"
+  },
+  {
+    "name": "Université Toulouse II Jean Jaurès",
+    "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
   },
   {
     "name": "Univerza v Ljubljani",
@@ -5560,6 +5548,10 @@
     "url": "https://ezproxy.urfu.ru/login?url=$@"
   },
   {
+    "name": "UT Health Center San Antonio",
+    "url": "http://libproxy.uthscsa.edu/login?url=$@"
+  },
+  {
     "name": "Utah State University",
     "url": "http://dist.lib.usu.edu/login?url=$@"
   },
@@ -5568,16 +5560,16 @@
     "url": "https://ezproxy.uvu.edu/login?qurl=$@"
   },
   {
+    "name": "UTCC",
+    "url": "https://login.ezproxy.utcc.ac.th/login?url=$@"
+  },
+  {
     "name": "Utica",
     "url": "https://ezproxy.utica.edu/login?url=$@"
   },
   {
     "name": "Utrecht University",
     "url": "https://login.proxy.library.uu.nl/login?url=$@"
-  },
-  {
-    "name": "VID vitenskapelige høgskole",
-    "url": "https://ezproxy.vid.no/login?url=$@"
   },
   {
     "name": "Valley City State",
@@ -5618,6 +5610,10 @@
   {
     "name": "Victoria University | Melbourne Australia",
     "url": "http://wallaby.vu.edu.au:2048/login?url=$@"
+  },
+  {
+    "name": "VID vitenskapelige høgskole",
+    "url": "https://ezproxy.vid.no/login?url=$@"
   },
   {
     "name": "Vienna University Library",
@@ -5680,12 +5676,12 @@
     "url": "https://ntserver1.wsulibs.wsu.edu:6443/login?url=$@"
   },
   {
-    "name": "Washington University School of Medicine",
-    "url": "https://beckerproxy.wustl.edu/login?url=$@"
-  },
-  {
     "name": "Washington University in St. Louis",
     "url": "http://libproxy.wustl.edu/login?url=$@"
+  },
+  {
+    "name": "Washington University School of Medicine",
+    "url": "https://beckerproxy.wustl.edu/login?url=$@"
   },
   {
     "name": "Washtenaw",
@@ -5918,10 +5914,6 @@
   {
     "name": "École des Mines d'Albi - Carmaux",
     "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
-  },
-  {
-    "name": "İzmir Institute of Technology",
-    "url": "http://libezproxy.iyte.edu.tr:81/login?url=$@"
   },
   {
     "name": "台湾新光医院 (Taiwan Xinguang Hospital)",

--- a/static/proxies.json
+++ b/static/proxies.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "A.T. Still University of Health Sciences",
-    "url": "http://p.atsu.edu/login?url=",
+    "url": "http://p.atsu.edu/login?url=$@",
     "location": {
       "lng": -92.58941430000002,
       "lat": 40.19314929999999
@@ -10,7 +10,7 @@
   },
   {
     "name": "Aalborg Universitet",
-    "url": "http://zorac.aub.aau.dk/login?qurl=",
+    "url": "http://zorac.aub.aau.dk/login?qurl=$@",
     "location": {
       "lng": 9.9845553,
       "lat": 57.0139858
@@ -19,7 +19,7 @@
   },
   {
     "name": "Aalto University",
-    "url": "http://libproxy.aalto.fi/login?url=",
+    "url": "http://libproxy.aalto.fi/login?url=$@",
     "location": {
       "lng": 24.827682,
       "lat": 60.1866693
@@ -28,7 +28,7 @@
   },
   {
     "name": "Abertay",
-    "url": "http://libproxy.abertay.ac.uk/login?url=",
+    "url": "http://libproxy.abertay.ac.uk/login?url=$@",
     "location": {
       "lng": -2.973917,
       "lat": 56.463307
@@ -37,7 +37,7 @@
   },
   {
     "name": "Acadia",
-    "url": "http://ezproxy.acadiau.ca:2048/login?url=",
+    "url": "http://ezproxy.acadiau.ca:2048/login?url=$@",
     "location": {
       "lng": -68.2733346,
       "lat": 44.3385559
@@ -46,7 +46,7 @@
   },
   {
     "name": "Adams State",
-    "url": "http://adams.idm.oclc.org/login?url=",
+    "url": "http://adams.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -105.8798507,
       "lat": 37.47427709999999
@@ -55,7 +55,7 @@
   },
   {
     "name": "Adelphi",
-    "url": "http://libproxy.adelphi.edu:2048/login?url=",
+    "url": "http://libproxy.adelphi.edu:2048/login?url=$@",
     "location": {
       "lng": -73.65247109262027,
       "lat": 40.72015882159732
@@ -64,7 +64,7 @@
   },
   {
     "name": "Adler University",
-    "url": "http://ezproxy.adler.edu/login?url=",
+    "url": "http://ezproxy.adler.edu/login?url=$@",
     "location": {
       "lng": -87.6291651,
       "lat": 41.8824688
@@ -73,7 +73,7 @@
   },
   {
     "name": "AFIT D'Azzo Research Library",
-    "url": "https://login.afit.idm.oclc.org/login?url=",
+    "url": "https://login.afit.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -84.0823546,
       "lat": 39.7832782
@@ -82,7 +82,7 @@
   },
   {
     "name": "AFRL D'Azzo Research Library",
-    "url": "http://wrs.idm.oclc.org/login?url=",
+    "url": "http://wrs.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -84.0823546,
       "lat": 39.7832782
@@ -91,7 +91,7 @@
   },
   {
     "name": "Agency for Science Technology and Research",
-    "url": "http://ejproxy.a-star.edu.sg/login?url=",
+    "url": "http://ejproxy.a-star.edu.sg/login?url=$@",
     "location": {
       "lng": 103.78764128619945,
       "lat": 1.299698103943425
@@ -100,7 +100,7 @@
   },
   {
     "name": "Aichi Shukutoku University Library",
-    "url": "https://aasa.idm.oclc.org/login?url=",
+    "url": "https://aasa.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 137.0314337,
       "lat": 35.1573669
@@ -109,7 +109,7 @@
   },
   {
     "name": "Air University",
-    "url": "http://aufric.idm.oclc.org/login?url=",
+    "url": "http://aufric.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -86.35099703480662,
       "lat": 32.37949101145906
@@ -118,7 +118,7 @@
   },
   {
     "name": "Akademie ved Ceske republiky",
-    "url": "https://ezproxy.lib.cas.cz/login?url=",
+    "url": "https://ezproxy.lib.cas.cz/login?url=$@",
     "location": {
       "lng": 14.4142,
       "lat": 50.0816138
@@ -127,7 +127,7 @@
   },
   {
     "name": "Alabama A M",
-    "url": "http://ezproxy.aamu.edu:2048/login?url=",
+    "url": "http://ezproxy.aamu.edu:2048/login?url=$@",
     "location": {
       "lng": -86.5722237,
       "lat": 34.78384090000001
@@ -136,7 +136,7 @@
   },
   {
     "name": "Alameda County Library",
-    "url": "https://ezproxy.aclibrary.org/login?url=",
+    "url": "https://ezproxy.aclibrary.org/login?url=$@",
     "location": {
       "lng": -121.7195459,
       "lat": 37.6016892
@@ -145,7 +145,7 @@
   },
   {
     "name": "Albany Medical",
-    "url": "http://elibrary.amc.edu/login?url=",
+    "url": "http://elibrary.amc.edu/login?url=$@",
     "location": {
       "lng": -73.7771411,
       "lat": 42.6536483
@@ -154,7 +154,7 @@
   },
   {
     "name": "Albert Einstein College of Medicine",
-    "url": "http://elibrary.einstein.yu.edu/login?url=",
+    "url": "http://elibrary.einstein.yu.edu/login?url=$@",
     "location": {
       "lng": -73.8459022,
       "lat": 40.8504961
@@ -163,7 +163,7 @@
   },
   {
     "name": "Alberta Health Services",
-    "url": "https://ahs.idm.oclc.org/login?url=",
+    "url": "https://ahs.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -114.13613106894597,
       "lat": 51.044717356702854
@@ -172,7 +172,7 @@
   },
   {
     "name": "Albright",
-    "url": "https://felix.albright.edu/login?url=",
+    "url": "https://felix.albright.edu/login?url=$@",
     "location": {
       "lng": -75.9106812,
       "lat": 40.363518
@@ -181,7 +181,7 @@
   },
   {
     "name": "Alfred",
-    "url": "http://ezproxy.alfred.edu:2048/login?url=",
+    "url": "http://ezproxy.alfred.edu:2048/login?url=$@",
     "location": {
       "lng": -77.78610634434509,
       "lat": 42.25587308337543
@@ -190,7 +190,7 @@
   },
   {
     "name": "Allan Hancock",
-    "url": "http://ezproxy.hancockcollege.edu:3048/login?url=",
+    "url": "http://ezproxy.hancockcollege.edu:3048/login?url=$@",
     "location": {
       "lng": -120.4189337,
       "lat": 34.9446133
@@ -199,7 +199,7 @@
   },
   {
     "name": "Allegheny College",
-    "url": "http://ezproxy1.allegheny.edu:2048/login?url=",
+    "url": "http://ezproxy1.allegheny.edu:2048/login?url=$@",
     "location": {
       "lng": -80.1455328,
       "lat": 41.6484557
@@ -208,7 +208,7 @@
   },
   {
     "name": "American Institutes for Research",
-    "url": "https://air.idm.oclc.org/login?url=",
+    "url": "https://air.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -79.01866958652967,
       "lat": 35.94014392918445
@@ -217,7 +217,7 @@
   },
   {
     "name": "American Jewish University",
-    "url": "https://proxy.aju.edu/login?url=",
+    "url": "https://proxy.aju.edu/login?url=$@",
     "location": {
       "lng": -118.4725275,
       "lat": 34.1263884
@@ -226,7 +226,7 @@
   },
   {
     "name": "American Museum of Natural History",
-    "url": "http://libraryproxy.amnh.org:9000/login?url=",
+    "url": "http://libraryproxy.amnh.org:9000/login?url=$@",
     "location": {
       "lng": -73.9739882,
       "lat": 40.7813241
@@ -235,7 +235,7 @@
   },
   {
     "name": "American Public University System",
-    "url": "https://login.ezproxy1.apus.edu/login?url=",
+    "url": "https://login.ezproxy1.apus.edu/login?url=$@",
     "location": {
       "lng": -77.86157952282755,
       "lat": 39.291746789555674
@@ -244,7 +244,7 @@
   },
   {
     "name": "American Public University System (Alternative)",
-    "url": "http://ezproxy.apus.edu/login?url=",
+    "url": "http://ezproxy.apus.edu/login?url=$@",
     "location": {
       "lng": -77.86157952282755,
       "lat": 39.291746789555674
@@ -253,7 +253,7 @@
   },
   {
     "name": "American University",
-    "url": "https://myau.american.edu/my.policy?url=",
+    "url": "https://myau.american.edu/my.policy?url=$@",
     "location": {
       "lng": -77.088922,
       "lat": 38.9380155
@@ -262,7 +262,7 @@
   },
   {
     "name": "American University in Cairo",
-    "url": "http://ezproxy.library.aucegypt.edu:2048/login?url=",
+    "url": "http://ezproxy.library.aucegypt.edu:2048/login?url=$@",
     "location": {
       "lng": 31.49908139999999,
       "lat": 30.0201508
@@ -271,7 +271,7 @@
   },
   {
     "name": "American University of Beirut",
-    "url": "https://ezproxy.aub.edu.lb/login?url=",
+    "url": "https://ezproxy.aub.edu.lb/login?url=$@",
     "location": {
       "lng": 35.480744,
       "lat": 33.9008359
@@ -280,7 +280,7 @@
   },
   {
     "name": "American University Washington College of Law",
-    "url": "http://proxy.wcl.american.edu/login?url=",
+    "url": "http://proxy.wcl.american.edu/login?url=$@",
     "location": {
       "lng": -77.088922,
       "lat": 38.9380155
@@ -289,7 +289,7 @@
   },
   {
     "name": "American University, Washington, D.C.",
-    "url": "http://proxyau.wrlc.org/login?url=",
+    "url": "http://proxyau.wrlc.org/login?url=$@",
     "location": {
       "lng": -77.08891112711191,
       "lat": 38.938133217419576
@@ -298,7 +298,7 @@
   },
   {
     "name": "Amherst College",
-    "url": "https://ezproxy.amherst.edu/login?url=",
+    "url": "https://ezproxy.amherst.edu/login?url=$@",
     "location": {
       "lng": -72.5170028,
       "lat": 42.3709104
@@ -307,7 +307,7 @@
   },
   {
     "name": "Anadolu University Library",
-    "url": "https://offcampus.anadolu.edu.tr/login?url=",
+    "url": "https://offcampus.anadolu.edu.tr/login?url=$@",
     "location": {
       "lng": 30.5006587,
       "lat": 39.789626
@@ -316,7 +316,7 @@
   },
   {
     "name": "Angelina College",
-    "url": "https://ezproxy.angelina.edu/login?url=",
+    "url": "https://ezproxy.angelina.edu/login?url=$@",
     "location": {
       "lng": -94.73120139999999,
       "lat": 31.2873317
@@ -325,7 +325,7 @@
   },
   {
     "name": "Angelo State",
-    "url": "https://easydb.angelo.edu/login?url=",
+    "url": "https://easydb.angelo.edu/login?url=$@",
     "location": {
       "lng": -100.4598144,
       "lat": 31.4386537
@@ -334,7 +334,7 @@
   },
   {
     "name": "Anglo-European College of Chiropractic",
-    "url": "http://aecc.idm.oclc.org/login?url=",
+    "url": "http://aecc.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -1.8286846,
       "lat": 50.72728189999999
@@ -343,7 +343,7 @@
   },
   {
     "name": "Antioch",
-    "url": "https://antioch.idm.oclc.org/login?url=",
+    "url": "https://antioch.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -121.805789,
       "lat": 38.0049214
@@ -352,7 +352,7 @@
   },
   {
     "name": "ANZCA",
-    "url": "http://ezproxy.anzca.edu.au/login?url=",
+    "url": "http://ezproxy.anzca.edu.au/login?url=$@",
     "location": {
       "lng": 153.0028309,
       "lat": -27.4798016
@@ -361,7 +361,7 @@
   },
   {
     "name": "Arcadia",
-    "url": "http://ezproxy.arcadia.edu:2048/login?url=",
+    "url": "http://ezproxy.arcadia.edu:2048/login?url=$@",
     "location": {
       "lng": -118.0353449,
       "lat": 34.1397292
@@ -370,7 +370,7 @@
   },
   {
     "name": "Arizona State University",
-    "url": "http://login.ezproxy1.lib.asu.edu/login?url=",
+    "url": "http://login.ezproxy1.lib.asu.edu/login?url=$@",
     "location": {
       "lng": -111.9280527,
       "lat": 33.4242399
@@ -379,7 +379,7 @@
   },
   {
     "name": "Arkansas State",
-    "url": "https://ezproxy.library.astate.edu/login?url=",
+    "url": "https://ezproxy.library.astate.edu/login?url=$@",
     "location": {
       "lng": -92.28634029999999,
       "lat": 34.5573549
@@ -388,7 +388,7 @@
   },
   {
     "name": "Arts University Bournemouth",
-    "url": "https://go.openathens.net/redirector/aub.ac.uk?url=",
+    "url": "https://go.openathens.net/redirector/aub.ac.uk?url=$@",
     "location": {
       "lng": -1.8961949,
       "lat": 50.7421804
@@ -397,7 +397,7 @@
   },
   {
     "name": "Asheville-Buncombe Technical",
-    "url": "http://lrc-proxy.abtech.edu:2048/login?url=",
+    "url": "http://lrc-proxy.abtech.edu:2048/login?url=$@",
     "location": {
       "lng": -82.5514869,
       "lat": 35.5950581
@@ -406,7 +406,7 @@
   },
   {
     "name": "Ashland",
-    "url": "http://proxy.ashland.edu:2048/login?url=",
+    "url": "http://proxy.ashland.edu:2048/login?url=$@",
     "location": {
       "lng": -122.7094767,
       "lat": 42.1945758
@@ -415,7 +415,7 @@
   },
   {
     "name": "Athabasca",
-    "url": "http://ezproxy.athabascau.ca:2048/login?url=",
+    "url": "http://ezproxy.athabascau.ca:2048/login?url=$@",
     "location": {
       "lng": -113.2858262,
       "lat": 54.72126549999999
@@ -424,7 +424,7 @@
   },
   {
     "name": "Auburn",
-    "url": "http://spot.lib.auburn.edu/login?url=",
+    "url": "http://spot.lib.auburn.edu/login?url=$@",
     "location": {
       "lng": -85.48078249999999,
       "lat": 32.6098566
@@ -433,7 +433,7 @@
   },
   {
     "name": "Auburn University ",
-    "url": "https://auaccess.auburn.edu/c/portal/login?url=",
+    "url": "https://auaccess.auburn.edu/c/portal/login?url=$@",
     "location": {
       "lng": -85.4951663,
       "lat": 32.5933574
@@ -442,7 +442,7 @@
   },
   {
     "name": "Auckland University of Technology",
-    "url": "http://ezproxy.aut.ac.nz/login?url=",
+    "url": "http://ezproxy.aut.ac.nz/login?url=$@",
     "location": {
       "lng": 174.7664805,
       "lat": -36.8536098
@@ -451,7 +451,7 @@
   },
   {
     "name": "Augsburg",
-    "url": "http://ezproxy.augsburg.edu/login?url=",
+    "url": "http://ezproxy.augsburg.edu/login?url=$@",
     "location": {
       "lng": 10.89779,
       "lat": 48.3705449
@@ -460,7 +460,7 @@
   },
   {
     "name": "Augusta University",
-    "url": "http://ezproxy.augusta.edu/login?url=",
+    "url": "http://ezproxy.augusta.edu/login?url=$@",
     "location": {
       "lng": -81.9898848,
       "lat": 33.4709094
@@ -469,7 +469,7 @@
   },
   {
     "name": "Augustana",
-    "url": "http://fulla.augustana.edu:2048/login?url=",
+    "url": "http://fulla.augustana.edu:2048/login?url=$@",
     "location": {
       "lng": -96.73936359999999,
       "lat": 43.5224294
@@ -478,7 +478,7 @@
   },
   {
     "name": "Auraria Library",
-    "url": "http://aurarialibrary.idm.oclc.org/login?url=",
+    "url": "http://aurarialibrary.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -105.002931,
       "lat": 39.743355
@@ -487,7 +487,7 @@
   },
   {
     "name": "Austin College",
-    "url": "http://webster.austincollege.edu/login?url=",
+    "url": "http://webster.austincollege.edu/login?url=$@",
     "location": {
       "lng": -96.5981984,
       "lat": 33.6473694
@@ -496,7 +496,7 @@
   },
   {
     "name": "Austin Community College",
-    "url": "https://lsproxy.austincc.edu/login?url=",
+    "url": "https://lsproxy.austincc.edu/login?url=$@",
     "location": {
       "lng": -97.7430608,
       "lat": 30.267153
@@ -505,7 +505,7 @@
   },
   {
     "name": "Austin Health",
-    "url": "http://journals.library.austin.org.au/login?url=",
+    "url": "http://journals.library.austin.org.au/login?url=$@",
     "location": {
       "lng": 145.0586279,
       "lat": -37.7562696
@@ -514,7 +514,7 @@
   },
   {
     "name": "Austin Peay State",
-    "url": "http://ezproxy.lib.apsu.edu/login?url=",
+    "url": "http://ezproxy.lib.apsu.edu/login?url=$@",
     "location": {
       "lng": -87.3548855,
       "lat": 36.53498
@@ -523,7 +523,7 @@
   },
   {
     "name": "Austin Public Library",
-    "url": "http://www.austinlibrary.com:2048/login?url=",
+    "url": "http://www.austinlibrary.com:2048/login?url=$@",
     "location": {
       "lng": -97.75204851901493,
       "lat": 30.269507888732885
@@ -532,7 +532,7 @@
   },
   {
     "name": "Austin University of Technology",
-    "url": "http://journals.library.austin.org.au/login?url=",
+    "url": "http://journals.library.austin.org.au/login?url=$@",
     "location": {
       "lng": -97.7430608,
       "lat": 30.267153
@@ -541,7 +541,7 @@
   },
   {
     "name": "Australian Catholic University",
-    "url": "http://ezproxy.acu.edu.au/login?url=",
+    "url": "http://ezproxy.acu.edu.au/login?url=$@",
     "location": {
       "lng": 153.0888676,
       "lat": -27.3780232
@@ -550,7 +550,7 @@
   },
   {
     "name": "Australian National University",
-    "url": "http://virtual.anu.edu.au/login?url=",
+    "url": "http://virtual.anu.edu.au/login?url=$@",
     "location": {
       "lng": 149.1183238,
       "lat": -35.2812533
@@ -559,7 +559,7 @@
   },
   {
     "name": "Averett",
-    "url": "http://ezproxy.averett.edu/login?url=",
+    "url": "http://ezproxy.averett.edu/login?url=$@",
     "location": {
       "lng": -79.4142589,
       "lat": 36.5793099
@@ -568,7 +568,7 @@
   },
   {
     "name": "Baden State Library",
-    "url": "https://login.ezproxy.blb-karlsruhe.de/login?url=",
+    "url": "https://login.ezproxy.blb-karlsruhe.de/login?url=$@",
     "location": {
       "lng": 8.3988313,
       "lat": 49.0079994
@@ -577,7 +577,7 @@
   },
   {
     "name": "Bakersfield",
-    "url": "https://ezproxy.bakersfieldcollege.edu/login?url=",
+    "url": "https://ezproxy.bakersfieldcollege.edu/login?url=$@",
     "location": {
       "lng": -119.0187125,
       "lat": 35.3732921
@@ -586,7 +586,7 @@
   },
   {
     "name": "Ball State",
-    "url": "http://proxy.bsu.edu/login?url=",
+    "url": "http://proxy.bsu.edu/login?url=$@",
     "location": {
       "lng": -85.4134775,
       "lat": 40.2079938
@@ -595,7 +595,7 @@
   },
   {
     "name": "Bank Street College of Education",
-    "url": "http://libproxy.bankstreet.edu/login?url=",
+    "url": "http://libproxy.bankstreet.edu/login?url=$@",
     "location": {
       "lng": -73.96648539011375,
       "lat": 40.80587775364672
@@ -604,7 +604,7 @@
   },
   {
     "name": "Baptist School of Health Professions",
-    "url": "http://ezproxy.bshp.edu:2048/login?url=",
+    "url": "http://ezproxy.bshp.edu:2048/login?url=$@",
     "location": {
       "lng": -98.56752,
       "lat": 29.5169589
@@ -613,7 +613,7 @@
   },
   {
     "name": "Bar-Ilan University (and other OpenAthens/MyAthens users)",
-    "url": "http://proxy1.athensams.net/login?url=",
+    "url": "http://proxy1.athensams.net/login?url=$@",
     "location": {
       "lng": 34.84325926136056,
       "lat": 32.06998078248142
@@ -622,7 +622,7 @@
   },
   {
     "name": "Bard College",
-    "url": "http://ezprox.bard.edu:2048/login?url=",
+    "url": "http://ezprox.bard.edu:2048/login?url=$@",
     "location": {
       "lng": -73.909314,
       "lat": 42.0230728
@@ -631,7 +631,7 @@
   },
   {
     "name": "Bard College at Simons Rock",
-    "url": "http://ezproxy.simons-rock.edu/login?url=",
+    "url": "http://ezproxy.simons-rock.edu/login?url=$@",
     "location": {
       "lng": -73.3804375,
       "lat": 42.2087695
@@ -640,7 +640,7 @@
   },
   {
     "name": "Barwon Health Library",
-    "url": "http://bh.idm.oclc.org/login?url=",
+    "url": "http://bh.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 144.3640160955289,
       "lat": -38.151645901131126
@@ -649,7 +649,7 @@
   },
   {
     "name": "Bath Spa",
-    "url": "http://ezproxy.bathspa.ac.uk:2048/login?url=",
+    "url": "http://ezproxy.bathspa.ac.uk:2048/login?url=$@",
     "location": {
       "lng": -2.3615092,
       "lat": 51.3803643
@@ -658,7 +658,7 @@
   },
   {
     "name": "Bath Spa University",
-    "url": "https://bathspa.idm.oclc.org/login?url=",
+    "url": "https://bathspa.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -2.4393324,
       "lat": 51.3748563
@@ -667,7 +667,7 @@
   },
   {
     "name": "Baylor Health Sciences Library",
-    "url": "http://bcd.tamhsc.libguides.com/proxy_login?url=",
+    "url": "http://bcd.tamhsc.libguides.com/proxy_login?url=$@",
     "location": {
       "lng": -96.7812168,
       "lat": 32.789823
@@ -676,7 +676,7 @@
   },
   {
     "name": "Baylor University ",
-    "url": "http://ezproxy.baylor.edu/login?url=",
+    "url": "http://ezproxy.baylor.edu/login?url=$@",
     "location": {
       "lng": -97.11354,
       "lat": 31.5500848
@@ -685,7 +685,7 @@
   },
   {
     "name": "Beaumont Health System",
-    "url": "http://login.beaumont.idm.oclc.org/login?url=",
+    "url": "http://login.beaumont.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -83.19237110373544,
       "lat": 42.51456776349747
@@ -694,7 +694,7 @@
   },
   {
     "name": "Beaumont Health System - LibLynx",
-    "url": "https://liblynxgateway.com/beaumont?url=",
+    "url": "https://liblynxgateway.com/beaumont?url=$@",
     "location": {
       "lng": -83.19237110373544,
       "lat": 42.51456776349747
@@ -703,7 +703,7 @@
   },
   {
     "name": "Beilinson Rabin Medical Center",
-    "url": "https://login.beilinson-ez.medlcp.tau.ac.il/login?url=",
+    "url": "https://login.beilinson-ez.medlcp.tau.ac.il/login?url=$@",
     "location": {
       "lng": 34.8670288,
       "lat": 32.0904591
@@ -712,7 +712,7 @@
   },
   {
     "name": "Bellevue University",
-    "url": "http://ezproxy.bellevue.edu/login?url=",
+    "url": "http://ezproxy.bellevue.edu/login?url=$@",
     "location": {
       "lng": -95.91815799999999,
       "lat": 41.150572
@@ -721,7 +721,7 @@
   },
   {
     "name": "Beloit",
-    "url": "https://ezproxy.beloit.edu/login?url=",
+    "url": "https://ezproxy.beloit.edu/login?url=$@",
     "location": {
       "lng": -89.03177649999999,
       "lat": 42.5083482
@@ -730,7 +730,7 @@
   },
   {
     "name": "Ben Gurion University",
-    "url": "https://ezproxy.bgu.ac.il/login?url=",
+    "url": "https://ezproxy.bgu.ac.il/login?url=$@",
     "location": {
       "lng": 34.7995546,
       "lat": 31.261426
@@ -739,7 +739,7 @@
   },
   {
     "name": "Berkeley Public Library",
-    "url": "https://login.ezproxy.berkeleypubliclibrary.org/login?url=",
+    "url": "https://login.ezproxy.berkeleypubliclibrary.org/login?url=$@",
     "location": {
       "lng": -122.26848638481121,
       "lat": 37.86821893293512
@@ -748,7 +748,7 @@
   },
   {
     "name": "Berklee College of Music",
-    "url": "http://catalog.berklee.edu:2048/login?url=",
+    "url": "http://catalog.berklee.edu:2048/login?url=$@",
     "location": {
       "lng": -71.0895292,
       "lat": 42.3465952
@@ -757,7 +757,7 @@
   },
   {
     "name": "Bethel",
-    "url": "http://ezproxy.bethel.edu/login?url=",
+    "url": "http://ezproxy.bethel.edu/login?url=$@",
     "location": {
       "lng": -122.3584268,
       "lat": 40.6098473
@@ -766,7 +766,7 @@
   },
   {
     "name": "BI Norwegian Business School",
-    "url": "http://ezproxy.library.bi.no/login?url=",
+    "url": "http://ezproxy.library.bi.no/login?url=$@",
     "location": {
       "lng": 10.7685565,
       "lat": 59.9484015
@@ -775,7 +775,7 @@
   },
   {
     "name": "BiblioPl@nets - CNRS INIST",
-    "url": "http://biblioplanets.gate.inist.fr/login?url=",
+    "url": "http://biblioplanets.gate.inist.fr/login?url=$@",
     "location": {
       "lng": 6.1499824,
       "lat": 48.65528200000001
@@ -784,7 +784,7 @@
   },
   {
     "name": "Bibliothèque nationale de Luxembourg",
-    "url": "http://proxy.bnl.lu/login?url=",
+    "url": "http://proxy.bnl.lu/login?url=$@",
     "location": {
       "lng": 6.1657734,
       "lat": 49.6295817
@@ -793,7 +793,7 @@
   },
   {
     "name": "Bindura University of Science Education",
-    "url": "http://liboasis.buse.ac.zw:2048/login?url=",
+    "url": "http://liboasis.buse.ac.zw:2048/login?url=$@",
     "location": {
       "lng": 31.3326816,
       "lat": -17.3246383
@@ -802,7 +802,7 @@
   },
   {
     "name": "Binghamton University",
-    "url": "https://login.proxy.binghamton.edu/login?url=",
+    "url": "https://login.proxy.binghamton.edu/login?url=$@",
     "location": {
       "lng": -75.9694885,
       "lat": 42.0894288
@@ -811,7 +811,7 @@
   },
   {
     "name": "Biola",
-    "url": "https://login.ezproxy.biola.edu/login?url=",
+    "url": "https://login.ezproxy.biola.edu/login?url=$@",
     "location": {
       "lng": -118.0155533,
       "lat": 33.9062611
@@ -820,7 +820,7 @@
   },
   {
     "name": "Birkbeck University of London",
-    "url": "http://ezproxy.lib.bbk.ac.uk/login?url=",
+    "url": "http://ezproxy.lib.bbk.ac.uk/login?url=$@",
     "location": {
       "lng": -0.1303146,
       "lat": 51.5218563
@@ -829,7 +829,7 @@
   },
   {
     "name": "Birkbeck, University of London",
-    "url": "http://login.ezproxy.lib.bbk.ac.uk/login?url=",
+    "url": "http://login.ezproxy.lib.bbk.ac.uk/login?url=$@",
     "location": {
       "lng": -0.1303146,
       "lat": 51.5218563
@@ -838,7 +838,7 @@
   },
   {
     "name": "Birmingham-Southern",
-    "url": "https://ezproxy.bsc.edu/login?url=",
+    "url": "https://ezproxy.bsc.edu/login?url=$@",
     "location": {
       "lng": -86.8510103,
       "lat": 33.5159411
@@ -847,7 +847,7 @@
   },
   {
     "name": "Blekinge Tekniska Hogskola",
-    "url": "http://miman.bib.bth.se/login?url=",
+    "url": "http://miman.bib.bth.se/login?url=$@",
     "location": {
       "lng": 15.5906982,
       "lat": 56.1806556
@@ -856,7 +856,7 @@
   },
   {
     "name": "Bloomsburg University",
-    "url": "http://proxy-bloomu.klnpa.org/login?url=",
+    "url": "http://proxy-bloomu.klnpa.org/login?url=$@",
     "location": {
       "lng": -76.4472749,
       "lat": 41.0081119
@@ -865,7 +865,7 @@
   },
   {
     "name": "Blue Mountain",
-    "url": "http://proxy.bluecc.edu:2048/login?url=",
+    "url": "http://proxy.bluecc.edu:2048/login?url=$@",
     "location": {
       "lng": -75.520864,
       "lat": 40.81073
@@ -874,7 +874,7 @@
   },
   {
     "name": "Bob Jones",
-    "url": "http://ezproxy.bju.net/login?url=",
+    "url": "http://ezproxy.bju.net/login?url=$@",
     "location": {
       "lng": -82.3624705,
       "lat": 34.8725832
@@ -883,7 +883,7 @@
   },
   {
     "name": "Boise State",
-    "url": "https://libproxy.boisestate.edu/login?url=",
+    "url": "https://libproxy.boisestate.edu/login?url=$@",
     "location": {
       "lng": -116.1998719,
       "lat": 43.60287599999999
@@ -892,7 +892,7 @@
   },
   {
     "name": "Bond University",
-    "url": "http://ezproxy.bond.edu.au/login?url=",
+    "url": "http://ezproxy.bond.edu.au/login?url=$@",
     "location": {
       "lng": 153.4166377,
       "lat": -28.0730934
@@ -901,7 +901,7 @@
   },
   {
     "name": "Boston Architectural",
-    "url": "http://proxy.the-bac.edu/login?url=",
+    "url": "http://proxy.the-bac.edu/login?url=$@",
     "location": {
       "lng": -71.0859315,
       "lat": 42.3479568
@@ -910,7 +910,7 @@
   },
   {
     "name": "Boston College",
-    "url": "https://login.proxy.bc.edu/login?url=",
+    "url": "https://login.proxy.bc.edu/login?url=$@",
     "location": {
       "lng": -71.16849450000001,
       "lat": 42.3355488
@@ -919,7 +919,7 @@
   },
   {
     "name": "Boston Public Library",
-    "url": "http://ezproxy.bpl.org/login?url=",
+    "url": "http://ezproxy.bpl.org/login?url=$@",
     "location": {
       "lng": -71.0588801,
       "lat": 42.3600825
@@ -928,7 +928,7 @@
   },
   {
     "name": "Boston University",
-    "url": "https://ezproxy.bu.edu/login?url=",
+    "url": "https://ezproxy.bu.edu/login?url=$@",
     "location": {
       "lng": -71.1053991,
       "lat": 42.3504997
@@ -937,7 +937,7 @@
   },
   {
     "name": "Bournemouth University",
-    "url": "http://libezproxy.bournemouth.ac.uk/login?url=",
+    "url": "http://libezproxy.bournemouth.ac.uk/login?url=$@",
     "location": {
       "lng": -1.8983382,
       "lat": 50.7435102
@@ -946,7 +946,7 @@
   },
   {
     "name": "Bowdoin",
-    "url": "http://ezproxy.bowdoin.edu/login?url=",
+    "url": "http://ezproxy.bowdoin.edu/login?url=$@",
     "location": {
       "lng": -69.9639971,
       "lat": 43.9076929
@@ -955,7 +955,7 @@
   },
   {
     "name": "Bowling Green State",
-    "url": "http://ezproxy.bgsu.edu:8080/login?url=",
+    "url": "http://ezproxy.bgsu.edu:8080/login?url=$@",
     "location": {
       "lng": -83.6300596,
       "lat": 41.3793592
@@ -964,7 +964,7 @@
   },
   {
     "name": "Bradford College",
-    "url": "http://shibboleth.bradfordcollege.ac.uk:2048/login?url=",
+    "url": "http://shibboleth.bradfordcollege.ac.uk:2048/login?url=$@",
     "location": {
       "lng": -121.2900205,
       "lat": 37.9524339
@@ -973,7 +973,7 @@
   },
   {
     "name": "Bradley",
-    "url": "https://login.ezproxy.bradley.edu/login?url=",
+    "url": "https://login.ezproxy.bradley.edu/login?url=$@",
     "location": {
       "lng": -89.6153484,
       "lat": 40.6977743
@@ -982,7 +982,7 @@
   },
   {
     "name": "Brandeis University",
-    "url": "https://go.openathens.net/redirector/brandeis.edu?url=",
+    "url": "https://go.openathens.net/redirector/brandeis.edu?url=$@",
     "location": {
       "lng": -71.2586441,
       "lat": 42.36535689999999
@@ -991,7 +991,7 @@
   },
   {
     "name": "Brazosport",
-    "url": "http://plainview.brazosport.edu:2048/login?url=",
+    "url": "http://plainview.brazosport.edu:2048/login?url=$@",
     "location": {
       "lng": -95.4091723,
       "lat": 29.0483827
@@ -1000,7 +1000,7 @@
   },
   {
     "name": "Brenau",
-    "url": "http://ezproxy.brenau.edu:2048/login?url=",
+    "url": "http://ezproxy.brenau.edu:2048/login?url=$@",
     "location": {
       "lng": -83.8197347,
       "lat": 34.3041267
@@ -1009,7 +1009,7 @@
   },
   {
     "name": "Brescia",
-    "url": "https://ezproxy.brescia.edu/login?url=",
+    "url": "https://ezproxy.brescia.edu/login?url=$@",
     "location": {
       "lng": 10.2118019,
       "lat": 45.5415526
@@ -1018,7 +1018,7 @@
   },
   {
     "name": "Briercrest College and Seminary",
-    "url": "http://ezproxy.briercrest.lib.sk.ca/login?url=",
+    "url": "http://ezproxy.briercrest.lib.sk.ca/login?url=$@",
     "location": {
       "lng": -105.81491,
       "lat": 50.4573732
@@ -1027,7 +1027,7 @@
   },
   {
     "name": "Brigham Young University",
-    "url": "https://www.lib.byu.edu/cgi-bin/remoteauth.pl?url=",
+    "url": "https://www.lib.byu.edu/cgi-bin/remoteauth.pl?url=$@",
     "location": {
       "lng": -111.6493156,
       "lat": 40.2518435
@@ -1036,7 +1036,7 @@
   },
   {
     "name": "British Medical Association",
-    "url": "http://ezproxy.bma.org.uk/login?url=",
+    "url": "http://ezproxy.bma.org.uk/login?url=$@",
     "location": {
       "lng": -0.12820981759989078,
       "lat": 51.52875768815621
@@ -1045,7 +1045,7 @@
   },
   {
     "name": "Brno University of Technology",
-    "url": "https://ezproxy.lib.vutbr.cz/login?qurl=",
+    "url": "https://ezproxy.lib.vutbr.cz/login?qurl=$@",
     "location": {
       "lng": 16.603619,
       "lat": 49.2015407
@@ -1054,7 +1054,7 @@
   },
   {
     "name": "Brock University",
-    "url": "https://login.proxy.library.brocku.ca/login?qurl=",
+    "url": "https://login.proxy.library.brocku.ca/login?qurl=$@",
     "location": {
       "lng": -79.24762812668484,
       "lat": 43.1178080458223
@@ -1063,7 +1063,7 @@
   },
   {
     "name": "Brooklyn College",
-    "url": "https://login.ez-proxy.brooklyn.cuny.edu/login?url=",
+    "url": "https://login.ez-proxy.brooklyn.cuny.edu/login?url=$@",
     "location": {
       "lng": -73.9523802,
       "lat": 40.6311257
@@ -1072,7 +1072,7 @@
   },
   {
     "name": "Brown University",
-    "url": "https://revproxy.brown.edu/login?url=",
+    "url": "https://revproxy.brown.edu/login?url=$@",
     "location": {
       "lng": -71.4025482,
       "lat": 41.8267718
@@ -1081,7 +1081,7 @@
   },
   {
     "name": "Brunel University",
-    "url": "https://login.ezproxy.brunel.ac.uk/login?url=",
+    "url": "https://login.ezproxy.brunel.ac.uk/login?url=$@",
     "location": {
       "lng": -0.4727493,
       "lat": 51.5321389
@@ -1090,7 +1090,7 @@
   },
   {
     "name": "Bryn Mawr",
-    "url": "https://proxy.brynmawr.edu/login?url=",
+    "url": "https://proxy.brynmawr.edu/login?url=$@",
     "location": {
       "lng": -75.3151772,
       "lat": 40.0230237
@@ -1099,7 +1099,7 @@
   },
   {
     "name": "Bucknell University",
-    "url": "http://ezproxy.bucknell.edu/login?url=",
+    "url": "http://ezproxy.bucknell.edu/login?url=$@",
     "location": {
       "lng": -76.88507589999999,
       "lat": 40.9547722
@@ -1108,7 +1108,7 @@
   },
   {
     "name": "Butler",
-    "url": "https://ezproxy.butler.edu:8443/login?url=",
+    "url": "https://ezproxy.butler.edu:8443/login?url=$@",
     "location": {
       "lng": -86.1708927,
       "lat": 39.8405491
@@ -1117,7 +1117,7 @@
   },
   {
     "name": "CAFe Comunidade Acadêmica Federada",
-    "url": "http://ez119.periodicos.capes.gov.br/login?url=",
+    "url": "http://ez119.periodicos.capes.gov.br/login?url=$@",
     "location": {
       "lng": -47.9858173931249,
       "lat": -15.699815561813493
@@ -1126,7 +1126,7 @@
   },
   {
     "name": "Cal Poly Pomona",
-    "url": "https://login.proxy.library.cpp.edu/login?url=",
+    "url": "https://login.proxy.library.cpp.edu/login?url=$@",
     "location": {
       "lng": -117.819263,
       "lat": 34.0555994
@@ -1135,7 +1135,7 @@
   },
   {
     "name": "Cal State Monterey Bay",
-    "url": "http://library2.csumb.edu:2048/login?url=",
+    "url": "http://library2.csumb.edu:2048/login?url=$@",
     "location": {
       "lng": -121.7977985,
       "lat": 36.6516548
@@ -1144,7 +1144,7 @@
   },
   {
     "name": "Caldwell",
-    "url": "http://ezproxy.caldwell.edu:2048/login?url=",
+    "url": "http://ezproxy.caldwell.edu:2048/login?url=$@",
     "location": {
       "lng": -74.2765366,
       "lat": 40.8398218
@@ -1153,7 +1153,7 @@
   },
   {
     "name": "California Baptist",
-    "url": "http://libproxy.calbaptist.edu/login?url=",
+    "url": "http://libproxy.calbaptist.edu/login?url=$@",
     "location": {
       "lng": -117.4259155,
       "lat": 33.9288906
@@ -1162,7 +1162,7 @@
   },
   {
     "name": "California Health Sciences University",
-    "url": "http://chsu.idm.oclc.org/login?url=",
+    "url": "http://chsu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -119.7019191,
       "lat": 36.8325594
@@ -1171,7 +1171,7 @@
   },
   {
     "name": "California Institute of Integral Studies",
-    "url": "https://ciis.idm.oclc.org/login?url=",
+    "url": "https://ciis.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.4164229,
       "lat": 37.7746792
@@ -1180,7 +1180,7 @@
   },
   {
     "name": "California Polytechnic State University",
-    "url": "http://ezproxy.lib.calpoly.edu/login?url=",
+    "url": "http://ezproxy.lib.calpoly.edu/login?url=$@",
     "location": {
       "lng": -120.6624942,
       "lat": 35.3050053
@@ -1189,7 +1189,7 @@
   },
   {
     "name": "California State University San Marcos",
-    "url": "https://ezproxy.csusm.edu/login?url=",
+    "url": "https://ezproxy.csusm.edu/login?url=$@",
     "location": {
       "lng": -117.1586856,
       "lat": 33.1298249
@@ -1198,7 +1198,7 @@
   },
   {
     "name": "California State University Stanislaus",
-    "url": "http://libproxy.csustan.edu/login?url=",
+    "url": "http://libproxy.csustan.edu/login?url=$@",
     "location": {
       "lng": -120.8554591,
       "lat": 37.525398
@@ -1207,7 +1207,7 @@
   },
   {
     "name": "California State University, Fullerton",
-    "url": "http://lib-proxy.fullerton.edu/login?url=",
+    "url": "http://lib-proxy.fullerton.edu/login?url=$@",
     "location": {
       "lng": -117.8851033,
       "lat": 33.8823476
@@ -1216,7 +1216,7 @@
   },
   {
     "name": "California State University, Los Angeles",
-    "url": "http://mimas.calstatela.edu/login?url=",
+    "url": "http://mimas.calstatela.edu/login?url=$@",
     "location": {
       "lng": -118.1684782,
       "lat": 34.0663797
@@ -1225,7 +1225,7 @@
   },
   {
     "name": "California State University, Northridge",
-    "url": "http://libproxy.csun.edu/login?url=",
+    "url": "http://libproxy.csun.edu/login?url=$@",
     "location": {
       "lng": -118.5300196,
       "lat": 34.2406756
@@ -1234,7 +1234,7 @@
   },
   {
     "name": "California University of PA",
-    "url": "http://proxy-calu.klnpa.org/login?url=",
+    "url": "http://proxy-calu.klnpa.org/login?url=$@",
     "location": {
       "lng": -79.8844522,
       "lat": 40.06439659999999
@@ -1243,7 +1243,7 @@
   },
   {
     "name": "California Western School of Law",
-    "url": "http://lib-proxy.cwsl.edu:2048/login?url=",
+    "url": "http://lib-proxy.cwsl.edu:2048/login?url=$@",
     "location": {
       "lng": -117.1624897,
       "lat": 32.721719
@@ -1252,7 +1252,7 @@
   },
   {
     "name": "Caltech",
-    "url": "http://clsproxy.library.caltech.edu/login?url=",
+    "url": "http://clsproxy.library.caltech.edu/login?url=$@",
     "location": {
       "lng": -118.125269,
       "lat": 34.1376576
@@ -1261,7 +1261,7 @@
   },
   {
     "name": "Calumet College of St Joseph",
-    "url": "http://ezproxy.ccsj.edu:2048/login?url=",
+    "url": "http://ezproxy.ccsj.edu:2048/login?url=$@",
     "location": {
       "lng": -87.49445899999999,
       "lat": 41.67086
@@ -1270,7 +1270,7 @@
   },
   {
     "name": "Calvin",
-    "url": "https://lib-proxy.calvin.edu/login?url=",
+    "url": "https://lib-proxy.calvin.edu/login?url=$@",
     "location": {
       "lng": -85.58897189999999,
       "lat": 42.9269528
@@ -1279,7 +1279,7 @@
   },
   {
     "name": "Cameron",
-    "url": "http://ezproxy.cameron.edu/login?url=",
+    "url": "http://ezproxy.cameron.edu/login?url=$@",
     "location": {
       "lng": -98.436244,
       "lat": 34.6049663
@@ -1288,7 +1288,7 @@
   },
   {
     "name": "Canadian Memorial Chiropractic",
-    "url": "http://ezproxy.cmcc.ca/login?url=",
+    "url": "http://ezproxy.cmcc.ca/login?url=$@",
     "location": {
       "lng": 2.7737521,
       "lat": 50.3795055
@@ -1297,7 +1297,7 @@
   },
   {
     "name": "Cancer Research UK",
-    "url": "http://libraryproxy.cancerresearchuk.org/login?url=",
+    "url": "http://libraryproxy.cancerresearchuk.org/login?url=$@",
     "location": {
       "lng": -1.2078627797469357,
       "lat": 51.731666502450146
@@ -1306,7 +1306,7 @@
   },
   {
     "name": "Canisius",
-    "url": "https://ezproxy.canisius.edu/login?url=",
+    "url": "https://ezproxy.canisius.edu/login?url=$@",
     "location": {
       "lng": -78.8550954,
       "lat": 42.9237929
@@ -1315,7 +1315,7 @@
   },
   {
     "name": "Cape Breton University",
-    "url": "https://cbu.idm.oclc.org/login?url=",
+    "url": "https://cbu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -60.08976879999999,
       "lat": 46.1672583
@@ -1324,7 +1324,7 @@
   },
   {
     "name": "Cape Peninsula University of Technology",
-    "url": "http://ezproxy.cput.ac.za/login?url=",
+    "url": "http://ezproxy.cput.ac.za/login?url=$@",
     "location": {
       "lng": 18.639063,
       "lat": -33.9305085
@@ -1333,7 +1333,7 @@
   },
   {
     "name": "Capella",
-    "url": "http://ezproxy.library.capella.edu/login?url=",
+    "url": "http://ezproxy.library.capella.edu/login?url=$@",
     "location": {
       "lng": -93.26858089999999,
       "lat": 44.976168
@@ -1342,7 +1342,7 @@
   },
   {
     "name": "Capilano",
-    "url": "https://ezproxy.capilanou.ca/login?url=",
+    "url": "https://ezproxy.capilanou.ca/login?url=$@",
     "location": {
       "lng": -123.1260877188983,
       "lat": 49.33730254215083
@@ -1351,7 +1351,7 @@
   },
   {
     "name": "Cardiff",
-    "url": "http://abc.cardiff.ac.uk/login?url=",
+    "url": "http://abc.cardiff.ac.uk/login?url=$@",
     "location": {
       "lng": -3.1680962,
       "lat": 51.483707
@@ -1360,7 +1360,7 @@
   },
   {
     "name": "Cardiff Metropolitan University",
-    "url": "https://ezproxy.cardiffmet.ac.uk/login?url=",
+    "url": "https://ezproxy.cardiffmet.ac.uk/login?url=$@",
     "location": {
       "lng": -3.2120517,
       "lat": 51.4959559
@@ -1369,7 +1369,7 @@
   },
   {
     "name": "Caribbean",
-    "url": "http://securelib.caribbean.edu:2048/login?url=",
+    "url": "http://securelib.caribbean.edu:2048/login?url=$@",
     "location": {
       "lng": -78.6568942,
       "lat": 21.4691137
@@ -1378,7 +1378,7 @@
   },
   {
     "name": "Carleton",
-    "url": "http://ezproxy.carleton.edu/login?url=",
+    "url": "http://ezproxy.carleton.edu/login?url=$@",
     "location": {
       "lng": -75.69602019999999,
       "lat": 45.3875812
@@ -1387,7 +1387,7 @@
   },
   {
     "name": "Carleton University",
-    "url": "https://login.proxy.library.carleton.ca/login?url=",
+    "url": "https://login.proxy.library.carleton.ca/login?url=$@",
     "location": {
       "lng": -75.69602019999999,
       "lat": 45.3875812
@@ -1396,7 +1396,7 @@
   },
   {
     "name": "Carlow",
-    "url": "http://carlow.idm.oclc.org/login?url=",
+    "url": "http://carlow.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -6.932474399999999,
       "lat": 52.835854
@@ -1405,7 +1405,7 @@
   },
   {
     "name": "Carnegie Mellon University (CMU)",
-    "url": "https://cmu.idm.oclc.org/login?url=",
+    "url": "https://cmu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -79.9428499,
       "lat": 40.4432027
@@ -1414,7 +1414,7 @@
   },
   {
     "name": "Catholic University of America",
-    "url": "http://proxycu.wrlc.org/login?url=",
+    "url": "http://proxycu.wrlc.org/login?url=$@",
     "location": {
       "lng": -76.99869199999999,
       "lat": 38.9368811
@@ -1423,7 +1423,7 @@
   },
   {
     "name": "Cayuga",
-    "url": "http://ezproxy.cayuga-cc.edu:2048/login?url=",
+    "url": "http://ezproxy.cayuga-cc.edu:2048/login?url=$@",
     "location": {
       "lng": -76.5488232,
       "lat": 42.7655231
@@ -1432,7 +1432,7 @@
   },
   {
     "name": "Cedars-Sinai Medical Center",
-    "url": "http://mlprox.csmc.edu/login?url=",
+    "url": "http://mlprox.csmc.edu/login?url=$@",
     "location": {
       "lng": -118.380967,
       "lat": 34.074922
@@ -1441,7 +1441,7 @@
   },
   {
     "name": "Centenary College of Louisiana",
-    "url": "https://centenary.idm.oclc.org/login?url=",
+    "url": "https://centenary.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -93.73215560000001,
       "lat": 32.4847432
@@ -1450,7 +1450,7 @@
   },
   {
     "name": "Central Baptist Theological Seminary",
-    "url": "http://library.cbts.edu:2048/login?url=",
+    "url": "http://library.cbts.edu:2048/login?url=$@",
     "location": {
       "lng": -94.8382488,
       "lat": 39.0093678
@@ -1459,7 +1459,7 @@
   },
   {
     "name": "Central Michigan",
-    "url": "http://cmich.idm.oclc.org/login?url=",
+    "url": "http://cmich.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -84.7755904,
       "lat": 43.5906616
@@ -1468,7 +1468,7 @@
   },
   {
     "name": "Central Oregon",
-    "url": "http://library.cocc.edu:2048/login?url=",
+    "url": "http://library.cocc.edu:2048/login?url=$@",
     "location": {
       "lng": -120.5542012,
       "lat": 43.8041334
@@ -1477,7 +1477,7 @@
   },
   {
     "name": "Central Washington",
-    "url": "https://login.ezp.lib.cwu.edu/login?url=",
+    "url": "https://login.ezp.lib.cwu.edu/login?url=$@",
     "location": {
       "lng": -120.5362805,
       "lat": 47.0073154
@@ -1486,7 +1486,7 @@
   },
   {
     "name": "Central Wyoming",
-    "url": "http://proxy.cwc.edu:2048/login?url=",
+    "url": "http://proxy.cwc.edu:2048/login?url=$@",
     "location": {
       "lng": -108.426918,
       "lat": 43.0304794
@@ -1495,7 +1495,7 @@
   },
   {
     "name": "Centre College",
-    "url": "https://ezproxy.centre.edu/login?url=",
+    "url": "https://ezproxy.centre.edu/login?url=$@",
     "location": {
       "lng": -84.77906100344322,
       "lat": 37.645860888911464
@@ -1504,7 +1504,7 @@
   },
   {
     "name": "CeRA - Indian Agricultural Research Institute",
-    "url": "http://14.139.56.75/login?url=",
+    "url": "http://14.139.56.75/login?url=$@",
     "location": {
       "lng": 77.15249589999999,
       "lat": 28.6331469
@@ -1513,7 +1513,7 @@
   },
   {
     "name": "CERN",
-    "url": "https://ezproxy.cern.ch/login?url=",
+    "url": "https://ezproxy.cern.ch/login?url=$@",
     "location": {
       "lng": 6.0556771,
       "lat": 46.2330492
@@ -1522,7 +1522,7 @@
   },
   {
     "name": "Cerro Coso",
-    "url": "http://ezproxy.cerrocoso.edu:2048/login?url=",
+    "url": "http://ezproxy.cerrocoso.edu:2048/login?url=$@",
     "location": {
       "lng": -117.667777,
       "lat": 35.5674569
@@ -1531,7 +1531,7 @@
   },
   {
     "name": "CETYS University",
-    "url": "https://ebiblio.cetys.mx/login?url=",
+    "url": "https://ebiblio.cetys.mx/login?url=$@",
     "location": {
       "lng": -115.4084339,
       "lat": 32.6547625
@@ -1540,7 +1540,7 @@
   },
   {
     "name": "Chadli Bendjedid University",
-    "url": "http://ezproxy.univ-eltarf.dz/login?url=",
+    "url": "http://ezproxy.univ-eltarf.dz/login?url=$@",
     "location": {
       "lng": 8.3211257,
       "lat": 36.7619589
@@ -1549,7 +1549,7 @@
   },
   {
     "name": "Chalmers tekniska hogskola AB",
-    "url": "http://proxy.lib.chalmers.se/login?url=",
+    "url": "http://proxy.lib.chalmers.se/login?url=$@",
     "location": {
       "lng": 11.93666,
       "lat": 57.70661589999999
@@ -1558,7 +1558,7 @@
   },
   {
     "name": "Chalmers University of Technology",
-    "url": "https://login.proxy.lib.chalmers.se/login?url=",
+    "url": "https://login.proxy.lib.chalmers.se/login?url=$@",
     "location": {
       "lng": 11.9741616,
       "lat": 57.6898004
@@ -1567,7 +1567,7 @@
   },
   {
     "name": "Champlain College Online",
-    "url": "https://cobalt.champlain.edu/login?url=",
+    "url": "https://cobalt.champlain.edu/login?url=$@",
     "location": {
       "lng": -73.2159534,
       "lat": 44.4610113
@@ -1576,7 +1576,7 @@
   },
   {
     "name": "Chandler-Gilbert",
-    "url": "http://ez1.maricopa.edu:2048/login?url=",
+    "url": "http://ez1.maricopa.edu:2048/login?url=$@",
     "location": {
       "lng": -111.7956814,
       "lat": 33.2951034
@@ -1585,7 +1585,7 @@
   },
   {
     "name": "Chang Gung",
-    "url": "http://proxy.lib.cgu.edu.tw:81/login?url=",
+    "url": "http://proxy.lib.cgu.edu.tw:81/login?url=$@",
     "location": {
       "lng": 121.3877767,
       "lat": 25.0349186
@@ -1594,7 +1594,7 @@
   },
   {
     "name": "Chapman University",
-    "url": "http://libproxy.chapman.edu/login?url=",
+    "url": "http://libproxy.chapman.edu/login?url=$@",
     "location": {
       "lng": -117.8520736,
       "lat": 33.7933203
@@ -1603,7 +1603,7 @@
   },
   {
     "name": "Charles Darwin University",
-    "url": "http://ezproxy.cdu.edu.au/login?url=",
+    "url": "http://ezproxy.cdu.edu.au/login?url=$@",
     "location": {
       "lng": 130.8688636,
       "lat": -12.3719948
@@ -1612,7 +1612,7 @@
   },
   {
     "name": "Charles Sturt University",
-    "url": "http://ezproxy.csu.edu.au/login?url=",
+    "url": "http://ezproxy.csu.edu.au/login?url=$@",
     "location": {
       "lng": 147.3871248690005,
       "lat": -34.87645965380469
@@ -1621,7 +1621,7 @@
   },
   {
     "name": "Charleston Southern University",
-    "url": "http://mendel.csuniv.edu/login?url=",
+    "url": "http://mendel.csuniv.edu/login?url=$@",
     "location": {
       "lng": -80.07065539999999,
       "lat": 32.9821829
@@ -1630,7 +1630,7 @@
   },
   {
     "name": "Cheyney University",
-    "url": "http://proxy-cheyney.klnpa.org/login?url=",
+    "url": "http://proxy-cheyney.klnpa.org/login?url=$@",
     "location": {
       "lng": -75.52950849999999,
       "lat": 39.9332726
@@ -1639,7 +1639,7 @@
   },
   {
     "name": "Chicago Theological Seminary",
-    "url": "https://cts.idm.oclc.org/login?url=",
+    "url": "https://cts.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -87.590926,
       "lat": 41.7854913
@@ -1648,7 +1648,7 @@
   },
   {
     "name": "Chinese University of Hong Kong",
-    "url": "https://easylogin1.lib.cuhk.edu.hk/login?url=",
+    "url": "https://easylogin1.lib.cuhk.edu.hk/login?url=$@",
     "location": {
       "lng": 114.2067606,
       "lat": 22.419625
@@ -1657,7 +1657,7 @@
   },
   {
     "name": "CIAP, NSW Health",
-    "url": "http://acs.hcn.com.au/?acc=36422&url=",
+    "url": "http://acs.hcn.com.au/?acc=36422&url=$@",
     "location": {
       "lng": 146.921099,
       "lat": -31.2532183
@@ -1666,7 +1666,7 @@
   },
   {
     "name": "Cincinnati State Technical and",
-    "url": "http://ezproxy1.cincinnatistate.edu:2048/login?url=",
+    "url": "http://ezproxy1.cincinnatistate.edu:2048/login?url=$@",
     "location": {
       "lng": -84.53711609999999,
       "lat": 39.1506136
@@ -1675,7 +1675,7 @@
   },
   {
     "name": "City College Brighton and Hove",
-    "url": "http://ezproxy.ccb.ac.uk:2048/login?url=",
+    "url": "http://ezproxy.ccb.ac.uk:2048/login?url=$@",
     "location": {
       "lng": -0.136965,
       "lat": 50.8291136
@@ -1684,7 +1684,7 @@
   },
   {
     "name": "City College of San Francisco",
-    "url": "http://ezproxy.ccsf.edu/login?url=",
+    "url": "http://ezproxy.ccsf.edu/login?url=$@",
     "location": {
       "lng": -122.4510797,
       "lat": 37.72569
@@ -1693,7 +1693,7 @@
   },
   {
     "name": "City University of Hong Kong",
-    "url": "https://lbapp01.lib.cityu.edu.hk/ezlogin/index.aspx?url=",
+    "url": "https://lbapp01.lib.cityu.edu.hk/ezlogin/index.aspx?url=$@",
     "location": {
       "lng": 114.17272,
       "lat": 22.3370342
@@ -1702,7 +1702,7 @@
   },
   {
     "name": "City University of New York",
-    "url": "https://ezproxy.gc.cuny.edu/login?url=",
+    "url": "https://ezproxy.gc.cuny.edu/login?url=$@",
     "location": {
       "lng": -73.9735038,
       "lat": 40.7509381
@@ -1711,7 +1711,7 @@
   },
   {
     "name": "City University of Seattle",
-    "url": "https://proxy.cityu.edu/login?url=",
+    "url": "https://proxy.cityu.edu/login?url=$@",
     "location": {
       "lng": -122.3444142,
       "lat": 47.6175471
@@ -1720,7 +1720,7 @@
   },
   {
     "name": "Claremont Colleges",
-    "url": "https://ccl.idm.oclc.org/login?url=",
+    "url": "https://ccl.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -117.7119768,
       "lat": 34.1035316
@@ -1729,7 +1729,7 @@
   },
   {
     "name": "Clarion University",
-    "url": "http://proxy-clarion.klnpa.org/login?url=",
+    "url": "http://proxy-clarion.klnpa.org/login?url=$@",
     "location": {
       "lng": -79.37856310000001,
       "lat": 41.2089367
@@ -1738,7 +1738,7 @@
   },
   {
     "name": "Clark University",
-    "url": "https://goddard40.clarku.edu/login?qurl=",
+    "url": "https://goddard40.clarku.edu/login?qurl=$@",
     "location": {
       "lng": -71.82455005320072,
       "lat": 42.25220425261454
@@ -1747,7 +1747,7 @@
   },
   {
     "name": "Clarkson University",
-    "url": "https://ezproxy.clarkson.edu/login?url=",
+    "url": "https://ezproxy.clarkson.edu/login?url=$@",
     "location": {
       "lng": -74.9932733,
       "lat": 44.6647724
@@ -1756,7 +1756,7 @@
   },
   {
     "name": "Clemson",
-    "url": "http://proxy.lib.clemson.edu/login?url=",
+    "url": "http://proxy.lib.clemson.edu/login?url=$@",
     "location": {
       "lng": -82.8367119,
       "lat": 34.673407
@@ -1765,7 +1765,7 @@
   },
   {
     "name": "Clemson University",
-    "url": "http://libproxy.clemson.edu/login?url=",
+    "url": "http://libproxy.clemson.edu/login?url=$@",
     "location": {
       "lng": -82.8367119,
       "lat": 34.673407
@@ -1774,7 +1774,7 @@
   },
   {
     "name": "Clermont Universite",
-    "url": "http://sicd.clermont-universite.fr/login?url=",
+    "url": "http://sicd.clermont-universite.fr/login?url=$@",
     "location": {
       "lng": 3.087025,
       "lat": 45.77722199999999
@@ -1783,7 +1783,7 @@
   },
   {
     "name": "Cleveland State",
-    "url": "http://proxy.ulib.csuohio.edu:2050/login?url=",
+    "url": "http://proxy.ulib.csuohio.edu:2050/login?url=$@",
     "location": {
       "lng": -81.67442299999999,
       "lat": 41.5027643
@@ -1792,7 +1792,7 @@
   },
   {
     "name": "Cleveland University-Kansas City",
-    "url": "http://ezproxy.cleveland.edu:2048/login?url=",
+    "url": "http://ezproxy.cleveland.edu:2048/login?url=$@",
     "location": {
       "lng": -94.6791964,
       "lat": 38.9320301
@@ -1801,7 +1801,7 @@
   },
   {
     "name": "Clinton Community College",
-    "url": "http://ezproxy.clinton.edu:2048/login?url=",
+    "url": "http://ezproxy.clinton.edu:2048/login?url=$@",
     "location": {
       "lng": -73.44005102061675,
       "lat": 44.64832548820429
@@ -1810,7 +1810,7 @@
   },
   {
     "name": "CNRS INEE",
-    "url": "http://inee.bib.cnrs.fr/login?url=",
+    "url": "http://inee.bib.cnrs.fr/login?url=$@",
     "location": {
       "lng": 2.2639934,
       "lat": 48.8476037
@@ -1819,7 +1819,7 @@
   },
   {
     "name": "CNRS INSB",
-    "url": "http://insb.bib.cnrs.fr/login?url=",
+    "url": "http://insb.bib.cnrs.fr/login?url=$@",
     "location": {
       "lng": 2.2639934,
       "lat": 48.8476037
@@ -1828,7 +1828,7 @@
   },
   {
     "name": "Coastal Carolina",
-    "url": "http://login.library.coastal.edu:2048/login?url=",
+    "url": "http://login.library.coastal.edu:2048/login?url=$@",
     "location": {
       "lng": -79.0136958,
       "lat": 33.79611939999999
@@ -1837,7 +1837,7 @@
   },
   {
     "name": "Colby",
-    "url": "https://colby.idm.oclc.org/login?url=",
+    "url": "https://colby.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -69.6626362,
       "lat": 44.5638691
@@ -1846,7 +1846,7 @@
   },
   {
     "name": "Cold Spring Harbor Laboratory",
-    "url": "http://journals.cshl.edu:2048/login?url=",
+    "url": "http://journals.cshl.edu:2048/login?url=$@",
     "location": {
       "lng": -73.4669315,
       "lat": 40.8580545
@@ -1855,7 +1855,7 @@
   },
   {
     "name": "College of Charleston",
-    "url": "http://nuncio.cofc.edu/login?url=",
+    "url": "http://nuncio.cofc.edu/login?url=$@",
     "location": {
       "lng": -79.93700179999999,
       "lat": 32.7834441
@@ -1864,7 +1864,7 @@
   },
   {
     "name": "College of DuPage",
-    "url": "https://cod.idm.oclc.org/login?url=",
+    "url": "https://cod.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -88.07334010000001,
       "lat": 41.8411058
@@ -1873,7 +1873,7 @@
   },
   {
     "name": "College of New Jersey",
-    "url": "http://ezproxy.tcnj.edu:2048/login?url=",
+    "url": "http://ezproxy.tcnj.edu:2048/login?url=$@",
     "location": {
       "lng": -74.77763329999999,
       "lat": 40.268479
@@ -1882,7 +1882,7 @@
   },
   {
     "name": "College of Southern Nevada",
-    "url": "http://ezproxy.library.csn.edu/login?url=",
+    "url": "http://ezproxy.library.csn.edu/login?url=$@",
     "location": {
       "lng": -114.9653903,
       "lat": 36.0081705
@@ -1891,7 +1891,7 @@
   },
   {
     "name": "College of the Canyons",
-    "url": "http://ezproxy.canyons.edu:2048/login?url=",
+    "url": "http://ezproxy.canyons.edu:2048/login?url=$@",
     "location": {
       "lng": -118.5696313,
       "lat": 34.4042187
@@ -1900,7 +1900,7 @@
   },
   {
     "name": "College of the Holy Cross",
-    "url": "https://holycross.idm.oclc.org/login?auth=cas&url=",
+    "url": "https://holycross.idm.oclc.org/login?auth=cas&url=$@",
     "location": {
       "lng": -71.8079608,
       "lat": 42.2392391
@@ -1909,7 +1909,7 @@
   },
   {
     "name": "College of the Mainland",
-    "url": "https://ezproxy.com.edu/login?url=",
+    "url": "https://ezproxy.com.edu/login?url=$@",
     "location": {
       "lng": -94.9998366,
       "lat": 29.3955473
@@ -1918,7 +1918,7 @@
   },
   {
     "name": "College of the Sequoias",
-    "url": "http://cos.idm.oclc.org/login?url=",
+    "url": "http://cos.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -119.3149754,
       "lat": 36.325102
@@ -1927,7 +1927,7 @@
   },
   {
     "name": "College of William and Mary",
-    "url": "https://proxy.wm.edu/login?url=",
+    "url": "https://proxy.wm.edu/login?url=$@",
     "location": {
       "lng": -76.71624659999999,
       "lat": 37.2709753
@@ -1936,7 +1936,7 @@
   },
   {
     "name": "Colorado Mountain",
-    "url": "http://cmclibraries.coloradomtn.edu/login?url=",
+    "url": "http://cmclibraries.coloradomtn.edu/login?url=$@",
     "location": {
       "lng": -107.3245249,
       "lat": 39.5464607
@@ -1945,7 +1945,7 @@
   },
   {
     "name": "Colorado School of Mines",
-    "url": "https://mines.idm.oclc.org/login?url=",
+    "url": "https://mines.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -105.2225708,
       "lat": 39.7510475
@@ -1954,7 +1954,7 @@
   },
   {
     "name": "Colorado State University",
-    "url": "http://ezproxy2.library.colostate.edu/login?url=",
+    "url": "http://ezproxy2.library.colostate.edu/login?url=$@",
     "location": {
       "lng": -105.0865487,
       "lat": 40.57341479999999
@@ -1963,7 +1963,7 @@
   },
   {
     "name": "Colorado State University-Global Campus",
-    "url": "https://csuglobal.idm.oclc.org/login?url=",
+    "url": "https://csuglobal.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -104.786609,
       "lat": 39.7251537
@@ -1972,7 +1972,7 @@
   },
   {
     "name": "Colorado Technical",
-    "url": "https://login.ctu.idm.oclc.org/login?qurl=",
+    "url": "https://login.ctu.idm.oclc.org/login?qurl=$@",
     "location": {
       "lng": -104.8561593,
       "lat": 38.8946973
@@ -1981,7 +1981,7 @@
   },
   {
     "name": "Columbia College",
-    "url": "https://proxy.ccis.edu/login?url=",
+    "url": "https://proxy.ccis.edu/login?url=$@",
     "location": {
       "lng": -92.3261593220258,
       "lat": 38.95833850911415
@@ -1990,7 +1990,7 @@
   },
   {
     "name": "Columbia College Sonora",
-    "url": "http://libdbcc.yosemite.edu/login?url=",
+    "url": "http://libdbcc.yosemite.edu/login?url=$@",
     "location": {
       "lng": -120.3885135,
       "lat": 38.0317977
@@ -1999,7 +1999,7 @@
   },
   {
     "name": "Columbia College Vancouver",
-    "url": "http://ezproxy.columbiacollege.bc.ca/login?url=",
+    "url": "http://ezproxy.columbiacollege.bc.ca/login?url=$@",
     "location": {
       "lng": -123.0947321,
       "lat": 49.27163239999999
@@ -2008,7 +2008,7 @@
   },
   {
     "name": "Columbia Gorge",
-    "url": "http://cgcc-access.sage.eou.edu/login?url=",
+    "url": "http://cgcc-access.sage.eou.edu/login?url=$@",
     "location": {
       "lng": -121.7524723,
       "lat": 45.7087498
@@ -2017,7 +2017,7 @@
   },
   {
     "name": "Columbia University",
-    "url": "http://ezproxy.cul.columbia.edu/login?url=",
+    "url": "http://ezproxy.cul.columbia.edu/login?url=$@",
     "location": {
       "lng": -73.9625727,
       "lat": 40.8075355
@@ -2026,7 +2026,7 @@
   },
   {
     "name": "Concordia College-New York",
-    "url": "http://ezproxy.concordia-ny.edu:2048/login?url=",
+    "url": "http://ezproxy.concordia-ny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.82214239999999,
       "lat": 40.94264
@@ -2035,7 +2035,7 @@
   },
   {
     "name": "Concordia University",
-    "url": "https://ezproxy.cui.edu/login?qurl=",
+    "url": "https://ezproxy.cui.edu/login?qurl=$@",
     "location": {
       "lng": -73.5779128,
       "lat": 45.4948363
@@ -2044,7 +2044,7 @@
   },
   {
     "name": "Concordia University (Montreal, Canada)",
-    "url": "https://lib-ezproxy.concordia.ca/login?url=",
+    "url": "https://lib-ezproxy.concordia.ca/login?url=$@",
     "location": {
       "lng": -73.5779128,
       "lat": 45.4948363
@@ -2053,7 +2053,7 @@
   },
   {
     "name": "Concordia University Irvine",
-    "url": "http://ezproxy.cui.edu/login?url=",
+    "url": "http://ezproxy.cui.edu/login?url=$@",
     "location": {
       "lng": -117.8105295,
       "lat": 33.6539343
@@ -2062,7 +2062,7 @@
   },
   {
     "name": "Concordia University Portland",
-    "url": "https://cupdx.idm.oclc.org/login?url=",
+    "url": "https://cupdx.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.6363765,
       "lat": 45.5690187
@@ -2071,7 +2071,7 @@
   },
   {
     "name": "Concordia University St Paul",
-    "url": "https://ezproxy.csp.edu/login?url=",
+    "url": "https://ezproxy.csp.edu/login?url=$@",
     "location": {
       "lng": -93.156483,
       "lat": 44.9490802
@@ -2080,7 +2080,7 @@
   },
   {
     "name": "Consiglio Nazionale delle Ricerche",
-    "url": "https://biblioproxy.cnr.it/login?url=",
+    "url": "https://biblioproxy.cnr.it/login?url=$@",
     "location": {
       "lng": 12.533432038742754,
       "lat": 41.94858996338506
@@ -2089,7 +2089,7 @@
   },
   {
     "name": "Contra Costa County Library",
-    "url": "https://login.ez.ccclib.org/login?url=",
+    "url": "https://login.ez.ccclib.org/login?url=$@",
     "location": {
       "lng": -121.9017954,
       "lat": 37.8534093
@@ -2098,7 +2098,7 @@
   },
   {
     "name": "Copenhagen Business School",
-    "url": "http://esc-web.lib.cbs.dk/login?url=",
+    "url": "http://esc-web.lib.cbs.dk/login?url=$@",
     "location": {
       "lng": 12.5296944,
       "lat": 55.68156519999999
@@ -2107,7 +2107,7 @@
   },
   {
     "name": "Copenhagen University - The Royal Library",
-    "url": "http://ep.fjernadgang.kb.dk/login?url=",
+    "url": "http://ep.fjernadgang.kb.dk/login?url=$@",
     "location": {
       "lng": 12.5826588,
       "lat": 55.6733994
@@ -2116,7 +2116,7 @@
   },
   {
     "name": "Corban",
-    "url": "http://ezproxy.corban.edu/login?url=",
+    "url": "http://ezproxy.corban.edu/login?url=$@",
     "location": {
       "lng": -122.9580948,
       "lat": 44.88383779999999
@@ -2125,7 +2125,7 @@
   },
   {
     "name": "Cornell",
-    "url": "https://proxy.library.cornell.edu/login?url=",
+    "url": "https://proxy.library.cornell.edu/login?url=$@",
     "location": {
       "lng": -76.4735027,
       "lat": 42.4534492
@@ -2134,7 +2134,7 @@
   },
   {
     "name": "Cornell University",
-    "url": "http://encompass.library.cornell.edu/cgi-bin/checkIP.cgi?access=gateway_standard&url=",
+    "url": "http://encompass.library.cornell.edu/cgi-bin/checkIP.cgi?access=gateway_standard&url=$@",
     "location": {
       "lng": -76.4735027,
       "lat": 42.4534492
@@ -2143,7 +2143,7 @@
   },
   {
     "name": "County College of Morris",
-    "url": "http://skynet.ccm.edu:2048/login?url=",
+    "url": "http://skynet.ccm.edu:2048/login?url=$@",
     "location": {
       "lng": -74.5814491,
       "lat": 40.85817369999999
@@ -2152,7 +2152,7 @@
   },
   {
     "name": "Covenant Theological Seminary",
-    "url": "https://search.covenantseminary.edu/login?url=",
+    "url": "https://search.covenantseminary.edu/login?url=$@",
     "location": {
       "lng": -90.4521276,
       "lat": 38.6437191
@@ -2161,7 +2161,7 @@
   },
   {
     "name": "CQUniversity Australia",
-    "url": "https://ezproxy.cqu.edu.au/login?url=",
+    "url": "https://ezproxy.cqu.edu.au/login?url=$@",
     "location": {
       "lng": 150.5189408,
       "lat": -23.3264685
@@ -2170,7 +2170,7 @@
   },
   {
     "name": "Creighton University",
-    "url": "https://login.cuhsl.creighton.edu/login?url=",
+    "url": "https://login.cuhsl.creighton.edu/login?url=$@",
     "location": {
       "lng": -95.94638619999999,
       "lat": 41.2655521
@@ -2179,7 +2179,7 @@
   },
   {
     "name": "CSU Chico",
-    "url": "http://mantis.csuchico.edu/login?url=",
+    "url": "http://mantis.csuchico.edu/login?url=$@",
     "location": {
       "lng": -121.8478871,
       "lat": 39.7296653
@@ -2188,7 +2188,7 @@
   },
   {
     "name": "CSU East Bay",
-    "url": "http://proxylib.csueastbay.edu/login?url=",
+    "url": "http://proxylib.csueastbay.edu/login?url=$@",
     "location": {
       "lng": -122.0558839,
       "lat": 37.6568259
@@ -2197,7 +2197,7 @@
   },
   {
     "name": "CSU Fresno",
-    "url": "http://hmlproxy.lib.csufresno.edu/login?url=",
+    "url": "http://hmlproxy.lib.csufresno.edu/login?url=$@",
     "location": {
       "lng": -119.7461767,
       "lat": 36.8136777
@@ -2206,7 +2206,7 @@
   },
   {
     "name": "CSU Sacramento",
-    "url": "http://proxy.lib.csus.edu/login?url=",
+    "url": "http://proxy.lib.csus.edu/login?url=$@",
     "location": {
       "lng": -121.4276493,
       "lat": 38.564761
@@ -2215,7 +2215,7 @@
   },
   {
     "name": "CSU San Bernardino",
-    "url": "http://libproxy.lib.csusb.edu/login?url=",
+    "url": "http://libproxy.lib.csusb.edu/login?url=$@",
     "location": {
       "lng": -117.3231875,
       "lat": 34.1813584
@@ -2224,7 +2224,7 @@
   },
   {
     "name": "CUNY Baruch",
-    "url": "http://remote.baruch.cuny.edu/login?url=",
+    "url": "http://remote.baruch.cuny.edu/login?url=$@",
     "location": {
       "lng": -73.9835124,
       "lat": 40.7402384
@@ -2233,7 +2233,7 @@
   },
   {
     "name": "CUNY Central Office",
-    "url": "http://central.ezproxy.cuny.edu:2048/login?url=",
+    "url": "http://central.ezproxy.cuny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9735038,
       "lat": 40.7509381
@@ -2242,7 +2242,7 @@
   },
   {
     "name": "CUNY City College of New York",
-    "url": "http://ccny-proxy1.libr.ccny.cuny.edu/login?url=",
+    "url": "http://ccny-proxy1.libr.ccny.cuny.edu/login?url=$@",
     "location": {
       "lng": -73.9492724,
       "lat": 40.8200471
@@ -2251,7 +2251,7 @@
   },
   {
     "name": "CUNY College of Staten Island",
-    "url": "http://proxy.library.csi.cuny.edu/login?url=",
+    "url": "http://proxy.library.csi.cuny.edu/login?url=$@",
     "location": {
       "lng": -74.15038109999999,
       "lat": 40.6021807
@@ -2260,7 +2260,7 @@
   },
   {
     "name": "CUNY Graduate School of Journalism",
-    "url": "http://journalism.ezproxy.cuny.edu:2048/login?url=",
+    "url": "http://journalism.ezproxy.cuny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9889219,
       "lat": 40.7554192
@@ -2269,7 +2269,7 @@
   },
   {
     "name": "CUNY Hostos",
-    "url": "http://hostos.ezproxy.cuny.edu:2048/login?url=",
+    "url": "http://hostos.ezproxy.cuny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9735038,
       "lat": 40.7509381
@@ -2278,7 +2278,7 @@
   },
   {
     "name": "CUNY Hunter",
-    "url": "http://proxy.wexler.hunter.cuny.edu/login?url=",
+    "url": "http://proxy.wexler.hunter.cuny.edu/login?url=$@",
     "location": {
       "lng": -73.9645291,
       "lat": 40.7678398
@@ -2287,7 +2287,7 @@
   },
   {
     "name": "CUNY John Jay College of Criminal Justice",
-    "url": "http://ez.lib.jjay.cuny.edu/login?url=",
+    "url": "http://ez.lib.jjay.cuny.edu/login?url=$@",
     "location": {
       "lng": -73.9735038,
       "lat": 40.7509381
@@ -2296,7 +2296,7 @@
   },
   {
     "name": "CUNY Kingsborough",
-    "url": "http://kbcc.ezproxy.cuny.edu:2048/login?url=",
+    "url": "http://kbcc.ezproxy.cuny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9351016,
       "lat": 40.5786707
@@ -2305,7 +2305,7 @@
   },
   {
     "name": "CUNY Law School",
-    "url": "http://law.ezproxy.cuny.edu:2048/login?url=",
+    "url": "http://law.ezproxy.cuny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.94398269999999,
       "lat": 40.747929
@@ -2314,7 +2314,7 @@
   },
   {
     "name": "CUNY Medgar Evers",
-    "url": "http://mec.ezproxy.cuny.edu:2048/login?url=",
+    "url": "http://mec.ezproxy.cuny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9574025,
       "lat": 40.6670398
@@ -2323,7 +2323,7 @@
   },
   {
     "name": "CUNY New York City College of Technology",
-    "url": "http://citytech.ezproxy.cuny.edu:2048/login?url=",
+    "url": "http://citytech.ezproxy.cuny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9735038,
       "lat": 40.7509381
@@ -2332,7 +2332,7 @@
   },
   {
     "name": "CUNY Queens",
-    "url": "http://queens.ezproxy.cuny.edu:2048/login?url=",
+    "url": "http://queens.ezproxy.cuny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9735038,
       "lat": 40.7509381
@@ -2341,7 +2341,7 @@
   },
   {
     "name": "CUNY Queensborough",
-    "url": "http://qbcc.ezproxy.cuny.edu:2048/login?url=",
+    "url": "http://qbcc.ezproxy.cuny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9735038,
       "lat": 40.7509381
@@ -2350,7 +2350,7 @@
   },
   {
     "name": "CUNY York",
-    "url": "http://york.ezproxy.cuny.edu:2048/login?url=",
+    "url": "http://york.ezproxy.cuny.edu:2048/login?url=$@",
     "location": {
       "lng": -73.7961103,
       "lat": 40.7010415
@@ -2359,7 +2359,7 @@
   },
   {
     "name": "Curry College",
-    "url": "http://odin.curry.edu/login?url=",
+    "url": "http://odin.curry.edu/login?url=$@",
     "location": {
       "lng": -71.11348937838551,
       "lat": 42.23474401938337
@@ -2368,7 +2368,7 @@
   },
   {
     "name": "Curtin",
-    "url": "http://dbgw.lis.curtin.edu.au/login?url=",
+    "url": "http://dbgw.lis.curtin.edu.au/login?url=$@",
     "location": {
       "lng": 115.8919818,
       "lat": -32.0054649
@@ -2377,7 +2377,7 @@
   },
   {
     "name": "Curtin University",
-    "url": "https://link.library.curtin.edu.au/gw?url=",
+    "url": "https://link.library.curtin.edu.au/gw?url=$@",
     "location": {
       "lng": 115.8919818,
       "lat": -32.0054649
@@ -2386,7 +2386,7 @@
   },
   {
     "name": "Dakota Wesleyan",
-    "url": "https://ezproxy.dwu.edu:2048/login?url=",
+    "url": "https://ezproxy.dwu.edu:2048/login?url=$@",
     "location": {
       "lng": -98.03122,
       "lat": 43.697665
@@ -2395,7 +2395,7 @@
   },
   {
     "name": "Dalhousie University",
-    "url": "https://login.ezproxy.library.dal.ca/login?url=",
+    "url": "https://login.ezproxy.library.dal.ca/login?url=$@",
     "location": {
       "lng": -63.59165549999999,
       "lat": 44.63658119999999
@@ -2404,7 +2404,7 @@
   },
   {
     "name": "Dallas Baptist",
-    "url": "http://library.dbu.edu:2048/login?url=",
+    "url": "http://library.dbu.edu:2048/login?url=$@",
     "location": {
       "lng": -96.9466776,
       "lat": 32.7095466
@@ -2413,7 +2413,7 @@
   },
   {
     "name": "Dalton State",
-    "url": "https://login.dsc.idm.oclc.org/login?qurl=",
+    "url": "https://login.dsc.idm.oclc.org/login?qurl=$@",
     "location": {
       "lng": -85.00294029999999,
       "lat": 34.7749867
@@ -2422,7 +2422,7 @@
   },
   {
     "name": "Danske museers e-tidsskriftadgang",
-    "url": "http://ep.museum-fjernadgang.kb.dk/login?url=",
+    "url": "http://ep.museum-fjernadgang.kb.dk/login?url=$@",
     "location": {
       "lng": 9.501785,
       "lat": 56.26392
@@ -2431,7 +2431,7 @@
   },
   {
     "name": "Dartmouth",
-    "url": "http://dartmouth.idm.oclc.org/login?url=",
+    "url": "http://dartmouth.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -72.2886934,
       "lat": 43.7044406
@@ -2440,7 +2440,7 @@
   },
   {
     "name": "Davidson College",
-    "url": "http://ezproxy.lib.davidson.edu/login?url=",
+    "url": "http://ezproxy.lib.davidson.edu/login?url=$@",
     "location": {
       "lng": -80.8423248,
       "lat": 35.5015528
@@ -2449,7 +2449,7 @@
   },
   {
     "name": "Davidson College (Alternative)",
-    "url": "https://login.proxy048.nclive.org/login?url=",
+    "url": "https://login.proxy048.nclive.org/login?url=$@",
     "location": {
       "lng": -80.8423248,
       "lat": 35.5015528
@@ -2458,7 +2458,7 @@
   },
   {
     "name": "Daviess County Public Library",
-    "url": "https://ezproxy.dcplibrary.org/login?url=",
+    "url": "https://ezproxy.dcplibrary.org/login?url=$@",
     "location": {
       "lng": -87.1121167,
       "lat": 37.7559529
@@ -2467,7 +2467,7 @@
   },
   {
     "name": "De Haagse Hogeschool",
-    "url": "http://ezproxy.hhs.nl:2048/login?url=",
+    "url": "http://ezproxy.hhs.nl:2048/login?url=$@",
     "location": {
       "lng": 4.323974,
       "lat": 52.0670747
@@ -2476,7 +2476,7 @@
   },
   {
     "name": "De Montfort University",
-    "url": "http://proxy.library.dmu.ac.uk/login?url=",
+    "url": "http://proxy.library.dmu.ac.uk/login?url=$@",
     "location": {
       "lng": -1.1398564,
       "lat": 52.6298398
@@ -2485,7 +2485,7 @@
   },
   {
     "name": "Deakin University",
-    "url": "http://ezproxy.deakin.edu.au/login?url=",
+    "url": "http://ezproxy.deakin.edu.au/login?url=$@",
     "location": {
       "lng": 145.11220195239576,
       "lat": -37.84431193559967
@@ -2494,7 +2494,7 @@
   },
   {
     "name": "Deerfield Academy",
-    "url": "http://proxy.library.deerfield.edu:2048/login?url=",
+    "url": "http://proxy.library.deerfield.edu:2048/login?url=$@",
     "location": {
       "lng": -72.6076286,
       "lat": 42.546129
@@ -2503,7 +2503,7 @@
   },
   {
     "name": "Del Mar",
-    "url": "http://library.delmar.edu:2048/login?url=",
+    "url": "http://library.delmar.edu:2048/login?url=$@",
     "location": {
       "lng": -117.2653146,
       "lat": 32.9594891
@@ -2512,7 +2512,7 @@
   },
   {
     "name": "Delta College",
-    "url": "http://ezproxy.delta.edu:2048/login?url=",
+    "url": "http://ezproxy.delta.edu:2048/login?url=$@",
     "location": {
       "lng": -83.98590972010047,
       "lat": 43.55929097881718
@@ -2521,7 +2521,7 @@
   },
   {
     "name": "DeVry",
-    "url": "http://proxy.devry.edu/login?url=",
+    "url": "http://proxy.devry.edu/login?url=$@",
     "location": {
       "lng": -88.1262831,
       "lat": 41.800125
@@ -2530,7 +2530,7 @@
   },
   {
     "name": "Dickinson College",
-    "url": "http://envoy.dickinson.edu:2048/login?url=",
+    "url": "http://envoy.dickinson.edu:2048/login?url=$@",
     "location": {
       "lng": -77.200919234303,
       "lat": 40.202869085904254
@@ -2539,7 +2539,7 @@
   },
   {
     "name": "Dixon Center",
-    "url": "http://proxy-dixon.klnpa.org/login?url=",
+    "url": "http://proxy-dixon.klnpa.org/login?url=$@",
     "location": {
       "lng": -123.2786381,
       "lat": 44.5631448
@@ -2548,7 +2548,7 @@
   },
   {
     "name": "Drake University",
-    "url": "https://login.cowles-proxy.drake.edu/login?qurl=",
+    "url": "https://login.cowles-proxy.drake.edu/login?qurl=$@",
     "location": {
       "lng": -93.65464811887604,
       "lat": 41.603179634141526
@@ -2557,7 +2557,7 @@
   },
   {
     "name": "Drew University",
-    "url": "http://ezproxy.drew.edu/login?url=",
+    "url": "http://ezproxy.drew.edu/login?url=$@",
     "location": {
       "lng": -74.42661744592519,
       "lat": 40.760385948806665
@@ -2566,7 +2566,7 @@
   },
   {
     "name": "Drexel University",
-    "url": "https://ezproxy2.library.drexel.edu/login?url=",
+    "url": "https://ezproxy2.library.drexel.edu/login?url=$@",
     "location": {
       "lng": -75.18994409999999,
       "lat": 39.9566127
@@ -2575,7 +2575,7 @@
   },
   {
     "name": "Dublin City University",
-    "url": "http://dcu.idm.oclc.org/login?url=",
+    "url": "http://dcu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -6.2588403,
       "lat": 53.38533169999999
@@ -2584,7 +2584,7 @@
   },
   {
     "name": "Duke",
-    "url": "http://proxy.lib.duke.edu/login?url=",
+    "url": "http://proxy.lib.duke.edu/login?url=$@",
     "location": {
       "lng": -78.9382286,
       "lat": 36.0014258
@@ -2593,7 +2593,7 @@
   },
   {
     "name": "Duke University",
-    "url": "http://proxy.lib.duke.edu:2048/login?url=",
+    "url": "http://proxy.lib.duke.edu:2048/login?url=$@",
     "location": {
       "lng": -78.9382286,
       "lat": 36.0014258
@@ -2602,7 +2602,7 @@
   },
   {
     "name": "Duquesne",
-    "url": "https://authenticate.library.duq.edu/login?url=",
+    "url": "https://authenticate.library.duq.edu/login?url=$@",
     "location": {
       "lng": -79.99025759999999,
       "lat": 40.4369485
@@ -2611,7 +2611,7 @@
   },
   {
     "name": "Durban University of Technology",
-    "url": "http://dutlib.dut.ac.za:2048/login?url=",
+    "url": "http://dutlib.dut.ac.za:2048/login?url=$@",
     "location": {
       "lng": 31.0061131,
       "lat": -29.8536128
@@ -2620,7 +2620,7 @@
   },
   {
     "name": "Durham University",
-    "url": "http://ezphost.dur.ac.uk/login?url=",
+    "url": "http://ezphost.dur.ac.uk/login?url=$@",
     "location": {
       "lng": -1.5782029,
       "lat": 54.7649859
@@ -2629,7 +2629,7 @@
   },
   {
     "name": "Dyersburg State",
-    "url": "http://ezproxy.dscc.edu:2048/login?url=",
+    "url": "http://ezproxy.dscc.edu:2048/login?url=$@",
     "location": {
       "lng": -89.39095449999999,
       "lat": 36.0480637
@@ -2638,7 +2638,7 @@
   },
   {
     "name": "DYouville",
-    "url": "https://dyc.idm.oclc.org/login?url=",
+    "url": "https://dyc.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -78.8905599,
       "lat": 42.9033183
@@ -2647,7 +2647,7 @@
   },
   {
     "name": "Earlham College",
-    "url": "http://proxy.earlham.edu:2048/login?url=",
+    "url": "http://proxy.earlham.edu:2048/login?url=$@",
     "location": {
       "lng": -84.913241,
       "lat": 39.823941
@@ -2656,7 +2656,7 @@
   },
   {
     "name": "East Carolina",
-    "url": "http://jproxy.lib.ecu.edu/login?url=",
+    "url": "http://jproxy.lib.ecu.edu/login?url=$@",
     "location": {
       "lng": -77.3665364,
       "lat": 35.6068806
@@ -2665,7 +2665,7 @@
   },
   {
     "name": "East Central",
-    "url": "http://ezproxy.eastcentral.edu:2048/login?url=",
+    "url": "http://ezproxy.eastcentral.edu:2048/login?url=$@",
     "location": {
       "lng": -98.265058,
       "lat": 29.3934197
@@ -2674,7 +2674,7 @@
   },
   {
     "name": "East Stroudsburg University",
-    "url": "http://navigator-esu.passhe.edu/login?url=",
+    "url": "http://navigator-esu.passhe.edu/login?url=$@",
     "location": {
       "lng": -75.1727074,
       "lat": 40.9974693
@@ -2683,7 +2683,7 @@
   },
   {
     "name": "East Texas Baptist University",
-    "url": "http://media.etbu.edu:2048/login?url=",
+    "url": "http://media.etbu.edu:2048/login?url=$@",
     "location": {
       "lng": -94.3734369,
       "lat": 32.5558104
@@ -2692,7 +2692,7 @@
   },
   {
     "name": "Eastern Illinois",
-    "url": "http://proxy.library.eiu.edu:2048/login?url=",
+    "url": "http://proxy.library.eiu.edu:2048/login?url=$@",
     "location": {
       "lng": -88.17521839999999,
       "lat": 39.4835612
@@ -2701,7 +2701,7 @@
   },
   {
     "name": "Eastern Illinois University",
-    "url": "http://proxy1.library.eiu.edu/login?url=",
+    "url": "http://proxy1.library.eiu.edu/login?url=$@",
     "location": {
       "lng": -88.17521839999999,
       "lat": 39.4835612
@@ -2710,7 +2710,7 @@
   },
   {
     "name": "Eastern Institute of Technology",
-    "url": "http://library.eit.ac.nz:2048/login?url=",
+    "url": "http://library.eit.ac.nz:2048/login?url=$@",
     "location": {
       "lng": 176.8385542,
       "lat": -39.5469143
@@ -2719,7 +2719,7 @@
   },
   {
     "name": "Eastern Kentucky University",
-    "url": "http://libproxy.eku.edu/login?url=",
+    "url": "http://libproxy.eku.edu/login?url=$@",
     "location": {
       "lng": -84.2987483,
       "lat": 37.7359731
@@ -2728,7 +2728,7 @@
   },
   {
     "name": "Eastern Michigan",
-    "url": "http://ezproxy.emich.edu/login?url=",
+    "url": "http://ezproxy.emich.edu/login?url=$@",
     "location": {
       "lng": -83.624089,
       "lat": 42.2506803
@@ -2737,7 +2737,7 @@
   },
   {
     "name": "Eastern Nazarene",
-    "url": "http://ezproxy.library.enc.edu:2048/login?url=",
+    "url": "http://ezproxy.library.enc.edu:2048/login?url=$@",
     "location": {
       "lng": -71.0104487,
       "lat": 42.2712766
@@ -2746,7 +2746,7 @@
   },
   {
     "name": "Eastern Oregon",
-    "url": "http://access.library.eou.edu/login?url=",
+    "url": "http://access.library.eou.edu/login?url=$@",
     "location": {
       "lng": -118.8917537,
       "lat": 44.4383953
@@ -2755,7 +2755,7 @@
   },
   {
     "name": "Eastern Virginia Medical School",
-    "url": "https://evms.idm.oclc.org/login?url=",
+    "url": "https://evms.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -76.3035708,
       "lat": 36.8604506
@@ -2764,7 +2764,7 @@
   },
   {
     "name": "Eastern Washington",
-    "url": "http://ezproxy.library.ewu.edu:2048/login?url=",
+    "url": "http://ezproxy.library.ewu.edu:2048/login?url=$@",
     "location": {
       "lng": -117.5847877,
       "lat": 47.4906616
@@ -2773,7 +2773,7 @@
   },
   {
     "name": "Eckerd",
-    "url": "http://proxy.eckerd.edu:5000/login?url=",
+    "url": "http://proxy.eckerd.edu:5000/login?url=$@",
     "location": {
       "lng": -82.6864739,
       "lat": 27.7147317
@@ -2782,7 +2782,7 @@
   },
   {
     "name": "Ecole Nationale Superieure dArts et Metiers",
-    "url": "http://rp1.ensam.eu/login?url=",
+    "url": "http://rp1.ensam.eu/login?url=$@",
     "location": {
       "lng": 2.3582236,
       "lat": 48.8330427
@@ -2791,7 +2791,7 @@
   },
   {
     "name": "Ecole normale superieure",
-    "url": "http://proxy.rubens.ens.fr/login?url=",
+    "url": "http://proxy.rubens.ens.fr/login?url=$@",
     "location": {
       "lng": 2.1653030679638117,
       "lat": 48.712692318826825
@@ -2800,7 +2800,7 @@
   },
   {
     "name": "Edge Hill",
-    "url": "https://edgehill.idm.oclc.org/login?url=",
+    "url": "https://edgehill.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -2.8703472,
       "lat": 53.5588278
@@ -2809,7 +2809,7 @@
   },
   {
     "name": "Edinboro University",
-    "url": "http://proxy-edinboro.klnpa.org/login?url=",
+    "url": "http://proxy-edinboro.klnpa.org/login?url=$@",
     "location": {
       "lng": -80.12080279999999,
       "lat": 41.871572
@@ -2818,7 +2818,7 @@
   },
   {
     "name": "Edinburgh Napier",
-    "url": "http://ezproxy.napier.ac.uk/login?url=",
+    "url": "http://ezproxy.napier.ac.uk/login?url=$@",
     "location": {
       "lng": -3.188267,
       "lat": 55.953252
@@ -2827,7 +2827,7 @@
   },
   {
     "name": "Edith Cowan University",
-    "url": "http://ezproxy.ecu.edu.au/login?url=",
+    "url": "http://ezproxy.ecu.edu.au/login?url=$@",
     "location": {
       "lng": 115.7727799,
       "lat": -31.7524902
@@ -2836,7 +2836,7 @@
   },
   {
     "name": "Eindhoven University of Technology",
-    "url": "https://janus.libr.tue.nl/login?url=",
+    "url": "https://janus.libr.tue.nl/login?url=$@",
     "location": {
       "lng": 5.4907148,
       "lat": 51.44860980000001
@@ -2845,7 +2845,7 @@
   },
   {
     "name": "Elizabethtown College",
-    "url": "http://ezproxy.etown.edu/login?url=",
+    "url": "http://ezproxy.etown.edu/login?url=$@",
     "location": {
       "lng": -76.58965393031816,
       "lat": 40.14947367887843
@@ -2854,7 +2854,7 @@
   },
   {
     "name": "Elmira",
-    "url": "http://ezproxy.elmira.edu:2048/login?url=",
+    "url": "http://ezproxy.elmira.edu:2048/login?url=$@",
     "location": {
       "lng": -76.8077338,
       "lat": 42.0897965
@@ -2863,7 +2863,7 @@
   },
   {
     "name": "Elms",
-    "url": "http://elms.idm.oclc.org/login?url=",
+    "url": "http://elms.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -87.6279965,
       "lat": 41.9033774
@@ -2872,7 +2872,7 @@
   },
   {
     "name": "Embry-Riddle Aeronautical University - Hunt Library",
-    "url": "http://ezproxy.libproxy.db.erau.edu/login?url=",
+    "url": "http://ezproxy.libproxy.db.erau.edu/login?url=$@",
     "location": {
       "lng": -81.0492933,
       "lat": 29.1878901
@@ -2881,7 +2881,7 @@
   },
   {
     "name": "Emerson College",
-    "url": "http://proxy.emerson.edu/login?url=",
+    "url": "http://proxy.emerson.edu/login?url=$@",
     "location": {
       "lng": -71.06582403235687,
       "lat": 42.352401004337835
@@ -2890,7 +2890,7 @@
   },
   {
     "name": "Emily Carr",
-    "url": "http://ezproxy.eciad.ca:2048/login?url=",
+    "url": "http://ezproxy.eciad.ca:2048/login?url=$@",
     "location": {
       "lng": -123.09266683437563,
       "lat": 49.26822477301482
@@ -2899,7 +2899,7 @@
   },
   {
     "name": "Emmanuel College",
-    "url": "http://library.emmanuel.edu:2048/login?url=",
+    "url": "http://library.emmanuel.edu:2048/login?url=$@",
     "location": {
       "lng": -71.10272270352222,
       "lat": 42.34124915409021
@@ -2908,7 +2908,7 @@
   },
   {
     "name": "Emory Henry",
-    "url": "http://ezproxy.ehc.edu:2048/login?url=",
+    "url": "http://ezproxy.ehc.edu:2048/login?url=$@",
     "location": {
       "lng": -81.82925,
       "lat": 36.77252
@@ -2917,7 +2917,7 @@
   },
   {
     "name": "Emory University",
-    "url": "https://proxy.library.emory.edu/login?url=",
+    "url": "https://proxy.library.emory.edu/login?url=$@",
     "location": {
       "lng": -84.32224,
       "lat": 33.7971368
@@ -2926,7 +2926,7 @@
   },
   {
     "name": "ENCG Settat",
-    "url": "https://www.ezproxy.uh1.ac.ma/login?url=",
+    "url": "https://www.ezproxy.uh1.ac.ma/login?url=$@",
     "location": {
       "lng": -7.616952899999999,
       "lat": 33.0329202
@@ -2935,7 +2935,7 @@
   },
   {
     "name": "Erasmus University Rotterdam",
-    "url": "https://eur.idm.oclc.org/login?url=",
+    "url": "https://eur.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 4.5263027,
       "lat": 51.9172477
@@ -2944,7 +2944,7 @@
   },
   {
     "name": "ERDC",
-    "url": "http://erdclibrary.idm.oclc.org/login?url=",
+    "url": "http://erdclibrary.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -90.8714067,
       "lat": 32.3012717
@@ -2953,7 +2953,7 @@
   },
   {
     "name": "Erie",
-    "url": "https://ezproxy.ecc.edu:2443/login?url=",
+    "url": "https://ezproxy.ecc.edu:2443/login?url=$@",
     "location": {
       "lng": -80.085059,
       "lat": 42.12922409999999
@@ -2962,7 +2962,7 @@
   },
   {
     "name": "ESSEC Business School",
-    "url": "https://login.ezp.essec.fr/login?url=",
+    "url": "https://login.ezp.essec.fr/login?url=$@",
     "location": {
       "lng": 2.078274,
       "lat": 49.0333771
@@ -2971,7 +2971,7 @@
   },
   {
     "name": "ETH Zurich",
-    "url": "https://proxy.ethz.ch/cgi-bin/login.pl?url=",
+    "url": "https://proxy.ethz.ch/cgi-bin/login.pl?url=$@",
     "location": {
       "lng": 8.547628,
       "lat": 47.37638889999999
@@ -2980,7 +2980,7 @@
   },
   {
     "name": "European University Institute",
-    "url": "http://ezproxy.eui.eu/login?url=",
+    "url": "http://ezproxy.eui.eu/login?url=$@",
     "location": {
       "lng": 11.282959,
       "lat": 43.803079
@@ -2989,7 +2989,7 @@
   },
   {
     "name": "Evangelische Hochschule Nürnberg",
-    "url": "https://evhn.idm.oclc.org/login?url=",
+    "url": "https://evhn.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 11.060193,
       "lat": 49.4510101
@@ -2998,7 +2998,7 @@
   },
   {
     "name": "Everett",
-    "url": "http://ezproxy.everettcc.edu/login?url=",
+    "url": "http://ezproxy.everettcc.edu/login?url=$@",
     "location": {
       "lng": -122.2020794,
       "lat": 47.9789848
@@ -3007,7 +3007,7 @@
   },
   {
     "name": "Evergreen Valley College",
-    "url": "https://login.evcezproxy.evc.edu/login?url=",
+    "url": "https://login.evcezproxy.evc.edu/login?url=$@",
     "location": {
       "lng": -121.76504700699878,
       "lat": 37.301315100042586
@@ -3016,7 +3016,7 @@
   },
   {
     "name": "Fachhochschule Munster",
-    "url": "https://www.hb.fh-muenster.de:2443/login?url=",
+    "url": "https://www.hb.fh-muenster.de:2443/login?url=$@",
     "location": {
       "lng": 7.6261347,
       "lat": 51.9606649
@@ -3025,7 +3025,7 @@
   },
   {
     "name": "Fachhochschule Salzburg",
-    "url": "http://ezproxy.fh-salzburg.ac.at/login?url=",
+    "url": "http://ezproxy.fh-salzburg.ac.at/login?url=$@",
     "location": {
       "lng": 13.0871253,
       "lat": 47.7233835
@@ -3034,7 +3034,7 @@
   },
   {
     "name": "Fairfield University",
-    "url": "http://libdb.fairfield.edu/login?url=",
+    "url": "http://libdb.fairfield.edu/login?url=$@",
     "location": {
       "lng": -73.25758271537647,
       "lat": 41.160089562662264
@@ -3043,7 +3043,7 @@
   },
   {
     "name": "Fashion Institute of Technology",
-    "url": "https://libproxy.fitsuny.edu/login?url=",
+    "url": "https://libproxy.fitsuny.edu/login?url=$@",
     "location": {
       "lng": -73.99502919999999,
       "lat": 40.7472624
@@ -3052,7 +3052,7 @@
   },
   {
     "name": "Faulkner University",
-    "url": "http://library.faulkner.edu:2048/login?url=",
+    "url": "http://library.faulkner.edu:2048/login?url=$@",
     "location": {
       "lng": -86.24262099952868,
       "lat": 32.559822310993205
@@ -3061,7 +3061,7 @@
   },
   {
     "name": "Fielding Graduate",
-    "url": "https://fgul.idm.oclc.org/login?url=",
+    "url": "https://fgul.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -119.7174748,
       "lat": 34.42927590000001
@@ -3070,7 +3070,7 @@
   },
   {
     "name": "Finger Lakes",
-    "url": "https://ezproxy.flcc.edu/login?url=",
+    "url": "https://ezproxy.flcc.edu/login?url=$@",
     "location": {
       "lng": -76.9297247,
       "lat": 42.7238165
@@ -3079,7 +3079,7 @@
   },
   {
     "name": "Finlandia",
-    "url": "http://20p4y.finlandia.edu:2048/login?url=",
+    "url": "http://20p4y.finlandia.edu:2048/login?url=$@",
     "location": {
       "lng": 25.748151,
       "lat": 61.92410999999999
@@ -3088,7 +3088,7 @@
   },
   {
     "name": "Flinders University",
-    "url": "http://ezproxy.flinders.edu.au/login?url=",
+    "url": "http://ezproxy.flinders.edu.au/login?url=$@",
     "location": {
       "lng": 138.5688883101934,
       "lat": -35.02296968878218
@@ -3097,7 +3097,7 @@
   },
   {
     "name": "Florida Atlantic University",
-    "url": "https://login.ezproxy.fau.edu/login?url=",
+    "url": "https://login.ezproxy.fau.edu/login?url=$@",
     "location": {
       "lng": -80.1289321,
       "lat": 26.3683064
@@ -3106,7 +3106,7 @@
   },
   {
     "name": "Florida Gulf Coast",
-    "url": "http://ezproxy.fgcu.edu/login?url=",
+    "url": "http://ezproxy.fgcu.edu/login?url=$@",
     "location": {
       "lng": -81.7800748,
       "lat": 26.4626967
@@ -3115,7 +3115,7 @@
   },
   {
     "name": "Florida International",
-    "url": "http://ezproxy.fiu.edu/login?url=",
+    "url": "http://ezproxy.fiu.edu/login?url=$@",
     "location": {
       "lng": -80.3755401,
       "lat": 25.7562465
@@ -3124,7 +3124,7 @@
   },
   {
     "name": "Florida International University",
-    "url": "https://login.ezproxy.fiu.edu/login?url=",
+    "url": "https://login.ezproxy.fiu.edu/login?url=$@",
     "location": {
       "lng": -80.3755401,
       "lat": 25.7562465
@@ -3133,7 +3133,7 @@
   },
   {
     "name": "Florida Southern",
-    "url": "http://ezproxy.flsouthern.edu:2048/login?url=",
+    "url": "http://ezproxy.flsouthern.edu:2048/login?url=$@",
     "location": {
       "lng": -81.9450401,
       "lat": 28.0314545
@@ -3142,7 +3142,7 @@
   },
   {
     "name": "Florida State",
-    "url": "https://login.proxy.lib.fsu.edu/login?url=",
+    "url": "https://login.proxy.lib.fsu.edu/login?url=$@",
     "location": {
       "lng": -81.5157535,
       "lat": 27.6648274
@@ -3151,7 +3151,7 @@
   },
   {
     "name": "Fordham University",
-    "url": "https://avoserv.library.fordham.edu/login?url=",
+    "url": "https://avoserv.library.fordham.edu/login?url=$@",
     "location": {
       "lng": -73.8852771,
       "lat": 40.8614567
@@ -3160,7 +3160,7 @@
   },
   {
     "name": "Fort Hays State",
-    "url": "http://ezproxy.fhsu.edu:2048/login?url=",
+    "url": "http://ezproxy.fhsu.edu:2048/login?url=$@",
     "location": {
       "lng": -99.3444887,
       "lat": 38.8714463
@@ -3169,7 +3169,7 @@
   },
   {
     "name": "Fort Lewis",
-    "url": "https://fortlewis.idm.oclc.org/login?url=",
+    "url": "https://fortlewis.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -107.8711817,
       "lat": 37.27368999999999
@@ -3178,7 +3178,7 @@
   },
   {
     "name": "Francis Marion",
-    "url": "http://fmarion.idm.oclc.org/login?url=",
+    "url": "http://fmarion.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -79.6519849,
       "lat": 34.1904251
@@ -3187,7 +3187,7 @@
   },
   {
     "name": "Franklin College",
-    "url": "https://ezproxy.franklincollege.edu/login?url=",
+    "url": "https://ezproxy.franklincollege.edu/login?url=$@",
     "location": {
       "lng": -86.04544828787014,
       "lat": 39.478843608085185
@@ -3196,7 +3196,7 @@
   },
   {
     "name": "Franklin Marshall",
-    "url": "http://auth.illiad.oclc.org:2048/login?url=",
+    "url": "http://auth.illiad.oclc.org:2048/login?url=$@",
     "location": {
       "lng": -76.3199261,
       "lat": 40.04874
@@ -3205,7 +3205,7 @@
   },
   {
     "name": "Fred Hutchinson Cancer Research Center",
-    "url": "https://login.fhcrc.idm.oclc.org/login?url=",
+    "url": "https://login.fhcrc.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.3314858,
       "lat": 47.6272634
@@ -3214,7 +3214,7 @@
   },
   {
     "name": "Free University Bozen Bolzano",
-    "url": "http://libproxy.unibz.it/login?url=",
+    "url": "http://libproxy.unibz.it/login?url=$@",
     "location": {
       "lng": 11.3507102,
       "lat": 46.4984534
@@ -3223,7 +3223,7 @@
   },
   {
     "name": "Fuller Theological Seminary",
-    "url": "http://proxy.fuller.edu:2048/login?url=",
+    "url": "http://proxy.fuller.edu:2048/login?url=$@",
     "location": {
       "lng": -118.1404425,
       "lat": 34.1482032
@@ -3232,7 +3232,7 @@
   },
   {
     "name": "Furman",
-    "url": "https://login.libproxy.furman.edu/login?url=",
+    "url": "https://login.libproxy.furman.edu/login?url=$@",
     "location": {
       "lng": -82.4400679,
       "lat": 34.9274741
@@ -3241,7 +3241,7 @@
   },
   {
     "name": "Gadjah Mada University",
-    "url": "http://ezproxy.ugm.ac.id/login?url=",
+    "url": "http://ezproxy.ugm.ac.id/login?url=$@",
     "location": {
       "lng": 110.3774998,
       "lat": -7.7713847
@@ -3250,7 +3250,7 @@
   },
   {
     "name": "Gavilan College",
-    "url": "http://ezproxy.gavilan.edu/login?url=",
+    "url": "http://ezproxy.gavilan.edu/login?url=$@",
     "location": {
       "lng": -121.5685598,
       "lat": 36.9732557
@@ -3259,7 +3259,7 @@
   },
   {
     "name": "Geneva University",
-    "url": "http://proxy-geneva.klnpa.org/login?url=",
+    "url": "http://proxy-geneva.klnpa.org/login?url=$@",
     "location": {
       "lng": 6.1451157,
       "lat": 46.199444
@@ -3268,7 +3268,7 @@
   },
   {
     "name": "George Fox",
-    "url": "https://georgefox.idm.oclc.org/login?url=",
+    "url": "https://georgefox.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.9667381,
       "lat": 45.3033817
@@ -3277,7 +3277,7 @@
   },
   {
     "name": "George Mason University",
-    "url": "http://mutex.gmu.edu/login?url=",
+    "url": "http://mutex.gmu.edu/login?url=$@",
     "location": {
       "lng": -77.31174709999999,
       "lat": 38.8314578
@@ -3286,7 +3286,7 @@
   },
   {
     "name": "George Washington University Law School",
-    "url": "https://gwlaw.idm.oclc.org/login?url=",
+    "url": "https://gwlaw.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -77.0457907,
       "lat": 38.8985596
@@ -3295,7 +3295,7 @@
   },
   {
     "name": "Georgetown",
-    "url": "http://ezproxy.georgetowncollege.edu:2048/login?url=",
+    "url": "http://ezproxy.georgetowncollege.edu:2048/login?url=$@",
     "location": {
       "lng": -77.06535650000001,
       "lat": 38.9097057
@@ -3304,7 +3304,7 @@
   },
   {
     "name": "Georgetown University",
-    "url": "http://proxy.library.georgetown.edu/login?url=",
+    "url": "http://proxy.library.georgetown.edu/login?url=$@",
     "location": {
       "lng": -77.07225849999999,
       "lat": 38.9076089
@@ -3313,7 +3313,7 @@
   },
   {
     "name": "Georgia Institute of Technology",
-    "url": "http://prx.library.gatech.edu/login?url=",
+    "url": "http://prx.library.gatech.edu/login?url=$@",
     "location": {
       "lng": -84.39628499999999,
       "lat": 33.7756178
@@ -3322,7 +3322,7 @@
   },
   {
     "name": "Georgia Southern",
-    "url": "http://libez.lib.georgiasouthern.edu:2048/login?url=",
+    "url": "http://libez.lib.georgiasouthern.edu:2048/login?url=$@",
     "location": {
       "lng": -81.7842919,
       "lat": 32.4196512
@@ -3331,7 +3331,7 @@
   },
   {
     "name": "Georgia Tech",
-    "url": "http://www.library.gatech.edu:2048/login?url=",
+    "url": "http://www.library.gatech.edu:2048/login?url=$@",
     "location": {
       "lng": -84.39628499999999,
       "lat": 33.7756178
@@ -3340,7 +3340,7 @@
   },
   {
     "name": "Glasgow Caledonian",
-    "url": "https://gcu.idm.oclc.org/login?url=",
+    "url": "https://gcu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -4.249960199999999,
       "lat": 55.8668183
@@ -3349,7 +3349,7 @@
   },
   {
     "name": "Glendale",
-    "url": "http://libproxy.gc.maricopa.edu/login?url=",
+    "url": "http://libproxy.gc.maricopa.edu/login?url=$@",
     "location": {
       "lng": -118.255075,
       "lat": 34.1425078
@@ -3358,7 +3358,7 @@
   },
   {
     "name": "God's Bible School and College",
-    "url": "http://www.ezproxy.gbs.edu:2048/login?url=",
+    "url": "http://www.ezproxy.gbs.edu:2048/login?url=$@",
     "location": {
       "lng": -84.5055938,
       "lat": 39.1157219
@@ -3367,7 +3367,7 @@
   },
   {
     "name": "Goethe-Uni Frankfurt am Main",
-    "url": "http://proxy.ub.uni-frankfurt.de/login?url=",
+    "url": "http://proxy.ub.uni-frankfurt.de/login?url=$@",
     "location": {
       "lng": 8.6677635,
       "lat": 50.1270675
@@ -3376,7 +3376,7 @@
   },
   {
     "name": "Gordon-Conwell Theological Seminary",
-    "url": "http://proxy.gordonconwell.edu/login?url=",
+    "url": "http://proxy.gordonconwell.edu/login?url=$@",
     "location": {
       "lng": -70.8450204,
       "lat": 42.6124501
@@ -3385,7 +3385,7 @@
   },
   {
     "name": "Goshen",
-    "url": "https://ezproxy.goshen.edu/login?url=",
+    "url": "https://ezproxy.goshen.edu/login?url=$@",
     "location": {
       "lng": -85.83456389999999,
       "lat": 41.5891606
@@ -3394,7 +3394,7 @@
   },
   {
     "name": "Grand Canyon",
-    "url": "https://lopes.idm.oclc.org/login?url=",
+    "url": "https://lopes.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -112.3535253,
       "lat": 36.2678855
@@ -3403,7 +3403,7 @@
   },
   {
     "name": "Grand Valley State",
-    "url": "http://ezproxy.gvsu.edu/login?url=",
+    "url": "http://ezproxy.gvsu.edu/login?url=$@",
     "location": {
       "lng": -85.8890404,
       "lat": 42.9641221
@@ -3412,7 +3412,7 @@
   },
   {
     "name": "Grand Valley State University",
-    "url": "https://login.ezproxy.gvsu.edu/login?url=",
+    "url": "https://login.ezproxy.gvsu.edu/login?url=$@",
     "location": {
       "lng": -85.8890404,
       "lat": 42.9641221
@@ -3421,7 +3421,7 @@
   },
   {
     "name": "Grays Harbor",
-    "url": "http://ezproxy.ghc.edu:2048/login?url=",
+    "url": "http://ezproxy.ghc.edu:2048/login?url=$@",
     "location": {
       "lng": -123.7012468,
       "lat": 46.9953526
@@ -3430,7 +3430,7 @@
   },
   {
     "name": "Great Basin College",
-    "url": "http://library.gbcnv.edu:2048/login?url=",
+    "url": "http://library.gbcnv.edu:2048/login?url=$@",
     "location": {
       "lng": -115.7671347,
       "lat": 40.8425713
@@ -3439,7 +3439,7 @@
   },
   {
     "name": "Griffith Univsity",
-    "url": "http://libraryproxy.griffith.edu.au/login?url=",
+    "url": "http://libraryproxy.griffith.edu.au/login?url=$@",
     "location": {
       "lng": 136.06403838387402,
       "lat": -30.904027644443286
@@ -3448,7 +3448,7 @@
   },
   {
     "name": "Grinnell",
-    "url": "https://grinnell.idm.oclc.org/login?url=",
+    "url": "https://grinnell.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -92.7232456,
       "lat": 41.74340919999999
@@ -3457,7 +3457,7 @@
   },
   {
     "name": "Guilford Technical",
-    "url": "http://ezproxy.gtcc.edu:2048/login?url=",
+    "url": "http://ezproxy.gtcc.edu:2048/login?url=$@",
     "location": {
       "lng": -79.9191627,
       "lat": 35.9981517
@@ -3466,7 +3466,7 @@
   },
   {
     "name": "Halmstad University",
-    "url": "https://ezproxy.bib.hh.se/login?url=",
+    "url": "https://ezproxy.bib.hh.se/login?url=$@",
     "location": {
       "lng": 12.8780003,
       "lat": 56.66467400000001
@@ -3475,7 +3475,7 @@
   },
   {
     "name": "Hamilton",
-    "url": "http://ez.hamilton.edu:2048/login?url=",
+    "url": "http://ez.hamilton.edu:2048/login?url=$@",
     "location": {
       "lng": -75.40602017163035,
       "lat": 43.052927735089526
@@ -3484,7 +3484,7 @@
   },
   {
     "name": "Hamline",
-    "url": "http://ezproxy.hamline.edu:2048/login?url=",
+    "url": "http://ezproxy.hamline.edu:2048/login?url=$@",
     "location": {
       "lng": -93.1644153,
       "lat": 44.9650421
@@ -3493,7 +3493,7 @@
   },
   {
     "name": "Hardin-Simmons",
-    "url": "http://ezproxy.hsutx.edu:2048/login?url=",
+    "url": "http://ezproxy.hsutx.edu:2048/login?url=$@",
     "location": {
       "lng": -99.7340564,
       "lat": 32.4768502
@@ -3502,7 +3502,7 @@
   },
   {
     "name": "Harding School of Theology",
-    "url": "http://ezproxy-hst.harding.edu:2048/login?url=",
+    "url": "http://ezproxy-hst.harding.edu:2048/login?url=$@",
     "location": {
       "lng": -89.9135055,
       "lat": 35.1044006
@@ -3511,7 +3511,7 @@
   },
   {
     "name": "Harrisburg University",
-    "url": "http://proxy-harrisburg.klnpa.org/login?url=",
+    "url": "http://proxy-harrisburg.klnpa.org/login?url=$@",
     "location": {
       "lng": -76.8802144,
       "lat": 40.2621191
@@ -3520,7 +3520,7 @@
   },
   {
     "name": "Hartford Seminiary",
-    "url": "http://ezproxy.hartsem.edu/login?url=",
+    "url": "http://ezproxy.hartsem.edu/login?url=$@",
     "location": {
       "lng": -72.7077092,
       "lat": 41.7698571
@@ -3529,7 +3529,7 @@
   },
   {
     "name": "Hartwick",
-    "url": "http://ezproxy.hartwick.edu:2048/login?url=",
+    "url": "http://ezproxy.hartwick.edu:2048/login?url=$@",
     "location": {
       "lng": -75.0718461,
       "lat": 42.4586674
@@ -3538,7 +3538,7 @@
   },
   {
     "name": "Harvard University",
-    "url": "http://ezp-prod1.hul.harvard.edu/login?url=",
+    "url": "http://ezp-prod1.hul.harvard.edu/login?url=$@",
     "location": {
       "lng": -71.116936,
       "lat": 42.3768943
@@ -3547,7 +3547,7 @@
   },
   {
     "name": "Haverford",
-    "url": "https://ezproxy.haverford.edu/login?url=",
+    "url": "https://ezproxy.haverford.edu/login?url=$@",
     "location": {
       "lng": -75.3208107,
       "lat": 40.0022406
@@ -3556,7 +3556,7 @@
   },
   {
     "name": "Haverford College",
-    "url": "https://www.ezproxy.haverford.edu/login?url=",
+    "url": "https://www.ezproxy.haverford.edu/login?url=$@",
     "location": {
       "lng": -75.3051299,
       "lat": 40.00744230000001
@@ -3565,7 +3565,7 @@
   },
   {
     "name": "HEC Montreal",
-    "url": "http://proxy2.hec.ca/login?url=",
+    "url": "http://proxy2.hec.ca/login?url=$@",
     "location": {
       "lng": -73.6211174,
       "lat": 45.5035488
@@ -3574,7 +3574,7 @@
   },
   {
     "name": "HEC Paris",
-    "url": "http://ezproxy.hec.fr/login?url=",
+    "url": "http://ezproxy.hec.fr/login?url=$@",
     "location": {
       "lng": 2.1687971,
       "lat": 48.7570776
@@ -3583,7 +3583,7 @@
   },
   {
     "name": "HEIG-VD",
-    "url": "https://biblioproxy.heig-vd.ch/login?url=",
+    "url": "https://biblioproxy.heig-vd.ch/login?url=$@",
     "location": {
       "lng": 6.6473097,
       "lat": 46.7812274
@@ -3592,7 +3592,7 @@
   },
   {
     "name": "Hellenic Open University (EAP)",
-    "url": "http://proxy.eap.gr/login?url=",
+    "url": "http://proxy.eap.gr/login?url=$@",
     "location": {
       "lng": 21.767111,
       "lat": 38.206531
@@ -3601,7 +3601,7 @@
   },
   {
     "name": "HELP University",
-    "url": "https://ezproxy.help.edu.my/login?url=",
+    "url": "https://ezproxy.help.edu.my/login?url=$@",
     "location": {
       "lng": 101.670172,
       "lat": 3.1515226
@@ -3610,7 +3610,7 @@
   },
   {
     "name": "Helsingin yliopisto",
-    "url": "http://libproxy.helsinki.fi/login?url=",
+    "url": "http://libproxy.helsinki.fi/login?url=$@",
     "location": {
       "lng": 24.9510419,
       "lat": 60.1726348
@@ -3619,7 +3619,7 @@
   },
   {
     "name": "Henderson State",
-    "url": "http://library.hsu.edu:2048/login?url=",
+    "url": "http://library.hsu.edu:2048/login?url=$@",
     "location": {
       "lng": -93.06025729999999,
       "lat": 34.1299174
@@ -3628,7 +3628,7 @@
   },
   {
     "name": "Heriot-Watt University",
-    "url": "https://ezproxy1.hw.ac.uk/login?url=",
+    "url": "https://ezproxy1.hw.ac.uk/login?url=$@",
     "location": {
       "lng": -3.3216711,
       "lat": 55.9111604
@@ -3637,7 +3637,7 @@
   },
   {
     "name": "Heriot-Watt University Edinburgh",
-    "url": "http://ezproxy1.hw.ac.uk:2048/login?url=",
+    "url": "http://ezproxy1.hw.ac.uk:2048/login?url=$@",
     "location": {
       "lng": -3.3216711,
       "lat": 55.9111604
@@ -3646,7 +3646,7 @@
   },
   {
     "name": "Highline",
-    "url": "http://moe.ic.highline.edu:2048/login?url=",
+    "url": "http://moe.ic.highline.edu:2048/login?url=$@",
     "location": {
       "lng": -74.0047649,
       "lat": 40.7479925
@@ -3655,7 +3655,7 @@
   },
   {
     "name": "Hiram",
-    "url": "http://ezproxy.hiram.edu/login?url=",
+    "url": "http://ezproxy.hiram.edu/login?url=$@",
     "location": {
       "lng": -81.1437098,
       "lat": 41.3125552
@@ -3664,7 +3664,7 @@
   },
   {
     "name": "Hofstra University",
-    "url": "http://ezproxy.hofstra.edu/login?url=",
+    "url": "http://ezproxy.hofstra.edu/login?url=$@",
     "location": {
       "lng": -73.5993965,
       "lat": 40.7166872
@@ -3673,7 +3673,7 @@
   },
   {
     "name": "Hogeschool Rotterdam",
-    "url": "http://ezproxy.hro.nl/login?url=",
+    "url": "http://ezproxy.hro.nl/login?url=$@",
     "location": {
       "lng": 4.4636372,
       "lat": 51.9100039
@@ -3682,7 +3682,7 @@
   },
   {
     "name": "Hokkaido University",
-    "url": "https://login.ezoris.lib.hokudai.ac.jp/login?url=",
+    "url": "https://login.ezoris.lib.hokudai.ac.jp/login?url=$@",
     "location": {
       "lng": 141.340013,
       "lat": 43.0779575
@@ -3691,7 +3691,7 @@
   },
   {
     "name": "Holland",
-    "url": "https://rpa.hollandcollege.com:2048/login?url=",
+    "url": "https://rpa.hollandcollege.com:2048/login?url=$@",
     "location": {
       "lng": 5.291265999999999,
       "lat": 52.132633
@@ -3700,7 +3700,7 @@
   },
   {
     "name": "Holy Family",
-    "url": "http://holyfamily.idm.oclc.org/login?url=",
+    "url": "http://holyfamily.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -75.00162943433621,
       "lat": 40.126963450134426
@@ -3709,7 +3709,7 @@
   },
   {
     "name": "Hong Kong Baptist University",
-    "url": "https://lib-ezproxy.hkbu.edu.hk/login?url=",
+    "url": "https://lib-ezproxy.hkbu.edu.hk/login?url=$@",
     "location": {
       "lng": 114.1798757,
       "lat": 22.3408088
@@ -3718,7 +3718,7 @@
   },
   {
     "name": "Hong Kong Institute of Vocational Education",
-    "url": "http://eproxy.vtclib9.vtc.edu.hk:2048/login?url=",
+    "url": "http://eproxy.vtclib9.vtc.edu.hk:2048/login?url=$@",
     "location": {
       "lng": 114.177926,
       "lat": 22.276239
@@ -3727,7 +3727,7 @@
   },
   {
     "name": "Hong Kong Metropolitan University",
-    "url": "https://ezproxy.lib.hkmu.edu.hk/login?url=",
+    "url": "https://ezproxy.lib.hkmu.edu.hk/login?url=$@",
     "location": {
       "lng": 114.1801817,
       "lat": 22.3163552
@@ -3736,7 +3736,7 @@
   },
   {
     "name": "Hong Kong Public Libraries",
-    "url": "https://ezproxy.hkpl.gov.hk/login?url=",
+    "url": "https://ezproxy.hkpl.gov.hk/login?url=$@",
     "location": {
       "lng": 114.1693611,
       "lat": 22.3193039
@@ -3745,7 +3745,7 @@
   },
   {
     "name": "Hong Kong University of Science and Technology",
-    "url": "https://lib.ezproxy.ust.hk/login?url=",
+    "url": "https://lib.ezproxy.ust.hk/login?url=$@",
     "location": {
       "lng": 114.2654655,
       "lat": 22.3363998
@@ -3754,7 +3754,7 @@
   },
   {
     "name": "Hood College",
-    "url": "http://taurus.hood.edu:2048/login?url=",
+    "url": "http://taurus.hood.edu:2048/login?url=$@",
     "location": {
       "lng": -77.41890870325902,
       "lat": 39.422899735458714
@@ -3763,7 +3763,7 @@
   },
   {
     "name": "Hope College",
-    "url": "https://login.ezproxy.hope.edu/login?url=",
+    "url": "https://login.ezproxy.hope.edu/login?url=$@",
     "location": {
       "lng": -86.1026663,
       "lat": 42.7875308
@@ -3772,7 +3772,7 @@
   },
   {
     "name": "Houston Academy of Medicine - Texas Medical Center",
-    "url": "http://ezproxyhost.library.tmc.edu/login?url=",
+    "url": "http://ezproxyhost.library.tmc.edu/login?url=$@",
     "location": {
       "lng": -95.3967443,
       "lat": 29.7118682
@@ -3781,7 +3781,7 @@
   },
   {
     "name": "Howard University",
-    "url": "https://proxyhu.wrlc.org/login?url=",
+    "url": "https://proxyhu.wrlc.org/login?url=$@",
     "location": {
       "lng": -77.0194377,
       "lat": 38.9226843
@@ -3790,7 +3790,7 @@
   },
   {
     "name": "Huddersfield University",
-    "url": "http://librouter.hud.ac.uk/login?url=",
+    "url": "http://librouter.hud.ac.uk/login?url=$@",
     "location": {
       "lng": -1.7780981,
       "lat": 53.64282850000001
@@ -3799,7 +3799,7 @@
   },
   {
     "name": "Hudson Valley",
-    "url": "http://proxy.hvcc.edu:2048/login?url=",
+    "url": "http://proxy.hvcc.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9612887,
       "lat": 41.9209018
@@ -3808,7 +3808,7 @@
   },
   {
     "name": "Humboldt State University",
-    "url": "http://ezproxy.humboldt.edu/login?url=",
+    "url": "http://ezproxy.humboldt.edu/login?url=$@",
     "location": {
       "lng": -124.0789268,
       "lat": 40.8747332
@@ -3817,7 +3817,7 @@
   },
   {
     "name": "Høgskolen i Innlandet",
-    "url": "http://ezproxy.inn.no/login?url=",
+    "url": "http://ezproxy.inn.no/login?url=$@",
     "location": {
       "lng": 11.074194,
       "lat": 60.7963798
@@ -3826,7 +3826,7 @@
   },
   {
     "name": "Høgskulen på Vestlandet",
-    "url": "https://login.galanga.hvl.no/login?url=",
+    "url": "https://login.galanga.hvl.no/login?url=$@",
     "location": {
       "lng": 5.350094299999999,
       "lat": 60.3689499
@@ -3835,7 +3835,7 @@
   },
   {
     "name": "Ibn Haldun University Library",
-    "url": "https://offcampus.ihu.edu.tr/login?url=",
+    "url": "https://offcampus.ihu.edu.tr/login?url=$@",
     "location": {
       "lng": 28.7968759,
       "lat": 41.1385303
@@ -3844,7 +3844,7 @@
   },
   {
     "name": "Idaho College of Osteopathic Medicine",
-    "url": "https://icom.idm.oclc.org/login?url=",
+    "url": "https://icom.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -116.3766313,
       "lat": 43.5948543
@@ -3853,7 +3853,7 @@
   },
   {
     "name": "Idaho State",
-    "url": "http://libpublic3.library.isu.edu/login?url=",
+    "url": "http://libpublic3.library.isu.edu/login?url=$@",
     "location": {
       "lng": -114.7420408,
       "lat": 44.0682019
@@ -3862,7 +3862,7 @@
   },
   {
     "name": "IIT Chicago-Kent College of Law",
-    "url": "http://libproxy.kentlaw.edu/login?url=",
+    "url": "http://libproxy.kentlaw.edu/login?url=$@",
     "location": {
       "lng": -87.6423118,
       "lat": 41.8788582
@@ -3871,7 +3871,7 @@
   },
   {
     "name": "IIT Italian Institute of Technology",
-    "url": "https://login.biblio.iit.it/login?url=",
+    "url": "https://login.biblio.iit.it/login?url=$@",
     "location": {
       "lng": 12.56738,
       "lat": 41.87194
@@ -3880,7 +3880,7 @@
   },
   {
     "name": "Illinois Institute of Technology",
-    "url": "https://ezproxy.gl.iit.edu/login?url=",
+    "url": "https://ezproxy.gl.iit.edu/login?url=$@",
     "location": {
       "lng": -87.6270059,
       "lat": 41.8348731
@@ -3889,7 +3889,7 @@
   },
   {
     "name": "Illinois State University",
-    "url": "http://sfx.carli.illinois.edu/login?url=",
+    "url": "http://sfx.carli.illinois.edu/login?url=$@",
     "location": {
       "lng": -88.99476299999999,
       "lat": 40.5121009
@@ -3898,7 +3898,7 @@
   },
   {
     "name": "Illinois Valley",
-    "url": "http://ezproxy.ivcc.edu:2048/login?url=",
+    "url": "http://ezproxy.ivcc.edu:2048/login?url=$@",
     "location": {
       "lng": -89.3985283,
       "lat": 40.6331249
@@ -3907,7 +3907,7 @@
   },
   {
     "name": "Imperial College London",
-    "url": "https://login.iclibezp1.cc.ic.ac.uk/login?url=",
+    "url": "https://login.iclibezp1.cc.ic.ac.uk/login?url=$@",
     "location": {
       "lng": -0.1748735,
       "lat": 51.49882220000001
@@ -3916,7 +3916,7 @@
   },
   {
     "name": "Indiana State",
-    "url": "http://ezproxy.indstate.edu:2048/login?url=",
+    "url": "http://ezproxy.indstate.edu:2048/login?url=$@",
     "location": {
       "lng": -86.1349019,
       "lat": 40.2671941
@@ -3925,7 +3925,7 @@
   },
   {
     "name": "Indiana University",
-    "url": "http://proxyiub.uits.iu.edu/login?url=",
+    "url": "http://proxyiub.uits.iu.edu/login?url=$@",
     "location": {
       "lng": -86.52300729999999,
       "lat": 39.1682449
@@ -3934,7 +3934,7 @@
   },
   {
     "name": "Indiana University of Pennsylvania",
-    "url": "http://proxy-iup.klnpa.org/login?url=",
+    "url": "http://proxy-iup.klnpa.org/login?url=$@",
     "location": {
       "lng": -79.1610224,
       "lat": 40.6143979
@@ -3943,7 +3943,7 @@
   },
   {
     "name": "Indiana University Purdue University Indianapolis",
-    "url": "http://proxy.ulib.iupui.edu/login?url=",
+    "url": "http://proxy.ulib.iupui.edu/login?url=$@",
     "location": {
       "lng": -86.1772798,
       "lat": 39.7749927
@@ -3952,7 +3952,7 @@
   },
   {
     "name": "Indiana University School of Medicine",
-    "url": "https://proxy.medlib.iupui.edu/login?url=",
+    "url": "https://proxy.medlib.iupui.edu/login?url=$@",
     "location": {
       "lng": -86.16517139999999,
       "lat": 39.7815613
@@ -3961,7 +3961,7 @@
   },
   {
     "name": "INFLIBNET Centre (Information and Library Network Centre)",
-    "url": "http://nlist.inflibnet.ac.in:2048/login?url=",
+    "url": "http://nlist.inflibnet.ac.in:2048/login?url=$@",
     "location": {
       "lng": 72.63325296349466,
       "lat": 23.18932292611307
@@ -3970,7 +3970,7 @@
   },
   {
     "name": "INSA de Rennes",
-    "url": "http://rproxy.insa-rennes.fr/login?url=",
+    "url": "http://rproxy.insa-rennes.fr/login?url=$@",
     "location": {
       "lng": -1.635663,
       "lat": 48.12085219999999
@@ -3979,7 +3979,7 @@
   },
   {
     "name": "Institut de l'Information Scientifique et Technique (INSERM)",
-    "url": "https://proxy.insermbiblio.inist.fr/login?url=",
+    "url": "https://proxy.insermbiblio.inist.fr/login?url=$@",
     "location": {
       "lng": 6.149990421500785,
       "lat": 48.65538067074214
@@ -3988,7 +3988,7 @@
   },
   {
     "name": "Institut national de la recherche scientifique",
-    "url": "http://erable.inrs.ca:2048/login?url=",
+    "url": "http://erable.inrs.ca:2048/login?url=$@",
     "location": {
       "lng": -71.21573520705446,
       "lat": 46.86790358778025
@@ -3997,7 +3997,7 @@
   },
   {
     "name": "Institut National des Sciences Appliquées  - Toulouse",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=",
+    "url": "https://gorgone.univ-toulouse.fr/login?url=$@",
     "location": {
       "lng": 1.4680904,
       "lat": 43.5703326
@@ -4006,7 +4006,7 @@
   },
   {
     "name": "Institut National Polytechnique - Toulouse",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=",
+    "url": "https://gorgone.univ-toulouse.fr/login?url=$@",
     "location": {
       "lng": 1.5039621,
       "lat": 43.5554249
@@ -4015,7 +4015,7 @@
   },
   {
     "name": "Institut national universitaire Jean-François - Champollion",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=",
+    "url": "https://gorgone.univ-toulouse.fr/login?url=$@",
     "location": {
       "lng": 2.138535,
       "lat": 43.91945279999999
@@ -4024,7 +4024,7 @@
   },
   {
     "name": "Institute of American Indian Arts",
-    "url": "http://pro.iaia.edu:2048/login?url=",
+    "url": "http://pro.iaia.edu:2048/login?url=$@",
     "location": {
       "lng": -106.0100577,
       "lat": 35.5870573
@@ -4033,7 +4033,7 @@
   },
   {
     "name": "Institute of Cancer Research",
-    "url": "https://ezproxy.icr.ac.uk/login?url=",
+    "url": "https://ezproxy.icr.ac.uk/login?url=$@",
     "location": {
       "lng": -0.1892491,
       "lat": 51.3440949
@@ -4042,7 +4042,7 @@
   },
   {
     "name": "Institute of Technology (Unitec)",
-    "url": "http://libproxy.unitec.ac.nz/login?url=",
+    "url": "http://libproxy.unitec.ac.nz/login?url=$@",
     "location": {
       "lng": 174.7090215575075,
       "lat": -36.88129537066539
@@ -4051,7 +4051,7 @@
   },
   {
     "name": "Institute of Technology Sligo",
-    "url": "http://ezproxy.library.itsligo.ie:2048/login?url=",
+    "url": "http://ezproxy.library.itsligo.ie:2048/login?url=$@",
     "location": {
       "lng": -8.461323,
       "lat": 54.2791632
@@ -4060,7 +4060,7 @@
   },
   {
     "name": "Instituto Tecnológico y de Estudios Superiores de Occidente (ITESO)",
-    "url": "http://ezproxy.iteso.mx/login?url=",
+    "url": "http://ezproxy.iteso.mx/login?url=$@",
     "location": {
       "lng": -103.4146601,
       "lat": 20.6083796
@@ -4069,7 +4069,7 @@
   },
   {
     "name": "International Medical University Malaysia",
-    "url": "http://ezp.imu.edu.my/login?url=",
+    "url": "http://ezp.imu.edu.my/login?url=$@",
     "location": {
       "lng": 101.68720503060177,
       "lat": 3.060037457138748
@@ -4078,7 +4078,7 @@
   },
   {
     "name": "Iowa State University",
-    "url": "http://proxy.lib.iastate.edu:2048/login?url=",
+    "url": "http://proxy.lib.iastate.edu:2048/login?url=$@",
     "location": {
       "lng": -93.64645159999999,
       "lat": 42.0266573
@@ -4087,7 +4087,7 @@
   },
   {
     "name": "Isik University",
-    "url": "http://ezp.isikun.edu.tr/login?url=",
+    "url": "http://ezp.isikun.edu.tr/login?url=$@",
     "location": {
       "lng": 29.5639972,
       "lat": 41.16889949999999
@@ -4096,7 +4096,7 @@
   },
   {
     "name": "IT University of Copenhagen",
-    "url": "https://ep.ituproxy.kb.dk/login?url=",
+    "url": "https://ep.ituproxy.kb.dk/login?url=$@",
     "location": {
       "lng": 12.590958,
       "lat": 55.65963499999999
@@ -4105,7 +4105,7 @@
   },
   {
     "name": "Ita-Suomen yliopisto",
-    "url": "http://ezproxy.uef.fi:2048/login?url=",
+    "url": "http://ezproxy.uef.fi:2048/login?url=$@",
     "location": {
       "lng": 27.6327062,
       "lat": 62.89027650000001
@@ -4114,7 +4114,7 @@
   },
   {
     "name": "Ithaca",
-    "url": "https://login.ezproxy.ithaca.edu/login?qurl=",
+    "url": "https://login.ezproxy.ithaca.edu/login?qurl=$@",
     "location": {
       "lng": -76.5018807,
       "lat": 42.4439614
@@ -4123,7 +4123,7 @@
   },
   {
     "name": "IUCAA",
-    "url": "http://ezproxy.iucaa.ernet.in:2048/login?url=",
+    "url": "http://ezproxy.iucaa.ernet.in:2048/login?url=$@",
     "location": {
       "lng": 73.8253115,
       "lat": 18.5592415
@@ -4132,7 +4132,7 @@
   },
   {
     "name": "Ivy Tech",
-    "url": "http://allstate.libproxy.ivytech.edu/login?url=",
+    "url": "http://allstate.libproxy.ivytech.edu/login?url=$@",
     "location": {
       "lng": -84.8466298,
       "lat": 39.0924828
@@ -4141,7 +4141,7 @@
   },
   {
     "name": "Iwate Medical",
-    "url": "http://ej.iwate-med.ac.jp:2048/login?url=",
+    "url": "http://ej.iwate-med.ac.jp:2048/login?url=$@",
     "location": {
       "lng": 141.1623651,
       "lat": 39.6109273
@@ -4150,7 +4150,7 @@
   },
   {
     "name": "İzmir Institute of Technology",
-    "url": "http://libezproxy.iyte.edu.tr:81/login?url=",
+    "url": "http://libezproxy.iyte.edu.tr:81/login?url=$@",
     "location": {
       "lng": 26.6432058,
       "lat": 38.3190947
@@ -4159,7 +4159,7 @@
   },
   {
     "name": "Jackson State",
-    "url": "http://ezproxy.jscc.edu/login?url=",
+    "url": "http://ezproxy.jscc.edu/login?url=$@",
     "location": {
       "lng": -90.2063989,
       "lat": 32.2968882
@@ -4168,7 +4168,7 @@
   },
   {
     "name": "James Cook University",
-    "url": "http://elibrary.jcu.edu.au/login?url=",
+    "url": "http://elibrary.jcu.edu.au/login?url=$@",
     "location": {
       "lng": 146.7566603,
       "lat": -19.3258585
@@ -4177,7 +4177,7 @@
   },
   {
     "name": "Jawaharlal Nehru Technological University ",
-    "url": "http://ezproxy.jntu.edu/login?irl=",
+    "url": "http://ezproxy.jntu.edu/login?irl=$@",
     "location": {
       "lng": 78.3913929,
       "lat": 17.4932682
@@ -4186,7 +4186,7 @@
   },
   {
     "name": "Jawaharlal Nehru University",
-    "url": "http://ezproxy.jnu.ac.in/login?url=",
+    "url": "http://ezproxy.jnu.ac.in/login?url=$@",
     "location": {
       "lng": 77.1664047,
       "lat": 28.5398035
@@ -4195,7 +4195,7 @@
   },
   {
     "name": "Jefferson College",
-    "url": "http://lib-proxy.jeffco.edu:2048/login?url=",
+    "url": "http://lib-proxy.jeffco.edu:2048/login?url=$@",
     "location": {
       "lng": -90.55972803191268,
       "lat": 38.259432789864434
@@ -4204,7 +4204,7 @@
   },
   {
     "name": "John Jay College of Criminal Justice",
-    "url": "https://login.ez.lib.jjay.cuny.edu/login?url=",
+    "url": "https://login.ez.lib.jjay.cuny.edu/login?url=$@",
     "location": {
       "lng": -73.9892342,
       "lat": 40.7707237
@@ -4213,7 +4213,7 @@
   },
   {
     "name": "John Marshall Law School",
-    "url": "http://ezproxy.jmls.edu:2048/login?url=",
+    "url": "http://ezproxy.jmls.edu:2048/login?url=$@",
     "location": {
       "lng": -87.628064,
       "lat": 41.877932
@@ -4222,7 +4222,7 @@
   },
   {
     "name": "Johns Hopkins",
-    "url": "http://proxy.library.jhu.edu/login?url=",
+    "url": "http://proxy.library.jhu.edu/login?url=$@",
     "location": {
       "lng": -76.6205177,
       "lat": 39.3299013
@@ -4231,7 +4231,7 @@
   },
   {
     "name": "Johns Hopkins University School of Medicine",
-    "url": "https://ezproxy.welch.jhmi.edu/login?url=",
+    "url": "https://ezproxy.welch.jhmi.edu/login?url=$@",
     "location": {
       "lng": -76.5933799,
       "lat": 39.2992161
@@ -4240,7 +4240,7 @@
   },
   {
     "name": "Johnson C Smith",
-    "url": "http://library.jcsu.edu:2048/login?url=",
+    "url": "http://library.jcsu.edu:2048/login?url=$@",
     "location": {
       "lng": -80.85579349999999,
       "lat": 35.2433851
@@ -4249,7 +4249,7 @@
   },
   {
     "name": "Jonkoping",
-    "url": "https://login.bibl.proxy.hj.se/login?url=",
+    "url": "https://login.bibl.proxy.hj.se/login?url=$@",
     "location": {
       "lng": 14.1617876,
       "lat": 57.78261370000001
@@ -4258,7 +4258,7 @@
   },
   {
     "name": "Julius-Maximilians-Uni Wurzburg",
-    "url": "http://ezproxy.bibliothek.uni-wuerzburg.de/login?url=",
+    "url": "http://ezproxy.bibliothek.uni-wuerzburg.de/login?url=$@",
     "location": {
       "lng": 9.93526,
       "lat": 49.7881814
@@ -4267,7 +4267,7 @@
   },
   {
     "name": "Jyvaskylan yliopisto",
-    "url": "http://ezproxy.jyu.fi/login?url=",
+    "url": "http://ezproxy.jyu.fi/login?url=$@",
     "location": {
       "lng": 25.7316335,
       "lat": 62.23653170000001
@@ -4276,7 +4276,7 @@
   },
   {
     "name": "Kadir Has University Library",
-    "url": "https://icproxy.khas.edu.tr/login?url=",
+    "url": "https://icproxy.khas.edu.tr/login?url=$@",
     "location": {
       "lng": 28.9589739,
       "lat": 41.0249511
@@ -4285,7 +4285,7 @@
   },
   {
     "name": "Kansas City University of Medicine and Biosciences",
-    "url": "http://proxy.kcumb.edu/login?url=",
+    "url": "http://proxy.kcumb.edu/login?url=$@",
     "location": {
       "lng": -94.5609759,
       "lat": 39.1072822
@@ -4294,7 +4294,7 @@
   },
   {
     "name": "Kansas State",
-    "url": "http://er.lib.k-state.edu/login?url=",
+    "url": "http://er.lib.k-state.edu/login?url=$@",
     "location": {
       "lng": -96.5847249,
       "lat": 39.1974437
@@ -4303,7 +4303,7 @@
   },
   {
     "name": "Kansas State University",
-    "url": "http://er.lib.ksu.edu/login?url=",
+    "url": "http://er.lib.ksu.edu/login?url=$@",
     "location": {
       "lng": -96.5847249,
       "lat": 39.1974437
@@ -4312,7 +4312,7 @@
   },
   {
     "name": "Kaohsiung Medical University Hospital",
-    "url": "http://ezp.kmu.edu.tw/login?url=",
+    "url": "http://ezp.kmu.edu.tw/login?url=$@",
     "location": {
       "lng": 120.3095722,
       "lat": 22.6460433
@@ -4321,7 +4321,7 @@
   },
   {
     "name": "Karolinska Institutet University Library",
-    "url": "http://proxy.kib.ki.se/login?url=",
+    "url": "http://proxy.kib.ki.se/login?url=$@",
     "location": {
       "lng": 18.0236578,
       "lat": 59.34814839999999
@@ -4330,7 +4330,7 @@
   },
   {
     "name": "Kean",
-    "url": "http://library.kean.edu:2048/login?url=",
+    "url": "http://library.kean.edu:2048/login?url=$@",
     "location": {
       "lng": -74.23311,
       "lat": 40.6801659
@@ -4339,7 +4339,7 @@
   },
   {
     "name": "Keele University",
-    "url": "https://ezproxy.keele.ac.uk/login?url=",
+    "url": "https://ezproxy.keele.ac.uk/login?url=$@",
     "location": {
       "lng": -2.2721329,
       "lat": 53.0029512
@@ -4348,7 +4348,7 @@
   },
   {
     "name": "Keiser University",
-    "url": "http://ezproxy.keiser.edu/login?url=",
+    "url": "http://ezproxy.keiser.edu/login?url=$@",
     "location": {
       "lng": -80.1640417,
       "lat": 26.1859293
@@ -4357,7 +4357,7 @@
   },
   {
     "name": "Kennesaw State",
-    "url": "http://proxy.kennesaw.edu/login?url=",
+    "url": "http://proxy.kennesaw.edu/login?url=$@",
     "location": {
       "lng": -84.6154897,
       "lat": 34.0234337
@@ -4366,7 +4366,7 @@
   },
   {
     "name": "Kent State University",
-    "url": "https://proxy.library.kent.edu/login?url=",
+    "url": "https://proxy.library.kent.edu/login?url=$@",
     "location": {
       "lng": -81.34331590000001,
       "lat": 41.1497945
@@ -4375,7 +4375,7 @@
   },
   {
     "name": "Kettering College",
-    "url": "https://proxy.kc.edu/login?url=",
+    "url": "https://proxy.kc.edu/login?url=$@",
     "location": {
       "lng": -84.19249769999999,
       "lat": 39.6949236
@@ -4384,7 +4384,7 @@
   },
   {
     "name": "Khalifa University",
-    "url": "https://login.libconnect.ku.ac.ae/login?url=",
+    "url": "https://login.libconnect.ku.ac.ae/login?url=$@",
     "location": {
       "lng": 54.3949088,
       "lat": 24.4473556
@@ -4393,7 +4393,7 @@
   },
   {
     "name": "Khalifa University of Science, Technology, and Research",
-    "url": "http://ezproxy.kustar.ac.ae:2048/login?url=",
+    "url": "http://ezproxy.kustar.ac.ae:2048/login?url=$@",
     "location": {
       "lng": 55.3990626,
       "lat": 25.3542829
@@ -4402,7 +4402,7 @@
   },
   {
     "name": "Khon Kaen University",
-    "url": "http://ezproxy.kku.ac.th/login?url=",
+    "url": "http://ezproxy.kku.ac.th/login?url=$@",
     "location": {
       "lng": 102.8219888,
       "lat": 16.4739913
@@ -4411,7 +4411,7 @@
   },
   {
     "name": "Kilgore College",
-    "url": "http://ezproxy.wildcatter.kilgore.edu:2048/login?url=",
+    "url": "http://ezproxy.wildcatter.kilgore.edu:2048/login?url=$@",
     "location": {
       "lng": -94.8722513,
       "lat": 32.37776760000001
@@ -4420,7 +4420,7 @@
   },
   {
     "name": "King Fahd University of Petroleum & Minerals (KFUPM)",
-    "url": "https://login.kfupm.idm.oclc.org/login?url=",
+    "url": "https://login.kfupm.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 50.1458938,
       "lat": 26.3070624
@@ -4429,7 +4429,7 @@
   },
   {
     "name": "Kings College London",
-    "url": "http://libproxy.kcl.ac.uk/login?url=",
+    "url": "http://libproxy.kcl.ac.uk/login?url=$@",
     "location": {
       "lng": -0.115997,
       "lat": 51.5114864
@@ -4438,7 +4438,7 @@
   },
   {
     "name": "Kings University",
-    "url": "http://ezproxy.aekc.talonline.ca/login?url=",
+    "url": "http://ezproxy.aekc.talonline.ca/login?url=$@",
     "location": {
       "lng": -97.1213015,
       "lat": 32.9396261
@@ -4447,7 +4447,7 @@
   },
   {
     "name": "Knowledge Network (NHS Education for Scotland)",
-    "url": "https://knowledge.idm.oclc.org/login?url=",
+    "url": "https://knowledge.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -4.1913914,
       "lat": 57.47676860000001
@@ -4456,7 +4456,7 @@
   },
   {
     "name": "Knox College",
-    "url": "http://ezproxy.knox.edu:2048/login?url=",
+    "url": "http://ezproxy.knox.edu:2048/login?url=$@",
     "location": {
       "lng": -90.37376334944817,
       "lat": 40.953008245946066
@@ -4465,7 +4465,7 @@
   },
   {
     "name": "Koc School Libraries",
-    "url": "https://offcampus.koc.k12.tr/login?url=",
+    "url": "https://offcampus.koc.k12.tr/login?url=$@",
     "location": {
       "lng": 29.3581415,
       "lat": 40.9185899
@@ -4474,7 +4474,7 @@
   },
   {
     "name": "Korea",
-    "url": "http://library.korea.ac.kr/login?url=",
+    "url": "http://library.korea.ac.kr/login?url=$@",
     "location": {
       "lng": 127.766922,
       "lat": 35.907757
@@ -4483,7 +4483,7 @@
   },
   {
     "name": "Korea University",
-    "url": "https://oca.korea.ac.kr/link.n2s?url=",
+    "url": "https://oca.korea.ac.kr/link.n2s?url=$@",
     "location": {
       "lng": 127.0277773,
       "lat": 37.590799
@@ -4492,7 +4492,7 @@
   },
   {
     "name": "Kristiania University College",
-    "url": "http://egms.idm.oclc.org/login?url=",
+    "url": "http://egms.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 10.7460873,
       "lat": 59.910952
@@ -4501,7 +4501,7 @@
   },
   {
     "name": "KULeuven",
-    "url": "https://kuleuven.e-bronnen.be/login?url=",
+    "url": "https://kuleuven.e-bronnen.be/login?url=$@",
     "location": {
       "lng": 4.699705300000001,
       "lat": 50.87809710000001
@@ -4510,7 +4510,7 @@
   },
   {
     "name": "Kungliga Tekniska Hogskolan",
-    "url": "http://focus.lib.kth.se/login?url=",
+    "url": "http://focus.lib.kth.se/login?url=$@",
     "location": {
       "lng": 18.0702566,
       "lat": 59.3498706
@@ -4519,7 +4519,7 @@
   },
   {
     "name": "Kutztown University",
-    "url": "http://proxy-kutztown.klnpa.org/login?url=",
+    "url": "http://proxy-kutztown.klnpa.org/login?url=$@",
     "location": {
       "lng": -75.78336800000001,
       "lat": 40.5100628
@@ -4528,7 +4528,7 @@
   },
   {
     "name": "Kuyper College ",
-    "url": "https://kuyper.idm.oclc.org/login?url=",
+    "url": "https://kuyper.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -85.5920676,
       "lat": 43.0221755
@@ -4537,7 +4537,7 @@
   },
   {
     "name": "Kuyper College Zondervan Library",
-    "url": "http://resources.kuyper.edu:2048/login?url=",
+    "url": "http://resources.kuyper.edu:2048/login?url=$@",
     "location": {
       "lng": -85.592714,
       "lat": 43.022184
@@ -4546,7 +4546,7 @@
   },
   {
     "name": "Kyorin University",
-    "url": "https://ezproxy.kyorin-u.ac.jp/login?url=",
+    "url": "https://ezproxy.kyorin-u.ac.jp/login?url=$@",
     "location": {
       "lng": 139.5658488826429,
       "lat": 35.67741634251354
@@ -4555,7 +4555,7 @@
   },
   {
     "name": "Kyungpook National University",
-    "url": "http://libproxy.knu.ac.kr/_Lib_Proxy_Url/",
+    "url": "http://libproxy.knu.ac.kr/_Lib_Proxy_Url/$@",
     "location": {
       "lng": 128.6102997,
       "lat": 35.888836
@@ -4564,7 +4564,7 @@
   },
   {
     "name": "LA BioMed",
-    "url": "http://journals.labiomed.org/login?url=",
+    "url": "http://journals.labiomed.org/login?url=$@",
     "location": {
       "lng": -118.2436849,
       "lat": 34.0522342
@@ -4573,7 +4573,7 @@
   },
   {
     "name": "La Salle",
-    "url": "http://dbproxy.lasalle.edu:2048/login?url=",
+    "url": "http://dbproxy.lasalle.edu:2048/login?url=$@",
     "location": {
       "lng": -73.6348608,
       "lat": 45.4306303
@@ -4582,7 +4582,7 @@
   },
   {
     "name": "La Sierra",
-    "url": "http://ezproxy.lasierra.edu:2048/login?url=",
+    "url": "http://ezproxy.lasierra.edu:2048/login?url=$@",
     "location": {
       "lng": -75.2262559,
       "lat": 38.4575916
@@ -4591,7 +4591,7 @@
   },
   {
     "name": "La Trobe University",
-    "url": "http://ez.library.latrobe.edu.au/login?url=",
+    "url": "http://ez.library.latrobe.edu.au/login?url=$@",
     "location": {
       "lng": 145.047159,
       "lat": -37.7207472
@@ -4600,7 +4600,7 @@
   },
   {
     "name": "Laguardia",
-    "url": "https://rpa.laguardia.edu/login?url=",
+    "url": "https://rpa.laguardia.edu/login?url=$@",
     "location": {
       "lng": -73.8739659,
       "lat": 40.7769271
@@ -4609,7 +4609,7 @@
   },
   {
     "name": "Lakehead University",
-    "url": "http://ezproxy.lakeheadu.ca/login?url=",
+    "url": "http://ezproxy.lakeheadu.ca/login?url=$@",
     "location": {
       "lng": -89.2606994,
       "lat": 48.42111080000001
@@ -4618,7 +4618,7 @@
   },
   {
     "name": "Lakeview College of Nursing",
-    "url": "http://ezproxy.lakeviewcol.edu:2048/login?url=",
+    "url": "http://ezproxy.lakeviewcol.edu:2048/login?url=$@",
     "location": {
       "lng": -87.6443161,
       "lat": 40.1385934
@@ -4627,7 +4627,7 @@
   },
   {
     "name": "Lamar State College at Orange",
-    "url": "http://ezproxy.lsco.edu:2048/login?url=",
+    "url": "http://ezproxy.lsco.edu:2048/login?url=$@",
     "location": {
       "lng": -117.8531007,
       "lat": 33.7879139
@@ -4636,7 +4636,7 @@
   },
   {
     "name": "Lamar University",
-    "url": "https://libproxy.lamar.edu/login?url=",
+    "url": "https://libproxy.lamar.edu/login?url=$@",
     "location": {
       "lng": -94.0747071,
       "lat": 30.0392256
@@ -4645,7 +4645,7 @@
   },
   {
     "name": "Lancaster",
-    "url": "http://ezproxy.lancs.ac.uk/login?url=",
+    "url": "http://ezproxy.lancs.ac.uk/login?url=$@",
     "location": {
       "lng": -76.3055144,
       "lat": 40.0378755
@@ -4654,7 +4654,7 @@
   },
   {
     "name": "Lane Community College",
-    "url": "http://lanecc.idm.oclc.org/login?url=",
+    "url": "http://lanecc.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -123.03486875630506,
       "lat": 44.009129093147926
@@ -4663,7 +4663,7 @@
   },
   {
     "name": "Lansing",
-    "url": "https://lcc.idm.oclc.org/login?url=",
+    "url": "https://lcc.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -84.5555347,
       "lat": 42.732535
@@ -4672,7 +4672,7 @@
   },
   {
     "name": "Las Positas College",
-    "url": "https://lpclibrary.idm.oclc.org/login?url=",
+    "url": "https://lpclibrary.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -121.80020242479456,
       "lat": 37.71065710946536
@@ -4681,7 +4681,7 @@
   },
   {
     "name": "Laurentian",
-    "url": "http://librweb.laurentian.ca/login?url=",
+    "url": "http://librweb.laurentian.ca/login?url=$@",
     "location": {
       "lng": -80.9757296,
       "lat": 46.4672485
@@ -4690,7 +4690,7 @@
   },
   {
     "name": "Laurentian University",
-    "url": "https://login.librweb.laurentian.ca/login?url=",
+    "url": "https://login.librweb.laurentian.ca/login?url=$@",
     "location": {
       "lng": -80.9757296,
       "lat": 46.4672485
@@ -4699,7 +4699,7 @@
   },
   {
     "name": "Lawrence Technological",
-    "url": "http://ezproxy.ltu.edu:8080/login?url=",
+    "url": "http://ezproxy.ltu.edu:8080/login?url=$@",
     "location": {
       "lng": -83.2507416,
       "lat": 42.4751235
@@ -4708,7 +4708,7 @@
   },
   {
     "name": "Lawrence University",
-    "url": "http://proxy.lawrence.edu:2048/login?url=",
+    "url": "http://proxy.lawrence.edu:2048/login?url=$@",
     "location": {
       "lng": -88.39935302776678,
       "lat": 44.26181495876797
@@ -4717,7 +4717,7 @@
   },
   {
     "name": "Lebanese University",
-    "url": "http://ezproxy.ul.edu.lb:82/login?url=",
+    "url": "http://ezproxy.ul.edu.lb:82/login?url=$@",
     "location": {
       "lng": 35.5217731,
       "lat": 33.8278696
@@ -4726,7 +4726,7 @@
   },
   {
     "name": "Lebanon Valley",
-    "url": "http://ezproxy.lvc.edu:2048/login?url=",
+    "url": "http://ezproxy.lvc.edu:2048/login?url=$@",
     "location": {
       "lng": -73.48697659999999,
       "lat": 42.4905395
@@ -4735,7 +4735,7 @@
   },
   {
     "name": "Lee College",
-    "url": "http://leonardo.lee.edu/login?url=",
+    "url": "http://leonardo.lee.edu/login?url=$@",
     "location": {
       "lng": -94.9764522,
       "lat": 29.7345406
@@ -4744,7 +4744,7 @@
   },
   {
     "name": "Leeds Beckett",
-    "url": "http://ezproxy.leedsbeckett.ac.uk/login?url=",
+    "url": "http://ezproxy.leedsbeckett.ac.uk/login?url=$@",
     "location": {
       "lng": -1.5480355,
       "lat": 53.8035274
@@ -4753,7 +4753,7 @@
   },
   {
     "name": "Leeds Metropolitan University",
-    "url": "https://login.ezproxy.leedsmet.ac.uk/login?url=",
+    "url": "https://login.ezproxy.leedsmet.ac.uk/login?url=$@",
     "location": {
       "lng": -1.5480355,
       "lat": 53.8035274
@@ -4762,7 +4762,7 @@
   },
   {
     "name": "Legacy Health",
-    "url": "https://lhs.idm.oclc.org/login?url=",
+    "url": "https://lhs.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.65682250648926,
       "lat": 45.525221254361185
@@ -4771,7 +4771,7 @@
   },
   {
     "name": "Lehigh",
-    "url": "https://ezproxy.lib.lehigh.edu/login?url=",
+    "url": "https://ezproxy.lib.lehigh.edu/login?url=$@",
     "location": {
       "lng": -75.3775187,
       "lat": 40.6048687
@@ -4780,7 +4780,7 @@
   },
   {
     "name": "Lehigh University",
-    "url": "https://login.ezproxy.lib.lehigh.edu/login?url=",
+    "url": "https://login.ezproxy.lib.lehigh.edu/login?url=$@",
     "location": {
       "lng": -75.3775187,
       "lat": 40.6048687
@@ -4789,7 +4789,7 @@
   },
   {
     "name": "Leiden University",
-    "url": "https://ezproxy.leidenuniv.nl:2443/login?url=",
+    "url": "https://ezproxy.leidenuniv.nl:2443/login?url=$@",
     "location": {
       "lng": 4.4863129,
       "lat": 52.1565752
@@ -4798,7 +4798,7 @@
   },
   {
     "name": "LeTourneau University",
-    "url": "http://research-db.letu.edu/login?url=",
+    "url": "http://research-db.letu.edu/login?url=$@",
     "location": {
       "lng": -94.7276606,
       "lat": 32.4669557
@@ -4807,7 +4807,7 @@
   },
   {
     "name": "Lewis & Clark College",
-    "url": "https://library.lcproxy.org/login?url=",
+    "url": "https://library.lcproxy.org/login?url=$@",
     "location": {
       "lng": -122.67004954776453,
       "lat": 45.45037271087549
@@ -4816,7 +4816,7 @@
   },
   {
     "name": "Liberty",
-    "url": "http://ezproxy.liberty.edu:2048/login?url=",
+    "url": "http://ezproxy.liberty.edu:2048/login?url=$@",
     "location": {
       "lng": -79.17841229999999,
       "lat": 37.3492244
@@ -4825,7 +4825,7 @@
   },
   {
     "name": "Liberty University",
-    "url": "http://ezproxy.liberty.edu/login?url=",
+    "url": "http://ezproxy.liberty.edu/login?url=$@",
     "location": {
       "lng": -79.17841229999999,
       "lat": 37.3492244
@@ -4834,7 +4834,7 @@
   },
   {
     "name": "Lietuvos sveikatos mokslų universitetas",
-    "url": "http://ezproxy.dbazes.lsmuni.lt:2048/login?url=",
+    "url": "http://ezproxy.dbazes.lsmuni.lt:2048/login?url=$@",
     "location": {
       "lng": 23.9167513,
       "lat": 54.8942492
@@ -4843,7 +4843,7 @@
   },
   {
     "name": "Lillehammer University College",
-    "url": "http://login.ezproxy.hil.no/login?url=",
+    "url": "http://login.ezproxy.hil.no/login?url=$@",
     "location": {
       "lng": 10.4225301,
       "lat": 61.1497953
@@ -4852,7 +4852,7 @@
   },
   {
     "name": "Lincoln University",
-    "url": "http://proxy-lincoln.klnpa.org/login?url=",
+    "url": "http://proxy-lincoln.klnpa.org/login?url=$@",
     "location": {
       "lng": -75.928474,
       "lat": 39.8071788
@@ -4861,7 +4861,7 @@
   },
   {
     "name": "Linfield",
-    "url": "https://ezproxy.linfield.edu/login?url=",
+    "url": "https://ezproxy.linfield.edu/login?url=$@",
     "location": {
       "lng": -123.1993365,
       "lat": 45.2006802
@@ -4870,7 +4870,7 @@
   },
   {
     "name": "Linköping University",
-    "url": "https://login.e.bibl.liu.se/login?url=",
+    "url": "https://login.e.bibl.liu.se/login?url=$@",
     "location": {
       "lng": 15.5760072,
       "lat": 58.3978364
@@ -4879,7 +4879,7 @@
   },
   {
     "name": "Linn-Benton",
-    "url": "http://ezproxy.libweb.linnbenton.edu:2048/login?url=",
+    "url": "http://ezproxy.libweb.linnbenton.edu:2048/login?url=$@",
     "location": {
       "lng": -123.1147938,
       "lat": 44.5870879
@@ -4888,7 +4888,7 @@
   },
   {
     "name": "Linnaeus University",
-    "url": "http://proxy.lnu.se/login?url=",
+    "url": "http://proxy.lnu.se/login?url=$@",
     "location": {
       "lng": 14.8303775,
       "lat": 56.8546039
@@ -4897,7 +4897,7 @@
   },
   {
     "name": "Lock Haven University",
-    "url": "http://proxy-lhup.klnpa.org/login?url=",
+    "url": "http://proxy-lhup.klnpa.org/login?url=$@",
     "location": {
       "lng": -77.46062429999999,
       "lat": 41.1427108
@@ -4906,7 +4906,7 @@
   },
   {
     "name": "Lone Star",
-    "url": "http://ezproxy.lonestar.edu/login?url=",
+    "url": "http://ezproxy.lonestar.edu/login?url=$@",
     "location": {
       "lng": -95.4665258,
       "lat": 29.868389
@@ -4915,7 +4915,7 @@
   },
   {
     "name": "Lone Star College",
-    "url": "http://lscsproxy.lonestar.edu/login?url=",
+    "url": "http://lscsproxy.lonestar.edu/login?url=$@",
     "location": {
       "lng": -95.4665258,
       "lat": 29.868389
@@ -4924,7 +4924,7 @@
   },
   {
     "name": "Longwood",
-    "url": "https://login.proxy.longwood.edu/login?url=",
+    "url": "https://login.proxy.longwood.edu/login?url=$@",
     "location": {
       "lng": -81.3384011,
       "lat": 28.7030519
@@ -4933,7 +4933,7 @@
   },
   {
     "name": "Los Angeles Harbor",
-    "url": "http://ezproxy.lahc.edu:2048/login?url=",
+    "url": "http://ezproxy.lahc.edu:2048/login?url=$@",
     "location": {
       "lng": -118.2599686241527,
       "lat": 33.73954589643058
@@ -4942,7 +4942,7 @@
   },
   {
     "name": "Louisiana State University",
-    "url": "http://libezp.lib.lsu.edu/login?url=",
+    "url": "http://libezp.lib.lsu.edu/login?url=$@",
     "location": {
       "lng": -91.1800023,
       "lat": 30.4132579
@@ -4951,7 +4951,7 @@
   },
   {
     "name": "Louisiana State University Paul M Hebert Law Center",
-    "url": "http://ezproxy.law.lsu.edu/login?url=",
+    "url": "http://ezproxy.law.lsu.edu/login?url=$@",
     "location": {
       "lng": -91.1749433,
       "lat": 30.414219
@@ -4960,7 +4960,7 @@
   },
   {
     "name": "Louisiana Tech University",
-    "url": "http://ezproxy.latech.edu:2048/login?url=",
+    "url": "http://ezproxy.latech.edu:2048/login?url=$@",
     "location": {
       "lng": -92.6522174,
       "lat": 32.5299582
@@ -4969,7 +4969,7 @@
   },
   {
     "name": "Loyola Marymount",
-    "url": "http://electra.lmu.edu:2048/login?url=",
+    "url": "http://electra.lmu.edu:2048/login?url=$@",
     "location": {
       "lng": -118.4170134,
       "lat": 33.9709541
@@ -4978,7 +4978,7 @@
   },
   {
     "name": "Loyola Marymount University | LA",
-    "url": "https://electra.lmu.edu/login?url=",
+    "url": "https://electra.lmu.edu/login?url=$@",
     "location": {
       "lng": -118.4170134,
       "lat": 33.9709541
@@ -4987,7 +4987,7 @@
   },
   {
     "name": "Loyola University Chicago",
-    "url": "http://flagship.luc.edu/login?url=",
+    "url": "http://flagship.luc.edu/login?url=$@",
     "location": {
       "lng": -87.65825919999999,
       "lat": 41.9989483
@@ -4996,7 +4996,7 @@
   },
   {
     "name": "Loyola University New Orleans",
-    "url": "http://ezproxy.loyno.edu/login?url=",
+    "url": "http://ezproxy.loyno.edu/login?url=$@",
     "location": {
       "lng": -90.1209925,
       "lat": 29.9346582
@@ -5005,7 +5005,7 @@
   },
   {
     "name": "LSU Health Sciences Center New Orleans",
-    "url": "https://ezproxy.lsuhsc.edu/login?url=",
+    "url": "https://ezproxy.lsuhsc.edu/login?url=$@",
     "location": {
       "lng": -90.0832621,
       "lat": 29.9572962
@@ -5014,7 +5014,7 @@
   },
   {
     "name": "Ludwig-Maximilians-Universität München",
-    "url": "http://emedien.ub.uni-muenchen.de/login?url=",
+    "url": "http://emedien.ub.uni-muenchen.de/login?url=$@",
     "location": {
       "lng": 11.5805262,
       "lat": 48.1507496
@@ -5023,7 +5023,7 @@
   },
   {
     "name": "Lulea Tekniska Universitet",
-    "url": "http://proxy.lib.ltu.se/login?url=",
+    "url": "http://proxy.lib.ltu.se/login?url=$@",
     "location": {
       "lng": 22.1401794,
       "lat": 65.6179964
@@ -5032,7 +5032,7 @@
   },
   {
     "name": "Lund University",
-    "url": "http://ludwig.lub.lu.se/login?url=",
+    "url": "http://ludwig.lub.lu.se/login?url=$@",
     "location": {
       "lng": 13.203493,
       "lat": 55.7119483
@@ -5041,7 +5041,7 @@
   },
   {
     "name": "Luther College",
-    "url": "http://proxy.luther.edu/login?url=",
+    "url": "http://proxy.luther.edu/login?url=$@",
     "location": {
       "lng": -90.80301436456544,
       "lat": 44.27698912983501
@@ -5050,7 +5050,7 @@
   },
   {
     "name": "Luther Seminary",
-    "url": "https://luthersem.idm.oclc.org/login?url=",
+    "url": "https://luthersem.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -93.1967707,
       "lat": 44.9858214
@@ -5059,7 +5059,7 @@
   },
   {
     "name": "Lycoming",
-    "url": "http://lyco2.lycoming.edu:2048/login?url=",
+    "url": "http://lyco2.lycoming.edu:2048/login?url=$@",
     "location": {
       "lng": -77.10249019999999,
       "lat": 41.2720004
@@ -5068,7 +5068,7 @@
   },
   {
     "name": "Lynchburg College",
-    "url": "http://ezproxy.lynchburg.edu/login?url=",
+    "url": "http://ezproxy.lynchburg.edu/login?url=$@",
     "location": {
       "lng": -79.183153,
       "lat": 37.4006
@@ -5077,7 +5077,7 @@
   },
   {
     "name": "Maastricht University",
-    "url": "http://ezproxy.ub.unimaas.nl/login?url=",
+    "url": "http://ezproxy.ub.unimaas.nl/login?url=$@",
     "location": {
       "lng": 5.6879801,
       "lat": 50.8469602
@@ -5086,7 +5086,7 @@
   },
   {
     "name": "Macalester",
-    "url": "http://ezproxy.macalester.edu/login?url=",
+    "url": "http://ezproxy.macalester.edu/login?url=$@",
     "location": {
       "lng": -93.1670857,
       "lat": 44.934297
@@ -5095,7 +5095,7 @@
   },
   {
     "name": "MacEwan University",
-    "url": "http://ezproxy.macewan.ca/login?url=",
+    "url": "http://ezproxy.macewan.ca/login?url=$@",
     "location": {
       "lng": -113.5063721,
       "lat": 53.5470544
@@ -5104,7 +5104,7 @@
   },
   {
     "name": "Macquarie University",
-    "url": "https://simsrad.net.ocs.mq.edu.au/login?qurl=",
+    "url": "https://simsrad.net.ocs.mq.edu.au/login?qurl=$@",
     "location": {
       "lng": 151.1126498,
       "lat": -33.77382370000001
@@ -5113,7 +5113,7 @@
   },
   {
     "name": "Madison",
-    "url": "http://ezproxy.madisoncollege.edu/login?url=",
+    "url": "http://ezproxy.madisoncollege.edu/login?url=$@",
     "location": {
       "lng": -89.4007501,
       "lat": 43.0721661
@@ -5122,7 +5122,7 @@
   },
   {
     "name": "Madonna University",
-    "url": "http://madonnaezp.liblime.com/login?url=",
+    "url": "http://madonnaezp.liblime.com/login?url=$@",
     "location": {
       "lng": -83.40627452064103,
       "lat": 42.38593207187496
@@ -5131,7 +5131,7 @@
   },
   {
     "name": "Mahec Digital Library",
-    "url": "http://ezproxy.maheclibrary.org/login?url=",
+    "url": "http://ezproxy.maheclibrary.org/login?url=$@",
     "location": {
       "lng": -91.7845624,
       "lat": 37.9525019
@@ -5140,7 +5140,7 @@
   },
   {
     "name": "Mahidol University",
-    "url": "https://ejournal.mahidol.ac.th/login?url=",
+    "url": "https://ejournal.mahidol.ac.th/login?url=$@",
     "location": {
       "lng": 100.3256274,
       "lat": 13.7943814
@@ -5149,7 +5149,7 @@
   },
   {
     "name": "Maine's Virtual Library",
-    "url": "http://libraries.maine.edu/mainedatabases/authmaine.asp?url=",
+    "url": "http://libraries.maine.edu/mainedatabases/authmaine.asp?url=$@",
     "location": {
       "lng": -69.4454689,
       "lat": 45.253783
@@ -5158,7 +5158,7 @@
   },
   {
     "name": "Malmo Hogskola",
-    "url": "http://proxy.mah.se/login?url=",
+    "url": "http://proxy.mah.se/login?url=$@",
     "location": {
       "lng": 12.994561,
       "lat": 55.6087954
@@ -5167,7 +5167,7 @@
   },
   {
     "name": "Manchester Metropolitan University",
-    "url": "http://ezproxy.mmu.ac.uk/login?url=",
+    "url": "http://ezproxy.mmu.ac.uk/login?url=$@",
     "location": {
       "lng": -2.2392999,
       "lat": 53.4703485
@@ -5176,7 +5176,7 @@
   },
   {
     "name": "Manhattanville",
-    "url": "http://librda.mville.edu:2048/login?url=",
+    "url": "http://librda.mville.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9558333,
       "lat": 40.8169443
@@ -5185,7 +5185,7 @@
   },
   {
     "name": "Manipal Institute of Technology",
-    "url": "https://mitezproxy.manipal.edu/login?url=",
+    "url": "https://mitezproxy.manipal.edu/login?url=$@",
     "location": {
       "lng": 74.79282239999999,
       "lat": 13.3525321
@@ -5194,7 +5194,7 @@
   },
   {
     "name": "Mansfield University",
-    "url": "http://proxy-mansfield.klnpa.org/login?url=",
+    "url": "http://proxy-mansfield.klnpa.org/login?url=$@",
     "location": {
       "lng": -77.07042799999999,
       "lat": 41.8047541
@@ -5203,7 +5203,7 @@
   },
   {
     "name": "Marist College",
-    "url": "http://login.online.library.marist.edu/login?url=",
+    "url": "http://login.online.library.marist.edu/login?url=$@",
     "location": {
       "lng": -73.9344876,
       "lat": 41.7231052
@@ -5212,7 +5212,7 @@
   },
   {
     "name": "Marlboro College Archives (Emerson College)",
-    "url": "http://libproxy.marlboro.edu/login?url=",
+    "url": "http://libproxy.marlboro.edu/login?url=$@",
     "location": {
       "lng": -72.73475190898273,
       "lat": 42.83921258087876
@@ -5221,7 +5221,7 @@
   },
   {
     "name": "Marshall University",
-    "url": "http://marshall.idm.oclc.org/login?url=",
+    "url": "http://marshall.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -82.42471979999999,
       "lat": 38.4236597
@@ -5230,7 +5230,7 @@
   },
   {
     "name": "Marshall University",
-    "url": "http://ezproxy.marshall.edu:2048/login?url=",
+    "url": "http://ezproxy.marshall.edu:2048/login?url=$@",
     "location": {
       "lng": -82.42497995923164,
       "lat": 38.42435645107813
@@ -5239,7 +5239,7 @@
   },
   {
     "name": "Marygrove",
-    "url": "http://library.marygrove.edu:2048/login?url=",
+    "url": "http://library.marygrove.edu:2048/login?url=$@",
     "location": {
       "lng": -90.35697139999999,
       "lat": 38.8231165
@@ -5248,7 +5248,7 @@
   },
   {
     "name": "Maryland Institute College of Art",
-    "url": "http://ezproxy.mica.edu:2048/login?url=",
+    "url": "http://ezproxy.mica.edu:2048/login?url=$@",
     "location": {
       "lng": -76.62108358440929,
       "lat": 39.30805373243502
@@ -5257,7 +5257,7 @@
   },
   {
     "name": "Marylhurst",
-    "url": "http://marylhurst.idm.oclc.org/login?url=",
+    "url": "http://marylhurst.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.6543286,
       "lat": 45.3891078
@@ -5266,7 +5266,7 @@
   },
   {
     "name": "Maryville",
-    "url": "http://proxy.library.maryville.edu/login?url=",
+    "url": "http://proxy.library.maryville.edu/login?url=$@",
     "location": {
       "lng": -83.9704593,
       "lat": 35.7564719
@@ -5275,7 +5275,7 @@
   },
   {
     "name": "Marywood",
-    "url": "http://marywood1.marywood.edu:2048/login?url=",
+    "url": "http://marywood1.marywood.edu:2048/login?url=$@",
     "location": {
       "lng": -75.6324234,
       "lat": 41.43513189999999
@@ -5284,7 +5284,7 @@
   },
   {
     "name": "Massachusetts College of Liberal Arts",
-    "url": "http://libproxy.mcla.edu:2048/login?url=",
+    "url": "http://libproxy.mcla.edu:2048/login?url=$@",
     "location": {
       "lng": -73.1033372,
       "lat": 42.691554
@@ -5293,7 +5293,7 @@
   },
   {
     "name": "Massachusetts Institute of Technology",
-    "url": "http://libproxy.mit.edu/login?url=",
+    "url": "http://libproxy.mit.edu/login?url=$@",
     "location": {
       "lng": -71.09416,
       "lat": 42.360091
@@ -5302,7 +5302,7 @@
   },
   {
     "name": "Massey Universtiy",
-    "url": "http://ezproxy.massey.ac.nz/login?url=",
+    "url": "http://ezproxy.massey.ac.nz/login?url=$@",
     "location": {
       "lng": 174.68605294966477,
       "lat": -36.69417903509752
@@ -5311,7 +5311,7 @@
   },
   {
     "name": "Max Planck Institute for Human Cognitive and Brain Sciences",
-    "url": "https://browser.cbs.mpg.de/login?url=",
+    "url": "https://browser.cbs.mpg.de/login?url=$@",
     "location": {
       "lng": 12.3889266,
       "lat": 51.3349446
@@ -5320,7 +5320,7 @@
   },
   {
     "name": "Max-Planck-Institut für molekulare Genetik",
-    "url": "https://login.ezproxy.molgen.mpg.de/login?url=",
+    "url": "https://login.ezproxy.molgen.mpg.de/login?url=$@",
     "location": {
       "lng": 13.2736288,
       "lat": 52.4449769
@@ -5329,7 +5329,7 @@
   },
   {
     "name": "Maynooth",
-    "url": "https://login.jproxy.nuim.ie/login?url=",
+    "url": "https://login.jproxy.nuim.ie/login?url=$@",
     "location": {
       "lng": -6.5918499,
       "lat": 53.3812896
@@ -5338,7 +5338,7 @@
   },
   {
     "name": "Mayo Clinic",
-    "url": "https://mclibrary.idm.oclc.org/login?url=",
+    "url": "https://mclibrary.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -92.4663757,
       "lat": 44.0230449
@@ -5347,7 +5347,7 @@
   },
   {
     "name": "McGill University",
-    "url": "http://proxy.library.mcgill.ca/login?url=",
+    "url": "http://proxy.library.mcgill.ca/login?url=$@",
     "location": {
       "lng": -73.5771511,
       "lat": 45.50478469999999
@@ -5356,7 +5356,7 @@
   },
   {
     "name": "McMaster University",
-    "url": "http://libaccess.lib.mcmaster.ca/login?url=",
+    "url": "http://libaccess.lib.mcmaster.ca/login?url=$@",
     "location": {
       "lng": -79.9192254,
       "lat": 43.260879
@@ -5365,7 +5365,7 @@
   },
   {
     "name": "MCPHS (Massachusetts College of Pharmacy and Health Science)",
-    "url": "https://ezproxymcp.flo.org/login?qurl=",
+    "url": "https://ezproxymcp.flo.org/login?qurl=$@",
     "location": {
       "lng": -71.1012629,
       "lat": 42.3367556
@@ -5374,7 +5374,7 @@
   },
   {
     "name": "Medical College of Wisconsin",
-    "url": "https://login.proxy.lib.mcw.edu/login?url=",
+    "url": "https://login.proxy.lib.mcw.edu/login?url=$@",
     "location": {
       "lng": -88.02116509999999,
       "lat": 43.0435728
@@ -5383,7 +5383,7 @@
   },
   {
     "name": "Medical University of Bialystok",
-    "url": "http://ebazy.umb.edu.pl/login?url=",
+    "url": "http://ebazy.umb.edu.pl/login?url=$@",
     "location": {
       "lng": 23.1653094,
       "lat": 53.13058119999999
@@ -5392,7 +5392,7 @@
   },
   {
     "name": "Medical University of South Carolina",
-    "url": "http://ezproxy.musc.edu/login?url=",
+    "url": "http://ezproxy.musc.edu/login?url=$@",
     "location": {
       "lng": -79.9497334,
       "lat": 32.784891
@@ -5401,7 +5401,7 @@
   },
   {
     "name": "Medical University Vienna",
-    "url": "http://ez.srv.meduniwien.ac.at/login?url=",
+    "url": "http://ez.srv.meduniwien.ac.at/login?url=$@",
     "location": {
       "lng": 16.3475329,
       "lat": 48.2196447
@@ -5410,7 +5410,7 @@
   },
   {
     "name": "MEF University",
-    "url": "http://ezproxy.mef.edu.tr/login?url=",
+    "url": "http://ezproxy.mef.edu.tr/login?url=$@",
     "location": {
       "lng": 29.0085964,
       "lat": 41.1088445
@@ -5419,7 +5419,7 @@
   },
   {
     "name": "Memorial Sloan Kettering Cancer Center",
-    "url": "https://login.libauth.mskcc.org/login?url=",
+    "url": "https://login.libauth.mskcc.org/login?url=$@",
     "location": {
       "lng": -73.95652612801905,
       "lat": 40.76602947564234
@@ -5428,7 +5428,7 @@
   },
   {
     "name": "Memorial University of Newfoundland",
-    "url": "https://qe2a-proxy.mun.ca/Login?url=",
+    "url": "https://qe2a-proxy.mun.ca/Login?url=$@",
     "location": {
       "lng": -57.6604364,
       "lat": 53.1355091
@@ -5437,7 +5437,7 @@
   },
   {
     "name": "Mercer University",
-    "url": "http://proxy-s.mercer.edu/login?url=",
+    "url": "http://proxy-s.mercer.edu/login?url=$@",
     "location": {
       "lng": -83.64969909999999,
       "lat": 32.8284878
@@ -5446,7 +5446,7 @@
   },
   {
     "name": "Mercy College",
-    "url": "http://rdas-proxy.mercy.edu:2048/login?url=",
+    "url": "http://rdas-proxy.mercy.edu:2048/login?url=$@",
     "location": {
       "lng": -73.98719830324937,
       "lat": 40.75027162459241
@@ -5455,7 +5455,7 @@
   },
   {
     "name": "Metropolitan College of New York",
-    "url": "https://ezproxy.mcny.edu/login?qurl=",
+    "url": "https://ezproxy.mcny.edu/login?qurl=$@",
     "location": {
       "lng": -74.0149887,
       "lat": 40.7085735
@@ -5464,7 +5464,7 @@
   },
   {
     "name": "Miami University Oxford Ohio",
-    "url": "http://proxy.lib.miamioh.edu/login?url=",
+    "url": "http://proxy.lib.miamioh.edu/login?url=$@",
     "location": {
       "lng": -84.73449149999999,
       "lat": 39.5087485
@@ -5473,7 +5473,7 @@
   },
   {
     "name": "Michigan State",
-    "url": "http://proxy1.cl.msu.edu/login?url=",
+    "url": "http://proxy1.cl.msu.edu/login?url=$@",
     "location": {
       "lng": -85.60236429999999,
       "lat": 44.3148443
@@ -5482,7 +5482,7 @@
   },
   {
     "name": "Michigan State University",
-    "url": "http://ezproxy.msu.edu/login?url=",
+    "url": "http://ezproxy.msu.edu/login?url=$@",
     "location": {
       "lng": -84.4821719,
       "lat": 42.701848
@@ -5491,7 +5491,7 @@
   },
   {
     "name": "Michigan Technological",
-    "url": "https://services.lib.mtu.edu/login?url=",
+    "url": "https://services.lib.mtu.edu/login?url=$@",
     "location": {
       "lng": -88.5452004,
       "lat": 47.1150259
@@ -5500,7 +5500,7 @@
   },
   {
     "name": "Mid-America Christian",
-    "url": "http://webserver.macu.edu:2048/login?url=",
+    "url": "http://webserver.macu.edu:2048/login?url=$@",
     "location": {
       "lng": -97.5784864,
       "lat": 35.3477803
@@ -5509,7 +5509,7 @@
   },
   {
     "name": "Mid-State Technical",
-    "url": "http://ezproxy.mstc.edu:2048/login?url=",
+    "url": "http://ezproxy.mstc.edu:2048/login?url=$@",
     "location": {
       "lng": -90.2095658,
       "lat": 44.666031
@@ -5518,7 +5518,7 @@
   },
   {
     "name": "Middle Tennessee State",
-    "url": "https://ezproxy.mtsu.edu:3443/login?url=",
+    "url": "https://ezproxy.mtsu.edu:3443/login?url=$@",
     "location": {
       "lng": -86.36691549999999,
       "lat": 35.8486229
@@ -5527,7 +5527,7 @@
   },
   {
     "name": "Middlebury",
-    "url": "http://ezproxy.middlebury.edu/login?url=",
+    "url": "http://ezproxy.middlebury.edu/login?url=$@",
     "location": {
       "lng": -73.16734,
       "lat": 44.0153371
@@ -5536,7 +5536,7 @@
   },
   {
     "name": "Middlesex University London",
-    "url": "http://ezproxy.mdx.ac.uk/login?url=",
+    "url": "http://ezproxy.mdx.ac.uk/login?url=$@",
     "location": {
       "lng": -0.2293488,
       "lat": 51.5897112
@@ -5545,7 +5545,7 @@
   },
   {
     "name": "Miles Community College",
-    "url": "https://library.milescc.edu:8443/login?url=",
+    "url": "https://library.milescc.edu:8443/login?url=$@",
     "location": {
       "lng": -105.8262634,
       "lat": 46.4053077
@@ -5554,7 +5554,7 @@
   },
   {
     "name": "Millersville University",
-    "url": "http://proxy-millersville.klnpa.org/login?url=",
+    "url": "http://proxy-millersville.klnpa.org/login?url=$@",
     "location": {
       "lng": -76.3527392,
       "lat": 39.9987943
@@ -5563,7 +5563,7 @@
   },
   {
     "name": "Mills College",
-    "url": "https://intra.mills.edu:2443/login?url=",
+    "url": "https://intra.mills.edu:2443/login?url=$@",
     "location": {
       "lng": -122.1825631,
       "lat": 37.78059880000001
@@ -5572,7 +5572,7 @@
   },
   {
     "name": "Millsaps",
-    "url": "http://ezproxy.millsaps.edu/login?url=",
+    "url": "http://ezproxy.millsaps.edu/login?url=$@",
     "location": {
       "lng": -90.1780014,
       "lat": 32.3223479
@@ -5581,7 +5581,7 @@
   },
   {
     "name": "Ming Chuan University ",
-    "url": "http://proxy.mcu.edu.tw/login?url=",
+    "url": "http://proxy.mcu.edu.tw/login?url=$@",
     "location": {
       "lng": 121.3423518,
       "lat": 24.9844808
@@ -5590,7 +5590,7 @@
   },
   {
     "name": "Minnesota State",
-    "url": "https://login.ezproxy.mnsu.edu/login?url=",
+    "url": "https://login.ezproxy.mnsu.edu/login?url=$@",
     "location": {
       "lng": -94.6858998,
       "lat": 46.729553
@@ -5599,7 +5599,7 @@
   },
   {
     "name": "Minot State",
-    "url": "http://ezproxy.minotstateu.edu:2048/login?url=",
+    "url": "http://ezproxy.minotstateu.edu:2048/login?url=$@",
     "location": {
       "lng": -101.3014106,
       "lat": 48.2486186
@@ -5608,7 +5608,7 @@
   },
   {
     "name": "Missouri State University",
-    "url": "http://proxy.missouristate.edu/login?url=",
+    "url": "http://proxy.missouristate.edu/login?url=$@",
     "location": {
       "lng": -93.2806806,
       "lat": 37.2005546
@@ -5617,7 +5617,7 @@
   },
   {
     "name": "Missouri University of Science and Technology",
-    "url": "http://libproxy.mst.edu:2048/login?url=",
+    "url": "http://libproxy.mst.edu:2048/login?url=$@",
     "location": {
       "lng": -91.7756271,
       "lat": 37.9537078
@@ -5626,7 +5626,7 @@
   },
   {
     "name": "MIT",
-    "url": "https://libproxy.mit.edu/cgi-bin/ezpauth?url=",
+    "url": "https://libproxy.mit.edu/cgi-bin/ezpauth?url=$@",
     "location": {
       "lng": -71.09416,
       "lat": 42.360091
@@ -5635,7 +5635,7 @@
   },
   {
     "name": "Mohawk College",
-    "url": "http://ezproxy.mohawkcollege.ca:2048/login?url=",
+    "url": "http://ezproxy.mohawkcollege.ca:2048/login?url=$@",
     "location": {
       "lng": -79.88859727632705,
       "lat": 43.24151882835353
@@ -5644,7 +5644,7 @@
   },
   {
     "name": "Molloy",
-    "url": "http://molloy.idm.oclc.org/login?url=",
+    "url": "http://molloy.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -73.6272086,
       "lat": 40.6862503
@@ -5653,7 +5653,7 @@
   },
   {
     "name": "Monash University",
-    "url": "http://ezproxy.lib.monash.edu.au/login?url=",
+    "url": "http://ezproxy.lib.monash.edu.au/login?url=$@",
     "location": {
       "lng": 145.1346592,
       "lat": -37.9142416
@@ -5662,7 +5662,7 @@
   },
   {
     "name": "Montana State",
-    "url": "http://proxybz.lib.montana.edu/login?url=",
+    "url": "http://proxybz.lib.montana.edu/login?url=$@",
     "location": {
       "lng": -110.3625658,
       "lat": 46.8796822
@@ -5671,7 +5671,7 @@
   },
   {
     "name": "Montgomery",
-    "url": "https://montgomerycollege.idm.oclc.org/login?url=",
+    "url": "https://montgomerycollege.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -86.3077368,
       "lat": 32.3792233
@@ -5680,7 +5680,7 @@
   },
   {
     "name": "Montgomery County",
-    "url": "https://ezproxy.mc3.edu/login?url=",
+    "url": "https://ezproxy.mc3.edu/login?url=$@",
     "location": {
       "lng": -77.2405153,
       "lat": 39.1547426
@@ -5689,7 +5689,7 @@
   },
   {
     "name": "Monticello",
-    "url": "https://tjportal.idm.oclc.org/login?url=",
+    "url": "https://tjportal.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -78.4531994,
       "lat": 38.0086043
@@ -5698,7 +5698,7 @@
   },
   {
     "name": "Morgan Community College",
-    "url": "http://ezproxy.morgancc.edu:2048/login?url=",
+    "url": "http://ezproxy.morgancc.edu:2048/login?url=$@",
     "location": {
       "lng": -103.77592475860006,
       "lat": 40.259184164619775
@@ -5707,7 +5707,7 @@
   },
   {
     "name": "Morningside",
-    "url": "http://ezproxy.morningside.edu:2048/login?url=",
+    "url": "http://ezproxy.morningside.edu:2048/login?url=$@",
     "location": {
       "lng": -96.3584236,
       "lat": 42.4731744
@@ -5716,7 +5716,7 @@
   },
   {
     "name": "Morrisville State",
-    "url": "http://ezproxy.librarylinks.morrisville.edu:2048/login?url=",
+    "url": "http://ezproxy.librarylinks.morrisville.edu:2048/login?url=$@",
     "location": {
       "lng": -75.6401825,
       "lat": 42.8986791
@@ -5725,7 +5725,7 @@
   },
   {
     "name": "Mount Allison University",
-    "url": "https://login.libproxy.mta.ca/login?url=",
+    "url": "https://login.libproxy.mta.ca/login?url=$@",
     "location": {
       "lng": -64.3731482,
       "lat": 45.8983431
@@ -5734,7 +5734,7 @@
   },
   {
     "name": "Mount Holyoke",
-    "url": "http://proxy.mtholyoke.edu:2048/login?url=",
+    "url": "http://proxy.mtholyoke.edu:2048/login?url=$@",
     "location": {
       "lng": -72.5728843,
       "lat": 42.255425
@@ -5743,7 +5743,7 @@
   },
   {
     "name": "Mount Royal",
-    "url": "http://library.mtroyal.ca:2048/login?url=",
+    "url": "http://library.mtroyal.ca:2048/login?url=$@",
     "location": {
       "lng": -73.5874072,
       "lat": 45.5071024
@@ -5752,7 +5752,7 @@
   },
   {
     "name": "Mount Royal University",
-    "url": "https://login.libproxy.mtroyal.ca/login?qurl=",
+    "url": "https://login.libproxy.mtroyal.ca/login?qurl=$@",
     "location": {
       "lng": -114.1318513,
       "lat": 51.01113609999999
@@ -5761,7 +5761,7 @@
   },
   {
     "name": "Mount Saint Marys",
-    "url": "https://msm.idm.oclc.org/login?url=",
+    "url": "https://msm.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -77.3486971,
       "lat": 39.6799914
@@ -5770,7 +5770,7 @@
   },
   {
     "name": "MPI for Human Development Berlin",
-    "url": "http://ezproxy.mpib-berlin.mpg.de/login?url=",
+    "url": "http://ezproxy.mpib-berlin.mpg.de/login?url=$@",
     "location": {
       "lng": 13.303832,
       "lat": 52.468554
@@ -5779,7 +5779,7 @@
   },
   {
     "name": "Mt. Sinai School of Medicine (NYU)",
-    "url": "http://eresources.library.mssm.edu:2048/login?url=",
+    "url": "http://eresources.library.mssm.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9531097,
       "lat": 40.7897148
@@ -5788,7 +5788,7 @@
   },
   {
     "name": "Mt.San Antonio College",
-    "url": "https://libris.mtsac.edu/login?url=",
+    "url": "https://libris.mtsac.edu/login?url=$@",
     "location": {
       "lng": -117.8421321,
       "lat": 34.0487487
@@ -5797,7 +5797,7 @@
   },
   {
     "name": "Muhlenberg",
-    "url": "http://muhlenberg.idm.oclc.org/login?url=",
+    "url": "http://muhlenberg.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -75.5081076,
       "lat": 40.5981933
@@ -5806,7 +5806,7 @@
   },
   {
     "name": "Munich University of Applied Sciences",
-    "url": "https://ezproxy.bib.hm.edu/login?url=",
+    "url": "https://ezproxy.bib.hm.edu/login?url=$@",
     "location": {
       "lng": 11.5527259,
       "lat": 48.1534199
@@ -5815,7 +5815,7 @@
   },
   {
     "name": "Murray State University",
-    "url": "https://ezproxy.waterfield.murraystate.edu/login?url=",
+    "url": "https://ezproxy.waterfield.murraystate.edu/login?url=$@",
     "location": {
       "lng": -88.3209372,
       "lat": 36.616251
@@ -5824,7 +5824,7 @@
   },
   {
     "name": "Mälardalens universitet",
-    "url": "https://ep.bib.mdh.se/login?url=",
+    "url": "https://ep.bib.mdh.se/login?url=$@",
     "location": {
       "lng": 16.5407143,
       "lat": 59.61857819999999
@@ -5833,7 +5833,7 @@
   },
   {
     "name": "Médiathèques FM6",
-    "url": "http://proxy.mediatheque-fm6.ma/login?url=",
+    "url": "http://proxy.mediatheque-fm6.ma/login?url=$@",
     "location": {
       "lng": -5.818574505466633,
       "lat": 35.77789186557232
@@ -5842,7 +5842,7 @@
   },
   {
     "name": "Nacionalna i sveucilisna knjiznica u Zagrebu",
-    "url": "http://ezproxy.nsk.hr/login?url=",
+    "url": "http://ezproxy.nsk.hr/login?url=$@",
     "location": {
       "lng": 15.9775578,
       "lat": 45.7966353
@@ -5851,7 +5851,7 @@
   },
   {
     "name": "Nagoya",
-    "url": "http://ejgw.nul.nagoya-u.ac.jp/login?url=",
+    "url": "http://ejgw.nul.nagoya-u.ac.jp/login?url=$@",
     "location": {
       "lng": 136.9065571,
       "lat": 35.18145060000001
@@ -5860,7 +5860,7 @@
   },
   {
     "name": "Nanyang Technological",
-    "url": "http://ezlibproxy1.ntu.edu.sg/login?url=",
+    "url": "http://ezlibproxy1.ntu.edu.sg/login?url=$@",
     "location": {
       "lng": 103.6831347,
       "lat": 1.3483099
@@ -5869,7 +5869,7 @@
   },
   {
     "name": "Nanyang Technological University",
-    "url": "https://remotexs.ntu.edu.sg/user/login?dest=",
+    "url": "https://remotexs.ntu.edu.sg/user/login?dest=$@",
     "location": {
       "lng": 103.6831347,
       "lat": 1.3483099
@@ -5878,7 +5878,7 @@
   },
   {
     "name": "Naropa",
-    "url": "http://ezproxy.naropa.edu:2048/login?url=",
+    "url": "http://ezproxy.naropa.edu:2048/login?url=$@",
     "location": {
       "lng": -105.2670571,
       "lat": 40.0142329
@@ -5887,7 +5887,7 @@
   },
   {
     "name": "Nashua",
-    "url": "https://ezproxyncc.ccsnh.edu/login?url=",
+    "url": "https://ezproxyncc.ccsnh.edu/login?url=$@",
     "location": {
       "lng": -71.46756599999999,
       "lat": 42.7653662
@@ -5896,7 +5896,7 @@
   },
   {
     "name": "National Cancer Institute",
-    "url": "http://ezlib.ncifcrf.gov/login?url=",
+    "url": "http://ezlib.ncifcrf.gov/login?url=$@",
     "location": {
       "lng": -77.43460436628231,
       "lat": 39.43532429492162
@@ -5905,7 +5905,7 @@
   },
   {
     "name": "National Central University, Taiwan",
-    "url": "https://ezproxy.lib.ncu.edu.tw/login?url=",
+    "url": "https://ezproxy.lib.ncu.edu.tw/login?url=$@",
     "location": {
       "lng": 121.1952988,
       "lat": 24.9681558
@@ -5914,7 +5914,7 @@
   },
   {
     "name": "National College of Natural Medicine",
-    "url": "http://ncnm.idm.oclc.org/login?url=",
+    "url": "http://ncnm.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.6764952,
       "lat": 45.5018378
@@ -5923,7 +5923,7 @@
   },
   {
     "name": "National Endowment for Democracy",
-    "url": "https://login.ned.idm.oclc.org/login?url=",
+    "url": "https://login.ned.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -77.02861097284573,
       "lat": 38.89590383968619
@@ -5932,7 +5932,7 @@
   },
   {
     "name": "National Institute of Standards & Technology",
-    "url": "https://nist.idm.oclc.org/login?url=",
+    "url": "https://nist.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -77.21849422151341,
       "lat": 39.140354778103784
@@ -5941,7 +5941,7 @@
   },
   {
     "name": "National Institutes of Health",
-    "url": "http://ezproxy.nihlibrary.nih.gov/login?url=",
+    "url": "http://ezproxy.nihlibrary.nih.gov/login?url=$@",
     "location": {
       "lng": -77.10454978367835,
       "lat": 39.00308529679233
@@ -5950,7 +5950,7 @@
   },
   {
     "name": "National Louis University (Kendall)",
-    "url": "http://ezp.kendall.edu/login?url=",
+    "url": "http://ezp.kendall.edu/login?url=$@",
     "location": {
       "lng": -87.62463814448434,
       "lat": 41.880522223965656
@@ -5959,7 +5959,7 @@
   },
   {
     "name": "National Research Council Canada",
-    "url": "https://login.pass.cisti-icist.nrc-cnrc.gc.ca/login?url=",
+    "url": "https://login.pass.cisti-icist.nrc-cnrc.gc.ca/login?url=$@",
     "location": {
       "lng": -106.346771,
       "lat": 56.130366
@@ -5968,7 +5968,7 @@
   },
   {
     "name": "National Sun Yat-sen",
-    "url": "http://ezproxy.lib.nsysu.edu.tw:8080/login?url=",
+    "url": "http://ezproxy.lib.nsysu.edu.tw:8080/login?url=$@",
     "location": {
       "lng": 120.2647299,
       "lat": 22.6283384
@@ -5977,7 +5977,7 @@
   },
   {
     "name": "National Taichung University of Science and Technology",
-    "url": "http://libsw.nutc.edu.tw:2048/login?url=",
+    "url": "http://libsw.nutc.edu.tw:2048/login?url=$@",
     "location": {
       "lng": 120.6837712,
       "lat": 24.1497433
@@ -5986,7 +5986,7 @@
   },
   {
     "name": "National Taipei University",
-    "url": "http://sw.library.ntpu.edu.tw:81/login?url=",
+    "url": "http://sw.library.ntpu.edu.tw:81/login?url=$@",
     "location": {
       "lng": 121.3709602,
       "lat": 24.9440905
@@ -5995,7 +5995,7 @@
   },
   {
     "name": "National Tsing Hua University",
-    "url": "https://nthulib-oc.nthu.edu.tw/login?url=",
+    "url": "https://nthulib-oc.nthu.edu.tw/login?url=$@",
     "location": {
       "lng": 120.9966699,
       "lat": 24.7961217
@@ -6004,7 +6004,7 @@
   },
   {
     "name": "National University of Colombia",
-    "url": "https://login.ezproxy.unal.edu.co/login?url=",
+    "url": "https://login.ezproxy.unal.edu.co/login?url=$@",
     "location": {
       "lng": -74.08404639999999,
       "lat": 4.6381938
@@ -6013,7 +6013,7 @@
   },
   {
     "name": "National University of Ireland, Galway",
-    "url": "https://nuigalway.idm.oclc.org/login?url=",
+    "url": "https://nuigalway.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -9.0617372,
       "lat": 53.27915489999999
@@ -6022,7 +6022,7 @@
   },
   {
     "name": "National University of Kaohsiung",
-    "url": "http://libsw.nuk.edu.tw/login?url=",
+    "url": "http://libsw.nuk.edu.tw/login?url=$@",
     "location": {
       "lng": 120.2845572,
       "lat": 22.7333814
@@ -6031,7 +6031,7 @@
   },
   {
     "name": "National University of Natural Medicine",
-    "url": "https://nunm.idm.oclc.org/login?url=",
+    "url": "https://nunm.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.6764952,
       "lat": 45.5018378
@@ -6040,7 +6040,7 @@
   },
   {
     "name": "National University of Singapore",
-    "url": "http://libproxy1.nus.edu.sg/login?url=",
+    "url": "http://libproxy1.nus.edu.sg/login?url=$@",
     "location": {
       "lng": 103.7763939,
       "lat": 1.2966426
@@ -6049,7 +6049,7 @@
   },
   {
     "name": "National Yang Ming Chiao Tung Univeristy",
-    "url": "https://ezproxy.lib.nctu.edu.tw/login?url=",
+    "url": "https://ezproxy.lib.nctu.edu.tw/login?url=$@",
     "location": {
       "lng": 120.9974969,
       "lat": 24.7868862
@@ -6058,7 +6058,7 @@
   },
   {
     "name": "National Yang-Ming",
-    "url": "http://ezproxy.lib.ym.edu.tw/login?url=",
+    "url": "http://ezproxy.lib.ym.edu.tw/login?url=$@",
     "location": {
       "lng": 120.9974969,
       "lat": 24.7868862
@@ -6067,7 +6067,7 @@
   },
   {
     "name": "Naval Postgraduate School",
-    "url": "http://libproxy.nps.edu/login?url=",
+    "url": "http://libproxy.nps.edu/login?url=$@",
     "location": {
       "lng": -121.8741343,
       "lat": 36.5968995
@@ -6076,7 +6076,7 @@
   },
   {
     "name": "Navitas Professional Institute",
-    "url": "https://ezproxy.navitas.com/login?url=",
+    "url": "https://ezproxy.navitas.com/login?url=$@",
     "location": {
       "lng": 115.85499447386246,
       "lat": -31.954140310146638
@@ -6085,7 +6085,7 @@
   },
   {
     "name": "Nazarbayev University",
-    "url": "http://ezproxy.nu.edu.kz:2048/login?url=",
+    "url": "http://ezproxy.nu.edu.kz:2048/login?url=$@",
     "location": {
       "lng": 71.3981646,
       "lat": 51.0905303
@@ -6094,7 +6094,7 @@
   },
   {
     "name": "Nebraska Wesleyan",
-    "url": "https://login.thor.nebrwesleyan.edu/login?url=",
+    "url": "https://login.thor.nebrwesleyan.edu/login?url=$@",
     "location": {
       "lng": -96.6509439,
       "lat": 40.838785
@@ -6103,7 +6103,7 @@
   },
   {
     "name": "Nelson Marlborough Institute of Technology",
-    "url": "http://llcp.nmit.ac.nz:2048/login?url=",
+    "url": "http://llcp.nmit.ac.nz:2048/login?url=$@",
     "location": {
       "lng": 173.2885334,
       "lat": -41.2753759
@@ -6112,7 +6112,7 @@
   },
   {
     "name": "Neosho County",
-    "url": "http://ezproxy.neosho.edu:2048/login?url=",
+    "url": "http://ezproxy.neosho.edu:2048/login?url=$@",
     "location": {
       "lng": -95.3102505,
       "lat": 37.6045688
@@ -6121,7 +6121,7 @@
   },
   {
     "name": "Netherlands Institute of Ecology (NIOO-KNAW)",
-    "url": "http://ezproxy.nioo.knaw.nl/login?url=",
+    "url": "http://ezproxy.nioo.knaw.nl/login?url=$@",
     "location": {
       "lng": 5.6711618,
       "lat": 51.9869795
@@ -6130,7 +6130,7 @@
   },
   {
     "name": "Nevada State",
-    "url": "http://ozone.nsc.edu:8080/login?url=",
+    "url": "http://ozone.nsc.edu:8080/login?url=$@",
     "location": {
       "lng": -116.419389,
       "lat": 38.8026097
@@ -6139,7 +6139,7 @@
   },
   {
     "name": "New Jersey City",
-    "url": "http://draweb.njcu.edu:2048/login?url=",
+    "url": "http://draweb.njcu.edu:2048/login?url=$@",
     "location": {
       "lng": -74.0431435,
       "lat": 40.7177545
@@ -6148,7 +6148,7 @@
   },
   {
     "name": "New Jersey Institute of Technology",
-    "url": "http://libdb.njit.edu:8888/login?url=",
+    "url": "http://libdb.njit.edu:8888/login?url=$@",
     "location": {
       "lng": -74.1793225,
       "lat": 40.7423462
@@ -6157,7 +6157,7 @@
   },
   {
     "name": "New Mexico Highlands",
-    "url": "http://donnelly.nmhu.edu:2048/login?url=",
+    "url": "http://donnelly.nmhu.edu:2048/login?url=$@",
     "location": {
       "lng": -105.2192167,
       "lat": 35.5962101
@@ -6166,7 +6166,7 @@
   },
   {
     "name": "New Mexico Junior",
-    "url": "http://ezproxy.nmjc.edu:2048/login?url=",
+    "url": "http://ezproxy.nmjc.edu:2048/login?url=$@",
     "location": {
       "lng": -103.181831,
       "lat": 32.759944
@@ -6175,7 +6175,7 @@
   },
   {
     "name": "New Mexico State University",
-    "url": "http://libezp.nmsu.edu:2048/login?url=",
+    "url": "http://libezp.nmsu.edu:2048/login?url=$@",
     "location": {
       "lng": -106.7491391,
       "lat": 32.2792887
@@ -6184,7 +6184,7 @@
   },
   {
     "name": "New River Community and Technical",
-    "url": "http://nrproxy.newriver.edu/login?url=",
+    "url": "http://nrproxy.newriver.edu/login?url=$@",
     "location": {
       "lng": -81.1357293,
       "lat": 37.7674765
@@ -6193,7 +6193,7 @@
   },
   {
     "name": "New York Chiropractic",
-    "url": "http://ezproxy.nycc.edu:2048/login?url=",
+    "url": "http://ezproxy.nycc.edu:2048/login?url=$@",
     "location": {
       "lng": -74.0059728,
       "lat": 40.7127753
@@ -6202,7 +6202,7 @@
   },
   {
     "name": "New York College of Podiatric Medicine",
-    "url": "https://nycpm.idm.oclc.org/login?url=",
+    "url": "https://nycpm.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -73.9403658,
       "lat": 40.8049519
@@ -6211,7 +6211,7 @@
   },
   {
     "name": "New York Institute of Technology",
-    "url": "http://arktos.nyit.edu/login?url=",
+    "url": "http://arktos.nyit.edu/login?url=$@",
     "location": {
       "lng": -73.6033947070762,
       "lat": 40.817338995275186
@@ -6220,7 +6220,7 @@
   },
   {
     "name": "New York Public Library",
-    "url": "https://login.i.ezproxy.nypl.org/login?qurl=",
+    "url": "https://login.i.ezproxy.nypl.org/login?qurl=$@",
     "location": {
       "lng": -74.0059728,
       "lat": 40.7127753
@@ -6229,7 +6229,7 @@
   },
   {
     "name": "New York University (NYU)",
-    "url": "https://ezproxy.library.nyu.edu/login?url=",
+    "url": "https://ezproxy.library.nyu.edu/login?url=$@",
     "location": {
       "lng": -73.9964609,
       "lat": 40.72951339999999
@@ -6238,7 +6238,7 @@
   },
   {
     "name": "Newcastle University",
-    "url": "http://libproxy.ncl.ac.uk/login?url=",
+    "url": "http://libproxy.ncl.ac.uk/login?url=$@",
     "location": {
       "lng": -1.6147156868252108,
       "lat": 54.97932243520263
@@ -6247,7 +6247,7 @@
   },
   {
     "name": "Niagara",
-    "url": "http://ezproxy.niagara.edu:2048/login?url=",
+    "url": "http://ezproxy.niagara.edu:2048/login?url=$@",
     "location": {
       "lng": -79.07416289999999,
       "lat": 43.0828162
@@ -6256,7 +6256,7 @@
   },
   {
     "name": "Nipissing University",
-    "url": "http://roxy.nipissingu.ca/login?url=",
+    "url": "http://roxy.nipissingu.ca/login?url=$@",
     "location": {
       "lng": -79.49083460000001,
       "lat": 46.3410121
@@ -6265,7 +6265,7 @@
   },
   {
     "name": "NMIMS",
-    "url": "https://ezproxy.svkm.ac.in/login?url=",
+    "url": "https://ezproxy.svkm.ac.in/login?url=$@",
     "location": {
       "lng": 72.83659879999999,
       "lat": 19.1033037
@@ -6274,7 +6274,7 @@
   },
   {
     "name": "Noble and Greenough School",
-    "url": "https://ezproxy.nobles.edu/login?url=",
+    "url": "https://ezproxy.nobles.edu/login?url=$@",
     "location": {
       "lng": -71.18503494443523,
       "lat": 42.262370254761706
@@ -6283,7 +6283,7 @@
   },
   {
     "name": "North Carolina A&T State University",
-    "url": "http://ncat.idm.oclc.org/login?url=",
+    "url": "http://ncat.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -79.01929969999999,
       "lat": 35.7595731
@@ -6292,7 +6292,7 @@
   },
   {
     "name": "North Carolina State University",
-    "url": "http://proxying.lib.ncsu.edu/index.php?url=",
+    "url": "http://proxying.lib.ncsu.edu/index.php?url=$@",
     "location": {
       "lng": -78.6820946,
       "lat": 35.7846633
@@ -6301,7 +6301,7 @@
   },
   {
     "name": "North Central Texas College",
-    "url": "http://www.ezproxy.nctc.edu/login?url=",
+    "url": "http://www.ezproxy.nctc.edu/login?url=$@",
     "location": {
       "lng": -97.16594049999999,
       "lat": 33.6187918
@@ -6310,7 +6310,7 @@
   },
   {
     "name": "North Central University",
-    "url": "https://ezproxy.northcentral.edu/login?url=",
+    "url": "https://ezproxy.northcentral.edu/login?url=$@",
     "location": {
       "lng": -93.26217525999988,
       "lat": 44.968981873484374
@@ -6319,7 +6319,7 @@
   },
   {
     "name": "North Dakota State University",
-    "url": "https://ezproxy.lib.ndsu.nodak.edu/login?url=",
+    "url": "https://ezproxy.lib.ndsu.nodak.edu/login?url=$@",
     "location": {
       "lng": -96.8024367,
       "lat": 46.8977528
@@ -6328,7 +6328,7 @@
   },
   {
     "name": "North Idaho",
-    "url": "http://ezproxy1.nic.edu:2048/login?url=",
+    "url": "http://ezproxy1.nic.edu:2048/login?url=$@",
     "location": {
       "lng": -117.0018462,
       "lat": 46.4152745
@@ -6337,7 +6337,7 @@
   },
   {
     "name": "North Iowa Area",
-    "url": "http://ezproxy.niacc.edu:2048/login?url=",
+    "url": "http://ezproxy.niacc.edu:2048/login?url=$@",
     "location": {
       "lng": -93.13282079999999,
       "lat": 43.156929
@@ -6346,7 +6346,7 @@
   },
   {
     "name": "North-West University",
-    "url": "http://nwulib.nwu.ac.za/login?url=",
+    "url": "http://nwulib.nwu.ac.za/login?url=$@",
     "location": {
       "lng": 27.0928977,
       "lat": -26.6906445
@@ -6355,7 +6355,7 @@
   },
   {
     "name": "Northeast Texas",
-    "url": "http://unicorn.ntcc.edu:2048/login?url=",
+    "url": "http://unicorn.ntcc.edu:2048/login?url=$@",
     "location": {
       "lng": -94.75097939999999,
       "lat": 32.4990747
@@ -6364,7 +6364,7 @@
   },
   {
     "name": "Northeast Wisconsin Technical",
-    "url": "http://ezproxy.nwtc.edu:2048/login?url=",
+    "url": "http://ezproxy.nwtc.edu:2048/login?url=$@",
     "location": {
       "lng": -88.10732639999999,
       "lat": 44.5272605
@@ -6373,7 +6373,7 @@
   },
   {
     "name": "Northeastern Illinois",
-    "url": "http://neiulibrary.idm.oclc.org/login?url=",
+    "url": "http://neiulibrary.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -87.7188527,
       "lat": 41.9794789
@@ -6382,7 +6382,7 @@
   },
   {
     "name": "Northeastern University",
-    "url": "http://ezproxy.neu.edu/login?URL=",
+    "url": "http://ezproxy.neu.edu/login?URL=$@",
     "location": {
       "lng": -71.0891717,
       "lat": 42.3398067
@@ -6391,7 +6391,7 @@
   },
   {
     "name": "Northern Arizona",
-    "url": "http://libproxy.nau.edu/login?url=",
+    "url": "http://libproxy.nau.edu/login?url=$@",
     "location": {
       "lng": -111.6540336,
       "lat": 35.1802684
@@ -6400,7 +6400,7 @@
   },
   {
     "name": "Northern Kentucky",
-    "url": "http://proxy1.nku.edu/login?url=",
+    "url": "http://proxy1.nku.edu/login?url=$@",
     "location": {
       "lng": -84.4625345,
       "lat": 39.0312035
@@ -6409,7 +6409,7 @@
   },
   {
     "name": "Northern Kentucky University",
-    "url": "https://ezproxy.lib.nku.edu/login?url=",
+    "url": "https://ezproxy.lib.nku.edu/login?url=$@",
     "location": {
       "lng": -84.4625345,
       "lat": 39.0312035
@@ -6418,7 +6418,7 @@
   },
   {
     "name": "Northern Michigan",
-    "url": "http://ezpolson.nmu.edu:2048/login?url=",
+    "url": "http://ezpolson.nmu.edu:2048/login?url=$@",
     "location": {
       "lng": -87.4076051,
       "lat": 46.5601965
@@ -6427,7 +6427,7 @@
   },
   {
     "name": "Northern Ontario School of Medicine",
-    "url": "http://normedproxy.lakeheadu.ca/login?URL=",
+    "url": "http://normedproxy.lakeheadu.ca/login?URL=$@",
     "location": {
       "lng": -80.9640026,
       "lat": 46.463603
@@ -6436,7 +6436,7 @@
   },
   {
     "name": "Northern Ontario School of Medicine (NOSM)",
-    "url": "https://proxy.lib.nosm.ca/login?url=",
+    "url": "https://proxy.lib.nosm.ca/login?url=$@",
     "location": {
       "lng": -80.9640026,
       "lat": 46.463603
@@ -6445,7 +6445,7 @@
   },
   {
     "name": "Northern Territory Health Library",
-    "url": "https://login.www.ezpdhcs.nt.gov.au/login?url=",
+    "url": "https://login.www.ezpdhcs.nt.gov.au/login?url=$@",
     "location": {
       "lng": 132.5509603,
       "lat": -19.4914108
@@ -6454,7 +6454,7 @@
   },
   {
     "name": "Northwest Mississippi",
-    "url": "http://ezproxy.northwestms.edu:2048/login?url=",
+    "url": "http://ezproxy.northwestms.edu:2048/login?url=$@",
     "location": {
       "lng": -89.96948119999999,
       "lat": 34.6254741
@@ -6463,7 +6463,7 @@
   },
   {
     "name": "Northwest Missouri State",
-    "url": "http://ezproxy.nwmissouri.edu:2048/login?url=",
+    "url": "http://ezproxy.nwmissouri.edu:2048/login?url=$@",
     "location": {
       "lng": -94.8825243,
       "lat": 40.3519854
@@ -6472,7 +6472,7 @@
   },
   {
     "name": "Northwestern",
-    "url": "http://ezproxy.galter.northwestern.edu/login?url=",
+    "url": "http://ezproxy.galter.northwestern.edu/login?url=$@",
     "location": {
       "lng": -87.67526699999999,
       "lat": 42.0564594
@@ -6481,7 +6481,7 @@
   },
   {
     "name": "Northwestern Michigan",
-    "url": "https://login.proxy.nmc.edu/login?url=",
+    "url": "https://login.proxy.nmc.edu/login?url=$@",
     "location": {
       "lng": -85.5824341,
       "lat": 44.7659019
@@ -6490,7 +6490,7 @@
   },
   {
     "name": "Northwestern State University of Louisiana",
-    "url": "http://ezproxy.nsula.edu/login?url=",
+    "url": "http://ezproxy.nsula.edu/login?url=$@",
     "location": {
       "lng": -93.097876,
       "lat": 31.7489726
@@ -6499,7 +6499,7 @@
   },
   {
     "name": "Northwestern University",
-    "url": "http://turing.library.northwestern.edu/login?url=",
+    "url": "http://turing.library.northwestern.edu/login?url=$@",
     "location": {
       "lng": -87.67526699999999,
       "lat": 42.0564594
@@ -6508,7 +6508,7 @@
   },
   {
     "name": "Norwegian School of Economics",
-    "url": "https://ezproxy.nhh.no/login?url=",
+    "url": "https://ezproxy.nhh.no/login?url=$@",
     "location": {
       "lng": 5.3024087,
       "lat": 60.42293759999999
@@ -6517,7 +6517,7 @@
   },
   {
     "name": "Norwich",
-    "url": "http://library.norwich.edu/login?url=",
+    "url": "http://library.norwich.edu/login?url=$@",
     "location": {
       "lng": 1.2978802,
       "lat": 52.6292567
@@ -6526,7 +6526,7 @@
   },
   {
     "name": "Notre Dame",
-    "url": "http://proxy.library.nd.edu/login?url=",
+    "url": "http://proxy.library.nd.edu/login?url=$@",
     "location": {
       "lng": 2.3499021,
       "lat": 48.85296820000001
@@ -6535,7 +6535,7 @@
   },
   {
     "name": "Notre Dame University-Louaize",
-    "url": "http://http://neptune.ndu.edu.lb:2048/login?url=",
+    "url": "http://http://neptune.ndu.edu.lb:2048/login?url=$@",
     "location": {
       "lng": 35.6151545,
       "lat": 33.9506781
@@ -6544,7 +6544,7 @@
   },
   {
     "name": "Nottingham Trent University",
-    "url": "http://ntu.idm.oclc.org/login?url=",
+    "url": "http://ntu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -1.1542327,
       "lat": 52.9581371
@@ -6553,7 +6553,7 @@
   },
   {
     "name": "Nova Southeastern",
-    "url": "http://ezproxylocal.library.nova.edu/login?url=",
+    "url": "http://ezproxylocal.library.nova.edu/login?url=$@",
     "location": {
       "lng": -80.2457075,
       "lat": 26.0786011
@@ -6562,7 +6562,7 @@
   },
   {
     "name": "Nova Southeastern University",
-    "url": "https://sherman.library.nova.edu/auth/index.php?qurl=",
+    "url": "https://sherman.library.nova.edu/auth/index.php?qurl=$@",
     "location": {
       "lng": -80.2457075,
       "lat": 26.0786011
@@ -6571,7 +6571,7 @@
   },
   {
     "name": "Nunez Community College",
-    "url": "https://nunez.idm.oclc.org/login?url=",
+    "url": "https://nunez.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -89.96083921920405,
       "lat": 29.954783117551013
@@ -6580,7 +6580,7 @@
   },
   {
     "name": "NYU Alumni",
-    "url": "http://alumniproxy.library.nyu.edu/login?url=",
+    "url": "http://alumniproxy.library.nyu.edu/login?url=$@",
     "location": {
       "lng": -73.9964609,
       "lat": 40.72951339999999
@@ -6589,7 +6589,7 @@
   },
   {
     "name": "NYU Medical",
-    "url": "https://ezproxy.med.nyu.edu/login?url=",
+    "url": "https://ezproxy.med.nyu.edu/login?url=$@",
     "location": {
       "lng": -73.9964609,
       "lat": 40.72951339999999
@@ -6598,7 +6598,7 @@
   },
   {
     "name": "Národní technická knihovna",
-    "url": "https://ezproxy.techlib.cz/login/?url=",
+    "url": "https://ezproxy.techlib.cz/login/?url=$@",
     "location": {
       "lng": 14.3906537,
       "lat": 50.1038974
@@ -6607,7 +6607,7 @@
   },
   {
     "name": "Oak Ridge National Laboratory",
-    "url": "http://orproxy.lib.utk.edu:2048/login?url=",
+    "url": "http://orproxy.lib.utk.edu:2048/login?url=$@",
     "location": {
       "lng": -84.3101161,
       "lat": 35.9311679
@@ -6616,7 +6616,7 @@
   },
   {
     "name": "Oakland Public Library",
-    "url": "http://opl.idm.oclc.org/login?url=",
+    "url": "http://opl.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.26378808263769,
       "lat": 37.80113784781194
@@ -6625,7 +6625,7 @@
   },
   {
     "name": "Oakland University William Beaumont SOM",
-    "url": "https://huaryu.kl.oakland.edu/login?url=",
+    "url": "https://huaryu.kl.oakland.edu/login?url=$@",
     "location": {
       "lng": -83.2152964,
       "lat": 42.6744905
@@ -6634,7 +6634,7 @@
   },
   {
     "name": "Oakton",
-    "url": "http://oaktonlibrary.oakton.edu:2048/login?url=",
+    "url": "http://oaktonlibrary.oakton.edu:2048/login?url=$@",
     "location": {
       "lng": -77.3008172,
       "lat": 38.8809451
@@ -6643,7 +6643,7 @@
   },
   {
     "name": "Oakwood University",
-    "url": "http://www.oakwood.edu:2048/login?url=",
+    "url": "http://www.oakwood.edu:2048/login?url=$@",
     "location": {
       "lng": -86.65561848524791,
       "lat": 34.75229782171196
@@ -6652,7 +6652,7 @@
   },
   {
     "name": "Oberlin",
-    "url": "http://ezproxy.oberlin.edu/login?url=",
+    "url": "http://ezproxy.oberlin.edu/login?url=$@",
     "location": {
       "lng": -82.21737859999999,
       "lat": 41.2939386
@@ -6661,7 +6661,7 @@
   },
   {
     "name": "Observatoire de Paris",
-    "url": "http://ezproxy.obspm.fr/login?url=",
+    "url": "http://ezproxy.obspm.fr/login?url=$@",
     "location": {
       "lng": 2.334253,
       "lat": 48.83596530000001
@@ -6670,7 +6670,7 @@
   },
   {
     "name": "OCAD",
-    "url": "https://ocadu.idm.oclc.org/login?url=",
+    "url": "https://ocadu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -79.3914842,
       "lat": 43.65318449999999
@@ -6679,7 +6679,7 @@
   },
   {
     "name": "Ohio",
-    "url": "http://proxy.library.ohiou.edu/login?url=",
+    "url": "http://proxy.library.ohiou.edu/login?url=$@",
     "location": {
       "lng": -82.90712300000001,
       "lat": 40.4172871
@@ -6688,7 +6688,7 @@
   },
   {
     "name": "Ohio State University",
-    "url": "https://proxy.lib.ohio-state.edu/login?url=",
+    "url": "https://proxy.lib.ohio-state.edu/login?url=$@",
     "location": {
       "lng": -83.0304546,
       "lat": 40.0066723
@@ -6697,7 +6697,7 @@
   },
   {
     "name": "OhioLink",
-    "url": "http://proxy.ohiolink.edu:9099/login?url=",
+    "url": "http://proxy.ohiolink.edu:9099/login?url=$@",
     "location": {
       "lng": -83.04053266136894,
       "lat": 40.00012431476218
@@ -6706,7 +6706,7 @@
   },
   {
     "name": "Okinawa Institute of Science and Technology",
-    "url": "https://login.ezproxy.oist.jp/login?url=",
+    "url": "https://login.ezproxy.oist.jp/login?url=$@",
     "location": {
       "lng": 127.8301869,
       "lat": 26.4643027
@@ -6715,7 +6715,7 @@
   },
   {
     "name": "Oklahoma Baptist",
-    "url": "http://ezproxy.okbu.edu:2048/login?url=",
+    "url": "http://ezproxy.okbu.edu:2048/login?url=$@",
     "location": {
       "lng": -96.93511160000001,
       "lat": 35.3614905
@@ -6724,7 +6724,7 @@
   },
   {
     "name": "Oklahoma Christian",
-    "url": "http://proxy.oc.edu:2048/login?url=",
+    "url": "http://proxy.oc.edu:2048/login?url=$@",
     "location": {
       "lng": -97.4697937,
       "lat": 35.6126232
@@ -6733,7 +6733,7 @@
   },
   {
     "name": "Oklahoma State",
-    "url": "https://login.argo.library.okstate.edu/login?url=",
+    "url": "https://login.argo.library.okstate.edu/login?url=$@",
     "location": {
       "lng": -97.092877,
       "lat": 35.0077519
@@ -6742,7 +6742,7 @@
   },
   {
     "name": "Oklahoma State University Tulsa",
-    "url": "http://ezproxy.osu-tulsa.okstate.edu/login?url=",
+    "url": "http://ezproxy.osu-tulsa.okstate.edu/login?url=$@",
     "location": {
       "lng": -95.9880553,
       "lat": 36.1638478
@@ -6751,7 +6751,7 @@
   },
   {
     "name": "Old Dominion University",
-    "url": "http://proxy.lib.odu.edu/login?url=",
+    "url": "http://proxy.lib.odu.edu/login?url=$@",
     "location": {
       "lng": -76.3058786,
       "lat": 36.8853217
@@ -6760,7 +6760,7 @@
   },
   {
     "name": "Olympic College",
-    "url": "http://ezproxy.olympic.edu:2048/login?url=",
+    "url": "http://ezproxy.olympic.edu:2048/login?url=$@",
     "location": {
       "lng": -122.63518312430871,
       "lat": 47.575379406817625
@@ -6769,7 +6769,7 @@
   },
   {
     "name": "Open Polytechnic",
-    "url": "http://campus-gw.openpolytechnic.ac.nz/login?url=",
+    "url": "http://campus-gw.openpolytechnic.ac.nz/login?url=$@",
     "location": {
       "lng": 174.9313866,
       "lat": -41.2185012
@@ -6778,7 +6778,7 @@
   },
   {
     "name": "Open Universiteit",
-    "url": "http://login.ezproxy.elib10.ub.unimaas.nl/login?url=",
+    "url": "http://login.ezproxy.elib10.ub.unimaas.nl/login?url=$@",
     "location": {
       "lng": 5.9582757,
       "lat": 50.8783644
@@ -6787,7 +6787,7 @@
   },
   {
     "name": "Open Universiteit Nederland",
-    "url": "https://login.ezproxy.elib11.ub.unimaas.nl/login?url=",
+    "url": "https://login.ezproxy.elib11.ub.unimaas.nl/login?url=$@",
     "location": {
       "lng": 5.9582757,
       "lat": 50.8783644
@@ -6796,7 +6796,7 @@
   },
   {
     "name": "Open University",
-    "url": "http://libezproxy.open.ac.uk/login?url=",
+    "url": "http://libezproxy.open.ac.uk/login?url=$@",
     "location": {
       "lng": -0.7081895,
       "lat": 52.02492950000001
@@ -6805,7 +6805,7 @@
   },
   {
     "name": "Open University of Israel",
-    "url": "https://elib.openu.ac.il/login?url=",
+    "url": "https://elib.openu.ac.il/login?url=$@",
     "location": {
       "lng": 34.887685,
       "lat": 32.188588
@@ -6814,7 +6814,7 @@
   },
   {
     "name": "Oral Roberts University",
-    "url": "http://ezproxy.oru.edu:2048/login?url=",
+    "url": "http://ezproxy.oru.edu:2048/login?url=$@",
     "location": {
       "lng": -95.95294944511247,
       "lat": 36.05101629198966
@@ -6823,7 +6823,7 @@
   },
   {
     "name": "Oregon College of Oriental Medicine",
-    "url": "https://ezproxy.ocom.edu:2443/login?url=",
+    "url": "https://ezproxy.ocom.edu:2443/login?url=$@",
     "location": {
       "lng": -122.6710932,
       "lat": 45.52396419999999
@@ -6832,7 +6832,7 @@
   },
   {
     "name": "Oregon Health & Sciences University",
-    "url": "http://liboff.ohsu.edu/login?url=",
+    "url": "http://liboff.ohsu.edu/login?url=$@",
     "location": {
       "lng": -120.5542012,
       "lat": 43.8041334
@@ -6841,7 +6841,7 @@
   },
   {
     "name": "Oregon Institute of Technology",
-    "url": "https://libproxy.oit.edu/login?url=",
+    "url": "https://libproxy.oit.edu/login?url=$@",
     "location": {
       "lng": -121.7851951,
       "lat": 42.2570051
@@ -6850,7 +6850,7 @@
   },
   {
     "name": "Oregon State",
-    "url": "http://proxy.library.oregonstate.edu/login?url=",
+    "url": "http://proxy.library.oregonstate.edu/login?url=$@",
     "location": {
       "lng": -120.5542012,
       "lat": 43.8041334
@@ -6859,7 +6859,7 @@
   },
   {
     "name": "Oregon State University",
-    "url": "https://login.ezproxy.proxy.library.oregonstate.edu/login?url=",
+    "url": "https://login.ezproxy.proxy.library.oregonstate.edu/login?url=$@",
     "location": {
       "lng": -123.2794442,
       "lat": 44.5637806
@@ -6868,7 +6868,7 @@
   },
   {
     "name": "Osaka",
-    "url": "http://remote.library.osaka-u.ac.jp/login?url=",
+    "url": "http://remote.library.osaka-u.ac.jp/login?url=$@",
     "location": {
       "lng": 135.5022535,
       "lat": 34.6937249
@@ -6877,7 +6877,7 @@
   },
   {
     "name": "OSF HealthCare",
-    "url": "http://libproxy.osfhealthcare.org/login?url=",
+    "url": "http://libproxy.osfhealthcare.org/login?url=$@",
     "location": {
       "lng": -89.59037028021434,
       "lat": 40.69113410998877
@@ -6886,7 +6886,7 @@
   },
   {
     "name": "Ottawa Public Library",
-    "url": "http://ezproxy.biblioottawalibrary.ca/login?url=",
+    "url": "http://ezproxy.biblioottawalibrary.ca/login?url=$@",
     "location": {
       "lng": -75.89525642850435,
       "lat": 45.32146161398508
@@ -6895,7 +6895,7 @@
   },
   {
     "name": "Otterbein",
-    "url": "http://ezproxy2.otterbein.edu/login?url=",
+    "url": "http://ezproxy2.otterbein.edu/login?url=$@",
     "location": {
       "lng": -82.9371852,
       "lat": 40.1268746
@@ -6904,7 +6904,7 @@
   },
   {
     "name": "Oxford Brookes University",
-    "url": "https://oxfordbrookes.idm.oclc.org/login?url=",
+    "url": "https://oxfordbrookes.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -1.2243230010788608,
       "lat": 51.755559360640696
@@ -6913,7 +6913,7 @@
   },
   {
     "name": "Pace University",
-    "url": "http://rlib.pace.edu/login?url=",
+    "url": "http://rlib.pace.edu/login?url=$@",
     "location": {
       "lng": -74.00508364400669,
       "lat": 40.71233338492282
@@ -6922,7 +6922,7 @@
   },
   {
     "name": "Pacific",
-    "url": "http://proxy.lib.pacificu.edu:2048/login?url=",
+    "url": "http://proxy.lib.pacificu.edu:2048/login?url=$@",
     "location": {
       "lng": -124.508523,
       "lat": -8.783195
@@ -6931,7 +6931,7 @@
   },
   {
     "name": "Pacific Lutheran",
-    "url": "http://ezproxy.plu.edu/login?url=",
+    "url": "http://ezproxy.plu.edu/login?url=$@",
     "location": {
       "lng": -122.4436669,
       "lat": 47.14519310000001
@@ -6940,7 +6940,7 @@
   },
   {
     "name": "Pacific Union College",
-    "url": "http://libproxy.puc.edu/login?url=",
+    "url": "http://libproxy.puc.edu/login?url=$@",
     "location": {
       "lng": -122.43973618566122,
       "lat": 38.57053060829952
@@ -6949,7 +6949,7 @@
   },
   {
     "name": "Pacifica Graduate Institute",
-    "url": "http://pgi.idm.oclc.org/login?url=",
+    "url": "http://pgi.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -119.5805358,
       "lat": 34.4219474
@@ -6958,7 +6958,7 @@
   },
   {
     "name": "Palestine Polytechnic University",
-    "url": "http://ezproxy.ppu.edu:8080/login?url=",
+    "url": "http://ezproxy.ppu.edu:8080/login?url=$@",
     "location": {
       "lng": 35.0903491,
       "lat": 31.5066556
@@ -6967,7 +6967,7 @@
   },
   {
     "name": "Palomar",
-    "url": "http://prozy.palomar.edu/login?url=",
+    "url": "http://prozy.palomar.edu/login?url=$@",
     "location": {
       "lng": -117.1821885,
       "lat": 33.1512505
@@ -6976,7 +6976,7 @@
   },
   {
     "name": "Panola College",
-    "url": "http://pas.panola.edu:2048/login?url=",
+    "url": "http://pas.panola.edu:2048/login?url=$@",
     "location": {
       "lng": -94.3564504,
       "lat": 32.1560799
@@ -6985,7 +6985,7 @@
   },
   {
     "name": "Paracelsus Medizinischen PrivatUni",
-    "url": "https://ez.srv.pmu.ac.at/login?url=",
+    "url": "https://ez.srv.pmu.ac.at/login?url=$@",
     "location": {
       "lng": 12.983645206177853,
       "lat": 47.912340440840325
@@ -6994,7 +6994,7 @@
   },
   {
     "name": "Pellissippi State Technical",
-    "url": "http://ezproxy.pstcc.edu:2048/login?url=",
+    "url": "http://ezproxy.pstcc.edu:2048/login?url=$@",
     "location": {
       "lng": -84.16579779999999,
       "lat": 35.9487513
@@ -7003,7 +7003,7 @@
   },
   {
     "name": "Peninsula Library System",
-    "url": "https://login.ezproxy.plsinfo.org/login?url=",
+    "url": "https://login.ezproxy.plsinfo.org/login?url=$@",
     "location": {
       "lng": -71.9544571892695,
       "lat": 41.57848918077987
@@ -7012,7 +7012,7 @@
   },
   {
     "name": "Penn Foster College",
-    "url": "https://my.pennfoster.edu/login?url=",
+    "url": "https://my.pennfoster.edu/login?url=$@",
     "location": {
       "lng": -111.8982122,
       "lat": 33.6161804
@@ -7021,7 +7021,7 @@
   },
   {
     "name": "Pennsylvania State University",
-    "url": "http://ezaccess.libraries.psu.edu/login?url=",
+    "url": "http://ezaccess.libraries.psu.edu/login?url=$@",
     "location": {
       "lng": -77.8599084,
       "lat": 40.7982133
@@ -7030,7 +7030,7 @@
   },
   {
     "name": "Pepperdine",
-    "url": "http://lib.pepperdine.edu/login?url=",
+    "url": "http://lib.pepperdine.edu/login?url=$@",
     "location": {
       "lng": -118.7095814,
       "lat": 34.0414045
@@ -7039,7 +7039,7 @@
   },
   {
     "name": "Peru State",
-    "url": "https://ezproxy.peru.edu/login?url=",
+    "url": "https://ezproxy.peru.edu/login?url=$@",
     "location": {
       "lng": -95.7321485,
       "lat": 40.4747647
@@ -7048,7 +7048,7 @@
   },
   {
     "name": "Philadelphia",
-    "url": "https://ezproxy.philau.edu/login?url=",
+    "url": "https://ezproxy.philau.edu/login?url=$@",
     "location": {
       "lng": -75.1652215,
       "lat": 39.9525839
@@ -7057,7 +7057,7 @@
   },
   {
     "name": "Philadelphia College of Ostheopathic Medicine",
-    "url": "http://ezproxy.pcom.edu:2048/login?url=",
+    "url": "http://ezproxy.pcom.edu:2048/login?url=$@",
     "location": {
       "lng": -75.1652215,
       "lat": 39.9525839
@@ -7066,7 +7066,7 @@
   },
   {
     "name": "Piedmont",
-    "url": "https://login.ezproxy.piedmont.edu/login?url=",
+    "url": "https://login.ezproxy.piedmont.edu/login?url=$@",
     "location": {
       "lng": 7.5153885,
       "lat": 45.0522366
@@ -7075,7 +7075,7 @@
   },
   {
     "name": "Piedmont Virginia Community College",
-    "url": "https://ezpvcc.vccs.edu:2443/login?url=",
+    "url": "https://ezpvcc.vccs.edu:2443/login?url=$@",
     "location": {
       "lng": -78.484332,
       "lat": 38.0063054
@@ -7084,7 +7084,7 @@
   },
   {
     "name": "Pisa University",
-    "url": "http://ezproxy.pisa.edu/login?url=",
+    "url": "http://ezproxy.pisa.edu/login?url=$@",
     "location": {
       "lng": 10.3988593,
       "lat": 43.7167235
@@ -7093,7 +7093,7 @@
   },
   {
     "name": "Plymouth",
-    "url": "https://plymouth.idm.oclc.org/login?url=",
+    "url": "https://plymouth.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -4.1426565,
       "lat": 50.3754565
@@ -7102,7 +7102,7 @@
   },
   {
     "name": "Point Park",
-    "url": "https://proxy.pointpark.edu/login?url=",
+    "url": "https://proxy.pointpark.edu/login?url=$@",
     "location": {
       "lng": -80.0017987,
       "lat": 40.4384916
@@ -7111,7 +7111,7 @@
   },
   {
     "name": "Point University",
-    "url": "http://ezproxy.point.edu:2048/login?url=",
+    "url": "http://ezproxy.point.edu:2048/login?url=$@",
     "location": {
       "lng": -85.18485164878003,
       "lat": 32.879303413312634
@@ -7120,7 +7120,7 @@
   },
   {
     "name": "Politecnico di Torino",
-    "url": "https://www.ezproxy.biblio.polito.it/login?url=",
+    "url": "https://www.ezproxy.biblio.polito.it/login?url=$@",
     "location": {
       "lng": 7.660124700000001,
       "lat": 45.0632841
@@ -7129,7 +7129,7 @@
   },
   {
     "name": "Pontificia Universidad Católica de Chile",
-    "url": "http://ezproxy.puc.cl/login?url=",
+    "url": "http://ezproxy.puc.cl/login?url=$@",
     "location": {
       "lng": -70.6399544,
       "lat": -33.44180680000001
@@ -7138,7 +7138,7 @@
   },
   {
     "name": "Pontificia Universidad Católica del Perú",
-    "url": "http://ezproxybib.pucp.edu.pe:2048/login?url=",
+    "url": "http://ezproxybib.pucp.edu.pe:2048/login?url=$@",
     "location": {
       "lng": -77.0780608,
       "lat": -12.0689502
@@ -7147,7 +7147,7 @@
   },
   {
     "name": "Pontificia Universidad Javeriana Bogotá",
-    "url": "https://login.ezproxy.javeriana.edu.co/login?url=",
+    "url": "https://login.ezproxy.javeriana.edu.co/login?url=$@",
     "location": {
       "lng": -74.06466449999999,
       "lat": 4.628487499999999
@@ -7156,7 +7156,7 @@
   },
   {
     "name": "Pontificia Universidad Javeriana, Cali",
-    "url": "http://bdbib.javerianacali.edu.co/login?url=",
+    "url": "http://bdbib.javerianacali.edu.co/login?url=$@",
     "location": {
       "lng": -76.5316285,
       "lat": 3.3487239
@@ -7165,7 +7165,7 @@
   },
   {
     "name": "Portland State",
-    "url": "http://proxy.lib.pdx.edu/login?url=",
+    "url": "http://proxy.lib.pdx.edu/login?url=$@",
     "location": {
       "lng": -122.6833385,
       "lat": 45.5111153
@@ -7174,7 +7174,7 @@
   },
   {
     "name": "Prairie View A M",
-    "url": "http://pvamu.idm.oclc.org/login?url=",
+    "url": "http://pvamu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -95.9907076,
       "lat": 30.0954974
@@ -7183,7 +7183,7 @@
   },
   {
     "name": "Pratt Institute",
-    "url": "https://ezproxy.pratt.edu/login?url=",
+    "url": "https://ezproxy.pratt.edu/login?url=$@",
     "location": {
       "lng": -73.9629858,
       "lat": 40.6913844
@@ -7192,7 +7192,7 @@
   },
   {
     "name": "Prescott",
-    "url": "http://ezproxy.prescott.edu:2048/login?url=",
+    "url": "http://ezproxy.prescott.edu:2048/login?url=$@",
     "location": {
       "lng": -112.4685025,
       "lat": 34.5400242
@@ -7201,7 +7201,7 @@
   },
   {
     "name": "Princeton Theological Seminary",
-    "url": "http://yeshebi.ptsem.edu:2048/login?url=",
+    "url": "http://yeshebi.ptsem.edu:2048/login?url=$@",
     "location": {
       "lng": -74.6635221,
       "lat": 40.3447493
@@ -7210,7 +7210,7 @@
   },
   {
     "name": "Princeton University",
-    "url": "http://ezproxy.princeton.edu/login?url=",
+    "url": "http://ezproxy.princeton.edu/login?url=$@",
     "location": {
       "lng": -74.65507389999999,
       "lat": 40.3430942
@@ -7219,7 +7219,7 @@
   },
   {
     "name": "Purchase",
-    "url": "http://ezproxy.purchase.edu:2048/login?url=",
+    "url": "http://ezproxy.purchase.edu:2048/login?url=$@",
     "location": {
       "lng": -73.700419,
       "lat": 41.0470553
@@ -7228,7 +7228,7 @@
   },
   {
     "name": "Purdue University",
-    "url": "https://login.ezproxy.lib.purdue.edu/login?url=",
+    "url": "https://login.ezproxy.lib.purdue.edu/login?url=$@",
     "location": {
       "lng": -86.92119459999999,
       "lat": 40.4237054
@@ -7237,7 +7237,7 @@
   },
   {
     "name": "Purdue University Fort Wayne",
-    "url": "https://ezproxy.library.pfw.edu/login?url=h",
+    "url": "https://ezproxy.library.pfw.edu/login?url=h$@",
     "location": {
       "lng": -85.1059405,
       "lat": 41.1184535
@@ -7246,7 +7246,7 @@
   },
   {
     "name": "Queen Mary University of London",
-    "url": "https://login.ezproxy.library.qmul.ac.uk/login?url=",
+    "url": "https://login.ezproxy.library.qmul.ac.uk/login?url=$@",
     "location": {
       "lng": -0.0403745,
       "lat": 51.5240671
@@ -7255,7 +7255,7 @@
   },
   {
     "name": "Queen Mary, University of London",
-    "url": "http://ezproxy.library.qmul.ac.uk/login?url=",
+    "url": "http://ezproxy.library.qmul.ac.uk/login?url=$@",
     "location": {
       "lng": -0.0403745,
       "lat": 51.5240671
@@ -7264,7 +7264,7 @@
   },
   {
     "name": "Queen's University",
-    "url": "https://proxy.queensu.ca/login?qurl=",
+    "url": "https://proxy.queensu.ca/login?qurl=$@",
     "location": {
       "lng": -76.49514119999999,
       "lat": 44.2252795
@@ -7273,7 +7273,7 @@
   },
   {
     "name": "Queens",
-    "url": "http://proxy.queensu.ca/login?url=",
+    "url": "http://proxy.queensu.ca/login?url=$@",
     "location": {
       "lng": -73.7948516,
       "lat": 40.7282239
@@ -7282,7 +7282,7 @@
   },
   {
     "name": "Queensland University of Teachnology",
-    "url": "https://go.openathens.net/redirector/qut.edu.au?url=",
+    "url": "https://go.openathens.net/redirector/qut.edu.au?url=$@",
     "location": {
       "lng": 153.0281982,
       "lat": -27.4773845
@@ -7291,7 +7291,7 @@
   },
   {
     "name": "Queensland University of Technology",
-    "url": "http://ezp01.library.qut.edu.au/login?url=",
+    "url": "http://ezp01.library.qut.edu.au/login?url=$@",
     "location": {
       "lng": 153.0281982,
       "lat": -27.4773845
@@ -7300,7 +7300,7 @@
   },
   {
     "name": "Quinsigamond Community College",
-    "url": "https://ezproxyqcc.helmlib.org/login?url=",
+    "url": "https://ezproxyqcc.helmlib.org/login?url=$@",
     "location": {
       "lng": -71.7936924,
       "lat": 42.3146459
@@ -7309,7 +7309,7 @@
   },
   {
     "name": "Radboud University, Nijmegen",
-    "url": "https://ru.idm.oclc.org/login?url=",
+    "url": "https://ru.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 5.863818699999999,
       "lat": 51.8220189
@@ -7318,7 +7318,7 @@
   },
   {
     "name": "Radford",
-    "url": "http://lib-proxy.radford.edu/login?url=",
+    "url": "http://lib-proxy.radford.edu/login?url=$@",
     "location": {
       "lng": -80.5764477,
       "lat": 37.13179239999999
@@ -7327,7 +7327,7 @@
   },
   {
     "name": "Reed College",
-    "url": "http://proxy.library.reed.edu/login?url=",
+    "url": "http://proxy.library.reed.edu/login?url=$@",
     "location": {
       "lng": -122.6308086,
       "lat": 45.4810848
@@ -7336,7 +7336,7 @@
   },
   {
     "name": "Regent University",
-    "url": "https://library.regent.edu/wamvalidate?url=",
+    "url": "https://library.regent.edu/wamvalidate?url=$@",
     "location": {
       "lng": -76.1928949,
       "lat": 36.8007899
@@ -7345,7 +7345,7 @@
   },
   {
     "name": "Regis",
-    "url": "http://dml.regis.edu/login?url=",
+    "url": "http://dml.regis.edu/login?url=$@",
     "location": {
       "lng": -105.0302396,
       "lat": 39.7896087
@@ -7354,7 +7354,7 @@
   },
   {
     "name": "Reinhardt University",
-    "url": "http://ezproxy.reinhardt.edu:2048/login?url=",
+    "url": "http://ezproxy.reinhardt.edu:2048/login?url=$@",
     "location": {
       "lng": -84.5509513,
       "lat": 34.3205083
@@ -7363,7 +7363,7 @@
   },
   {
     "name": "Rensselaer Polytechnic Institute",
-    "url": "https://libproxy.rpi.edu/login?url=",
+    "url": "https://libproxy.rpi.edu/login?url=$@",
     "location": {
       "lng": -73.67888839999999,
       "lat": 42.7297628
@@ -7372,7 +7372,7 @@
   },
   {
     "name": "Rice University",
-    "url": "https://login.ezproxy.rice.edu/login?url=",
+    "url": "https://login.ezproxy.rice.edu/login?url=$@",
     "location": {
       "lng": -95.40183119999999,
       "lat": 29.7173941
@@ -7381,7 +7381,7 @@
   },
   {
     "name": "Ripon",
-    "url": "https://login.ripon.idm.oclc.org/login?qurl=",
+    "url": "https://login.ripon.idm.oclc.org/login?qurl=$@",
     "location": {
       "lng": -1.5237756,
       "lat": 54.1361346
@@ -7390,7 +7390,7 @@
   },
   {
     "name": "RIT",
-    "url": "http://ezproxy.rit.edu/login?url=",
+    "url": "http://ezproxy.rit.edu/login?url=$@",
     "location": {
       "lng": -77.67153549999999,
       "lat": 43.08484869999999
@@ -7399,7 +7399,7 @@
   },
   {
     "name": "Riverside City",
-    "url": "http://ezproxy.rcc.edu:2048/login?url=",
+    "url": "http://ezproxy.rcc.edu:2048/login?url=$@",
     "location": {
       "lng": -117.3754942,
       "lat": 33.9806005
@@ -7408,7 +7408,7 @@
   },
   {
     "name": "RMIT University ",
-    "url": "https://login.ezproxy.lib.rmit.edu.au/login?url=",
+    "url": "https://login.ezproxy.lib.rmit.edu.au/login?url=$@",
     "location": {
       "lng": 144.9639386,
       "lat": -37.8083332
@@ -7417,7 +7417,7 @@
   },
   {
     "name": "Robert Morris University",
-    "url": "https://reddog.rmu.edu/login?url=",
+    "url": "https://reddog.rmu.edu/login?url=$@",
     "location": {
       "lng": -80.10201104140535,
       "lat": 41.21315087360136
@@ -7426,7 +7426,7 @@
   },
   {
     "name": "Rollins",
-    "url": "http://ezproxy.rollins.edu:2048/login?url=",
+    "url": "http://ezproxy.rollins.edu:2048/login?url=$@",
     "location": {
       "lng": -81.3485013,
       "lat": 28.5927153
@@ -7435,7 +7435,7 @@
   },
   {
     "name": "Roosevelt University",
-    "url": "http://ezproxy.roosevelt.edu:2048/login?url=",
+    "url": "http://ezproxy.roosevelt.edu:2048/login?url=$@",
     "location": {
       "lng": -86.57591665394143,
       "lat": 42.99407383950141
@@ -7444,7 +7444,7 @@
   },
   {
     "name": "Rosalind Franklin University",
-    "url": "https://rosalindfranklin.idm.oclc.org/login?url=",
+    "url": "https://rosalindfranklin.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -87.8588156,
       "lat": 42.3003584
@@ -7453,7 +7453,7 @@
   },
   {
     "name": "Rosemont",
-    "url": "https://rosemont.idm.oclc.org/login?url=",
+    "url": "https://rosemont.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -87.8721602,
       "lat": 41.98675069999999
@@ -7462,7 +7462,7 @@
   },
   {
     "name": "Rowan",
-    "url": "http://ezproxy.rowan.edu/login?url=",
+    "url": "http://ezproxy.rowan.edu/login?url=$@",
     "location": {
       "lng": -75.1191932,
       "lat": 39.7099689
@@ -7471,7 +7471,7 @@
   },
   {
     "name": "Royal Australasian College of Surgeons",
-    "url": "http://ezproxy.surgeons.org/login?url=",
+    "url": "http://ezproxy.surgeons.org/login?url=$@",
     "location": {
       "lng": 144.9728155,
       "lat": -37.8085073
@@ -7480,7 +7480,7 @@
   },
   {
     "name": "Royal College of Nursing",
-    "url": "https://rcn.idm.oclc.org/login?url=",
+    "url": "https://rcn.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -1.7647339349683775,
       "lat": 52.72904889363981
@@ -7489,7 +7489,7 @@
   },
   {
     "name": "Royal College of Surgeons in Ireland - Medical University of Bahrain",
-    "url": "https://login.ezproxy.rcsi.com/login?url=",
+    "url": "https://login.ezproxy.rcsi.com/login?url=$@",
     "location": {
       "lng": 50.59699269999999,
       "lat": 26.261768
@@ -7498,7 +7498,7 @@
   },
   {
     "name": "Royal Holloway University of London",
-    "url": "http://ezproxy01.rhul.ac.uk:2048/login?url=",
+    "url": "http://ezproxy01.rhul.ac.uk:2048/login?url=$@",
     "location": {
       "lng": -0.5630625,
       "lat": 51.425673
@@ -7507,7 +7507,7 @@
   },
   {
     "name": "Royal Holloway, University of London",
-    "url": "http://ezproxy01.rhul.ac.uk/login?url=",
+    "url": "http://ezproxy01.rhul.ac.uk/login?url=$@",
     "location": {
       "lng": -0.5630625,
       "lat": 51.425673
@@ -7516,7 +7516,7 @@
   },
   {
     "name": "Royal Perth Hospital",
-    "url": "https://login.rplibresources.health.wa.gov.au/login?url=",
+    "url": "https://login.rplibresources.health.wa.gov.au/login?url=$@",
     "location": {
       "lng": 115.8664238,
       "lat": -31.9540512
@@ -7525,7 +7525,7 @@
   },
   {
     "name": "Royal Roads University",
-    "url": "https://ezproxy.royalroads.ca/login?url=",
+    "url": "https://ezproxy.royalroads.ca/login?url=$@",
     "location": {
       "lng": -123.4739689,
       "lat": 48.4342047
@@ -7534,7 +7534,7 @@
   },
   {
     "name": "Rush University Medical Center",
-    "url": "https://login.ezproxy.rush.edu/login?url=",
+    "url": "https://login.ezproxy.rush.edu/login?url=$@",
     "location": {
       "lng": -87.668836,
       "lat": 41.8745746
@@ -7543,7 +7543,7 @@
   },
   {
     "name": "Rutgers University",
-    "url": "https://proxy.libraries.rutgers.edu/login?url=",
+    "url": "https://proxy.libraries.rutgers.edu/login?url=$@",
     "location": {
       "lng": -74.44990026192792,
       "lat": 40.507370660344286
@@ -7552,7 +7552,7 @@
   },
   {
     "name": "Saint Louis",
-    "url": "http://ezp.slu.edu/login?url=",
+    "url": "http://ezp.slu.edu/login?url=$@",
     "location": {
       "lng": -90.19940419999999,
       "lat": 38.6270025
@@ -7561,7 +7561,7 @@
   },
   {
     "name": "Saint Mary's",
-    "url": "http://smcproxy1.saintmarys.edu:2048/login?url=",
+    "url": "http://smcproxy1.saintmarys.edu:2048/login?url=$@",
     "location": {
       "lng": -86.25709416282052,
       "lat": 41.70790941026819
@@ -7570,7 +7570,7 @@
   },
   {
     "name": "Saint Marys College CA",
-    "url": "https://stmarys-ca.idm.oclc.org/login?url=",
+    "url": "https://stmarys-ca.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.1089374,
       "lat": 37.8408837
@@ -7579,7 +7579,7 @@
   },
   {
     "name": "Saint Marys University of Minnesota",
-    "url": "http://ezproxy.smumn.edu/login?url=",
+    "url": "http://ezproxy.smumn.edu/login?url=$@",
     "location": {
       "lng": -91.6957309,
       "lat": 44.0447868
@@ -7588,7 +7588,7 @@
   },
   {
     "name": "Saint Michaels",
-    "url": "http://library.smcvt.edu/login?url=",
+    "url": "http://library.smcvt.edu/login?url=$@",
     "location": {
       "lng": -76.22332020000002,
       "lat": 38.785393
@@ -7597,7 +7597,7 @@
   },
   {
     "name": "Saint Petersburg State University",
-    "url": "https://proxy.library.spbu.ru/login?url=",
+    "url": "https://proxy.library.spbu.ru/login?url=$@",
     "location": {
       "lng": 30.2989198,
       "lat": 59.941894
@@ -7606,7 +7606,7 @@
   },
   {
     "name": "Salem State",
-    "url": "http://corvette.salemstate.edu:2048/login?url=",
+    "url": "http://corvette.salemstate.edu:2048/login?url=$@",
     "location": {
       "lng": -70.8902384,
       "lat": 42.5041326
@@ -7615,7 +7615,7 @@
   },
   {
     "name": "Salford University",
-    "url": "https://salford.idm.oclc.org/login?url=",
+    "url": "https://salford.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -2.2737375,
       "lat": 53.48723260000001
@@ -7624,7 +7624,7 @@
   },
   {
     "name": "Salus University",
-    "url": "http://salus.idm.oclc.org/login?url=",
+    "url": "http://salus.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -75.12914920858499,
       "lat": 40.08656103619193
@@ -7633,7 +7633,7 @@
   },
   {
     "name": "Sam Houston State University",
-    "url": "http://login.ezproxy.shsu.edu/login?url=",
+    "url": "http://login.ezproxy.shsu.edu/login?url=$@",
     "location": {
       "lng": -95.547276,
       "lat": 30.7135813
@@ -7642,7 +7642,7 @@
   },
   {
     "name": "San Diego State",
-    "url": "http://libproxy.sdsu.edu/login?url=",
+    "url": "http://libproxy.sdsu.edu/login?url=$@",
     "location": {
       "lng": -117.0714068,
       "lat": 32.7774047
@@ -7651,7 +7651,7 @@
   },
   {
     "name": "San Francisco Public Library",
-    "url": "http://ezproxy.sfpl.org/login?url=",
+    "url": "http://ezproxy.sfpl.org/login?url=$@",
     "location": {
       "lng": -122.4194155,
       "lat": 37.7749295
@@ -7660,7 +7660,7 @@
   },
   {
     "name": "San Francisco State",
-    "url": "http://jpllnet.sfsu.edu/login?url=",
+    "url": "http://jpllnet.sfsu.edu/login?url=$@",
     "location": {
       "lng": -122.4799405,
       "lat": 37.7241492
@@ -7669,7 +7669,7 @@
   },
   {
     "name": "San Jose City College",
-    "url": "https://login.sjccezproxy.sjcc.edu/login?url=",
+    "url": "https://login.sjccezproxy.sjcc.edu/login?url=$@",
     "location": {
       "lng": -121.92723079518598,
       "lat": 37.31480350267728
@@ -7678,7 +7678,7 @@
   },
   {
     "name": "San Jose State University",
-    "url": "http://libaccess.sjlibrary.org/login?url=",
+    "url": "http://libaccess.sjlibrary.org/login?url=$@",
     "location": {
       "lng": -121.8810715,
       "lat": 37.3351874
@@ -7687,7 +7687,7 @@
   },
   {
     "name": "San José Public Library",
-    "url": "https://login.sjezpt01.sjlibrary.org/login?url=",
+    "url": "https://login.sjezpt01.sjlibrary.org/login?url=$@",
     "location": {
       "lng": -121.8852525,
       "lat": 37.33874
@@ -7696,7 +7696,7 @@
   },
   {
     "name": "Santa Clara County Library",
-    "url": "http://rpa.sccl.org/login?url=",
+    "url": "http://rpa.sccl.org/login?url=$@",
     "location": {
       "lng": -121.7195459,
       "lat": 37.2938907
@@ -7705,7 +7705,7 @@
   },
   {
     "name": "Sapienza Università di Roma",
-    "url": "https://login.ezproxy.uniroma1.it/login?url=",
+    "url": "https://login.ezproxy.uniroma1.it/login?url=$@",
     "location": {
       "lng": 12.5144384,
       "lat": 41.9037626
@@ -7714,7 +7714,7 @@
   },
   {
     "name": "Sarah Lawrence",
-    "url": "http://remote.slc.edu/login?url=",
+    "url": "http://remote.slc.edu/login?url=$@",
     "location": {
       "lng": -73.8455821,
       "lat": 40.93459
@@ -7723,7 +7723,7 @@
   },
   {
     "name": "Saskatchewan Health Information Resource Partnership",
-    "url": "http://ezproxy.shirp.ca/login?url=",
+    "url": "http://ezproxy.shirp.ca/login?url=$@",
     "location": {
       "lng": -106.4508639,
       "lat": 52.9399159
@@ -7732,7 +7732,7 @@
   },
   {
     "name": "School for International Training",
-    "url": "http://reference.sit.edu:2048/login?url=",
+    "url": "http://reference.sit.edu:2048/login?url=$@",
     "location": {
       "lng": -72.5645828,
       "lat": 42.8903298
@@ -7741,7 +7741,7 @@
   },
   {
     "name": "Scottsdale",
-    "url": "http://ezproxy.scottsdalecc.edu:2048/login?url=",
+    "url": "http://ezproxy.scottsdalecc.edu:2048/login?url=$@",
     "location": {
       "lng": -111.9260519,
       "lat": 33.4941704
@@ -7750,7 +7750,7 @@
   },
   {
     "name": "Seattle Pacific University",
-    "url": "http://ezproxy.spu.edu/login?url=",
+    "url": "http://ezproxy.spu.edu/login?url=$@",
     "location": {
       "lng": -122.3618554,
       "lat": 47.6491714
@@ -7759,7 +7759,7 @@
   },
   {
     "name": "Seattle Public Library",
-    "url": "https://ezproxy.spl.org/login?url=",
+    "url": "https://ezproxy.spl.org/login?url=$@",
     "location": {
       "lng": -122.3320708,
       "lat": 47.6062095
@@ -7768,7 +7768,7 @@
   },
   {
     "name": "Seattle University",
-    "url": "http://proxy.seattleu.edu/login?url=",
+    "url": "http://proxy.seattleu.edu/login?url=$@",
     "location": {
       "lng": -122.3178465,
       "lat": 47.6091765
@@ -7777,7 +7777,7 @@
   },
   {
     "name": "Seneca",
-    "url": "http://lcweb.senecac.on.ca:2048/login?url=",
+    "url": "http://lcweb.senecac.on.ca:2048/login?url=$@",
     "location": {
       "lng": -79.34809038106465,
       "lat": 43.79704149159459
@@ -7786,7 +7786,7 @@
   },
   {
     "name": "Seoul National University",
-    "url": "https://lib.snu.ac.kr/user/login?proxyurl=",
+    "url": "https://lib.snu.ac.kr/user/login?proxyurl=$@",
     "location": {
       "lng": 126.9500385,
       "lat": 37.4565095
@@ -7795,7 +7795,7 @@
   },
   {
     "name": "Seoul National University (Alternative)",
-    "url": "https://ezproxy.snu.ac.kr/login?url=",
+    "url": "https://ezproxy.snu.ac.kr/login?url=$@",
     "location": {
       "lng": 126.9500385,
       "lat": 37.4565095
@@ -7804,7 +7804,7 @@
   },
   {
     "name": "Seton Hall University",
-    "url": "http://ezproxy.shu.edu/login?url=",
+    "url": "http://ezproxy.shu.edu/login?url=$@",
     "location": {
       "lng": -74.246082,
       "lat": 40.7430841
@@ -7813,7 +7813,7 @@
   },
   {
     "name": "Shanghai University of Finance and Economics",
-    "url": "http://ezlibrary.sufe.edu.cn/login?url=",
+    "url": "http://ezlibrary.sufe.edu.cn/login?url=$@",
     "location": {
       "lng": 121.494038,
       "lat": 31.306594
@@ -7822,7 +7822,7 @@
   },
   {
     "name": "Shasta College",
-    "url": "http://ezproxy.shastacollege.edu:2048/login?url=",
+    "url": "http://ezproxy.shastacollege.edu:2048/login?url=$@",
     "location": {
       "lng": -122.31812778116573,
       "lat": 40.62572461708596
@@ -7831,7 +7831,7 @@
   },
   {
     "name": "Sheba Medical Center Library",
-    "url": "https://sheba-tdnetdiscover-com.sheba.idm.oclc.org/logging/outgoing?url=",
+    "url": "https://sheba-tdnetdiscover-com.sheba.idm.oclc.org/logging/outgoing?url=$@",
     "location": {
       "lng": 34.8460728,
       "lat": 32.0486696
@@ -7840,7 +7840,7 @@
   },
   {
     "name": "Sheffield Hallam University",
-    "url": "https://hallam.idm.oclc.org/login?url=",
+    "url": "https://hallam.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -1.4659387,
       "lat": 53.3785622
@@ -7849,7 +7849,7 @@
   },
   {
     "name": "Shenandoah",
-    "url": "http://suproxy.su.edu/login?url=",
+    "url": "http://suproxy.su.edu/login?url=$@",
     "location": {
       "lng": -78.4534573,
       "lat": 38.4754706
@@ -7858,7 +7858,7 @@
   },
   {
     "name": "Shenzhen University",
-    "url": "http://ezproxy.lib.szu.edu.cn//login?url=",
+    "url": "http://ezproxy.lib.szu.edu.cn//login?url=$@",
     "location": {
       "lng": 113.932813,
       "lat": 22.53306
@@ -7867,7 +7867,7 @@
   },
   {
     "name": "Shippensburg University",
-    "url": "http://proxy-ship.klnpa.org/login?url=",
+    "url": "http://proxy-ship.klnpa.org/login?url=$@",
     "location": {
       "lng": -77.521684,
       "lat": 40.0609352
@@ -7876,7 +7876,7 @@
   },
   {
     "name": "SHIRP (University of Saskatchewan)",
-    "url": "http://www.shirp.ca/doproxy?url=",
+    "url": "http://www.shirp.ca/doproxy?url=$@",
     "location": {
       "lng": -106.63133844875824,
       "lat": 52.13349456776281
@@ -7885,7 +7885,7 @@
   },
   {
     "name": "Siberian Federal University",
-    "url": "https://libproxy.bik.sfu-kras.ru/login?url=",
+    "url": "https://libproxy.bik.sfu-kras.ru/login?url=$@",
     "location": {
       "lng": 92.765776,
       "lat": 56.004056
@@ -7894,7 +7894,7 @@
   },
   {
     "name": "Siena",
-    "url": "http://ezproxy.siena.edu:2048/login?url=",
+    "url": "http://ezproxy.siena.edu:2048/login?url=$@",
     "location": {
       "lng": 11.3307574,
       "lat": 43.31880899999999
@@ -7903,7 +7903,7 @@
   },
   {
     "name": "Simmons",
-    "url": "http://ezproxy.simmons.edu:2048/login?url=",
+    "url": "http://ezproxy.simmons.edu:2048/login?url=$@",
     "location": {
       "lng": -71.10043759999999,
       "lat": 42.339063
@@ -7912,7 +7912,7 @@
   },
   {
     "name": "Simon Fraser University",
-    "url": "http://proxy.lib.sfu.ca/login?url=",
+    "url": "http://proxy.lib.sfu.ca/login?url=$@",
     "location": {
       "lng": -122.9198833,
       "lat": 49.2780937
@@ -7921,7 +7921,7 @@
   },
   {
     "name": "Singapore Institute of Management",
-    "url": "http://libproxy.sim.edu.sg/login?url=",
+    "url": "http://libproxy.sim.edu.sg/login?url=$@",
     "location": {
       "lng": 103.7761745,
       "lat": 1.3294012
@@ -7930,7 +7930,7 @@
   },
   {
     "name": "Singapore Management University (SMU)",
-    "url": "http://libproxy.smu.edu.sg/login?url=",
+    "url": "http://libproxy.smu.edu.sg/login?url=$@",
     "location": {
       "lng": 103.8501578,
       "lat": 1.2962727
@@ -7939,7 +7939,7 @@
   },
   {
     "name": "Slippery Rock University",
-    "url": "http://proxy-sru.klnpa.org/login?url=",
+    "url": "http://proxy-sru.klnpa.org/login?url=$@",
     "location": {
       "lng": -80.04119899999999,
       "lat": 41.0629938
@@ -7948,7 +7948,7 @@
   },
   {
     "name": "Smith",
-    "url": "http://libproxy.smith.edu:2048/login?url=",
+    "url": "http://libproxy.smith.edu:2048/login?url=$@",
     "location": {
       "lng": -72.64026739705753,
       "lat": 42.31646706621614
@@ -7957,7 +7957,7 @@
   },
   {
     "name": "SNDL Systeme National de Documentation en Ligne",
-    "url": "http://www.sndl1.arn.dz/login?url=",
+    "url": "http://www.sndl1.arn.dz/login?url=$@",
     "location": {
       "lng": 3.0814079492144626,
       "lat": 36.73940747345419
@@ -7966,7 +7966,7 @@
   },
   {
     "name": "Sofia",
-    "url": "http://ezproxy.sofia.edu:2048/login?url=",
+    "url": "http://ezproxy.sofia.edu:2048/login?url=$@",
     "location": {
       "lng": 23.3218675,
       "lat": 42.6977082
@@ -7975,7 +7975,7 @@
   },
   {
     "name": "Solano",
-    "url": "https://ezproxy.solano.edu/login?url=",
+    "url": "https://ezproxy.solano.edu/login?url=$@",
     "location": {
       "lng": -121.9017954,
       "lat": 38.3104969
@@ -7984,7 +7984,7 @@
   },
   {
     "name": "Sonoma State",
-    "url": "https://sonoma.idm.oclc.org/login?url=",
+    "url": "https://sonoma.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.6730677,
       "lat": 38.3409222
@@ -7993,7 +7993,7 @@
   },
   {
     "name": "Sookmyung University",
-    "url": "http://libproxy.sookmyung.ac.kr/_Lib_Proxy_Url/login?url=",
+    "url": "http://libproxy.sookmyung.ac.kr/_Lib_Proxy_Url/login?url=$@",
     "location": {
       "lng": 126.9646916,
       "lat": 37.54647500000001
@@ -8002,7 +8002,7 @@
   },
   {
     "name": "Sorbonne Université",
-    "url": "http://accesdistant.sorbonne-universite.fr/login?url=",
+    "url": "http://accesdistant.sorbonne-universite.fr/login?url=$@",
     "location": {
       "lng": 2.3403275,
       "lat": 48.85055149999999
@@ -8011,7 +8011,7 @@
   },
   {
     "name": "Sothebys Institute of Art",
-    "url": "http://ezproxy.sothebysinstitute.com:2048/login?url=",
+    "url": "http://ezproxy.sothebysinstitute.com:2048/login?url=$@",
     "location": {
       "lng": -0.1312174,
       "lat": 51.51863849999999
@@ -8020,7 +8020,7 @@
   },
   {
     "name": "South and East Metropolitan Health Service",
-    "url": "https://login.smhslibresources.health.wa.gov.au/login?url=",
+    "url": "https://login.smhslibresources.health.wa.gov.au/login?url=$@",
     "location": {
       "lng": 115.8646998,
       "lat": -31.9546179
@@ -8029,7 +8029,7 @@
   },
   {
     "name": "South Asian University (SAU)",
-    "url": "https://sau.idm.oclc.org/login?url=",
+    "url": "https://sau.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 77.19023020000002,
       "lat": 28.5852347
@@ -8038,7 +8038,7 @@
   },
   {
     "name": "South College",
-    "url": "http://proxy.southcollegetn.edu:2048/login?url=",
+    "url": "http://proxy.southcollegetn.edu:2048/login?url=$@",
     "location": {
       "lng": -83.97313136352469,
       "lat": 35.961129109913685
@@ -8047,7 +8047,7 @@
   },
   {
     "name": "South Dakota State University",
-    "url": "https://excelsior.sdstate.edu/login?url=",
+    "url": "https://excelsior.sdstate.edu/login?url=$@",
     "location": {
       "lng": -96.78351819999999,
       "lat": 44.3191071
@@ -8056,7 +8056,7 @@
   },
   {
     "name": "South Plains",
-    "url": "https://ezproxy.southplainscollege.edu:2443/login?url=",
+    "url": "https://ezproxy.southplainscollege.edu:2443/login?url=$@",
     "location": {
       "lng": -102.3669395,
       "lat": 33.578406
@@ -8065,7 +8065,7 @@
   },
   {
     "name": "South Texas",
-    "url": "http://ezproxy.southtexascollege.edu:2048/login?url=",
+    "url": "http://ezproxy.southtexascollege.edu:2048/login?url=$@",
     "location": {
       "lng": -99.9018131,
       "lat": 31.9685988
@@ -8074,7 +8074,7 @@
   },
   {
     "name": "Southern College of Optometry",
-    "url": "http://sco.idm.oclc.org/login?url=",
+    "url": "http://sco.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -90.0200838,
       "lat": 35.1383947
@@ -8083,7 +8083,7 @@
   },
   {
     "name": "Southern Illinois University Carbondale",
-    "url": "https://proxy.lib.siu.edu/login?url=",
+    "url": "https://proxy.lib.siu.edu/login?url=$@",
     "location": {
       "lng": -89.2229983,
       "lat": 37.7079717
@@ -8092,7 +8092,7 @@
   },
   {
     "name": "Southern Illinois University School of Medicine",
-    "url": "https://libproxy.siumed.edu/login?url=",
+    "url": "https://libproxy.siumed.edu/login?url=$@",
     "location": {
       "lng": -89.657583,
       "lat": 39.8101074
@@ -8101,7 +8101,7 @@
   },
   {
     "name": "Southern Methodist",
-    "url": "http://proxy.libraries.smu.edu/login?url=",
+    "url": "http://proxy.libraries.smu.edu/login?url=$@",
     "location": {
       "lng": -96.78451749999999,
       "lat": 32.8412178
@@ -8110,7 +8110,7 @@
   },
   {
     "name": "Southern New Hampshire University SNHU",
-    "url": "http://ezproxy.snhu.edu/login?url=",
+    "url": "http://ezproxy.snhu.edu/login?url=$@",
     "location": {
       "lng": -71.4493554,
       "lat": 43.0382166
@@ -8119,7 +8119,7 @@
   },
   {
     "name": "Southern Oregon",
-    "url": "http://glacier.sou.edu/login?url=",
+    "url": "http://glacier.sou.edu/login?url=$@",
     "location": {
       "lng": -122.4332992,
       "lat": 42.7976791
@@ -8128,7 +8128,7 @@
   },
   {
     "name": "Southern University at New Orleans",
-    "url": "http://ezproxy.suno.edu:2048/login?url=",
+    "url": "http://ezproxy.suno.edu:2048/login?url=$@",
     "location": {
       "lng": -90.0449055,
       "lat": 30.0259133
@@ -8137,7 +8137,7 @@
   },
   {
     "name": "Southwestern",
-    "url": "https://navigator.southwestern.edu/login?url=",
+    "url": "https://navigator.southwestern.edu/login?url=$@",
     "location": {
       "lng": -97.66285150000002,
       "lat": 30.6369218
@@ -8146,7 +8146,7 @@
   },
   {
     "name": "Southwestern Illinois",
-    "url": "http://ezproxy.swic.edu/login?url=",
+    "url": "http://ezproxy.swic.edu/login?url=$@",
     "location": {
       "lng": -87.86479609999999,
       "lat": 38.8742719
@@ -8155,7 +8155,7 @@
   },
   {
     "name": "Southwestern Oklahoma State University",
-    "url": "http://libnet.swosu.edu/login?url=",
+    "url": "http://libnet.swosu.edu/login?url=$@",
     "location": {
       "lng": -98.70789540000001,
       "lat": 35.5357732
@@ -8164,7 +8164,7 @@
   },
   {
     "name": "St Cloud State",
-    "url": "https://login.libproxy.stcloudstate.edu/login?qurl=",
+    "url": "https://login.libproxy.stcloudstate.edu/login?qurl=$@",
     "location": {
       "lng": -94.1515367,
       "lat": 45.548639
@@ -8173,7 +8173,7 @@
   },
   {
     "name": "St Edwards University in Austin",
-    "url": "https://ezproxy.stedwards.edu/login?url=",
+    "url": "https://ezproxy.stedwards.edu/login?url=$@",
     "location": {
       "lng": -97.75833,
       "lat": 30.23218
@@ -8182,7 +8182,7 @@
   },
   {
     "name": "St Louis",
-    "url": "http://ezproxy.stlcc.edu/login?url=",
+    "url": "http://ezproxy.stlcc.edu/login?url=$@",
     "location": {
       "lng": -90.19940419999999,
       "lat": 38.6270025
@@ -8191,7 +8191,7 @@
   },
   {
     "name": "St Olaf",
-    "url": "http://ezproxy.stolaf.edu/login?url=",
+    "url": "http://ezproxy.stolaf.edu/login?url=$@",
     "location": {
       "lng": -93.18402809999999,
       "lat": 44.4621319
@@ -8200,7 +8200,7 @@
   },
   {
     "name": "St Thomas",
-    "url": "http://proxy.stu.edu:2048/login?url=",
+    "url": "http://proxy.stu.edu:2048/login?url=$@",
     "location": {
       "lng": -64.8940946,
       "lat": 18.3380965
@@ -8209,7 +8209,7 @@
   },
   {
     "name": "St Vincents Health Australia",
-    "url": "https://svhm.idm.oclc.org/login?url=",
+    "url": "https://svhm.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 133.775136,
       "lat": -25.274398
@@ -8218,7 +8218,7 @@
   },
   {
     "name": "St. Francis Xavier University",
-    "url": "http://libproxy.stfx.ca/login?url=",
+    "url": "http://libproxy.stfx.ca/login?url=$@",
     "location": {
       "lng": -61.99539410000001,
       "lat": 45.6177357
@@ -8227,7 +8227,7 @@
   },
   {
     "name": "St. John's University",
-    "url": "https://jerome.stjohns.edu/login?url=",
+    "url": "https://jerome.stjohns.edu/login?url=$@",
     "location": {
       "lng": -73.7975501796871,
       "lat": 40.72167369686328
@@ -8236,7 +8236,7 @@
   },
   {
     "name": "St. Lawrence University",
-    "url": "http://stlawu.idm.oclc.org/login?url=",
+    "url": "http://stlawu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -75.1608814,
       "lat": 44.5892119
@@ -8245,7 +8245,7 @@
   },
   {
     "name": "St. Mary's University",
-    "url": "http://blume.stmarytx.edu:2048/login?url=",
+    "url": "http://blume.stmarytx.edu:2048/login?url=$@",
     "location": {
       "lng": -98.56502264652597,
       "lat": 29.46030146736221
@@ -8254,7 +8254,7 @@
   },
   {
     "name": "Stanford",
-    "url": "http://laneproxy.stanford.edu/login?url=",
+    "url": "http://laneproxy.stanford.edu/login?url=$@",
     "location": {
       "lng": -122.1660756,
       "lat": 37.42410599999999
@@ -8263,7 +8263,7 @@
   },
   {
     "name": "Stanford University",
-    "url": "https://stanford.idm.oclc.org/login?url=",
+    "url": "https://stanford.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.169719,
       "lat": 37.4274745
@@ -8272,7 +8272,7 @@
   },
   {
     "name": "State and University Library, Aarhus",
-    "url": "http://ez.statsbiblioteket.dk:2048/login?url=",
+    "url": "http://ez.statsbiblioteket.dk:2048/login?url=$@",
     "location": {
       "lng": 10.203921,
       "lat": 56.162939
@@ -8281,7 +8281,7 @@
   },
   {
     "name": "State Library of Pennsylvania",
-    "url": "http://proxy-stlib.klnpa.org/login?url=",
+    "url": "http://proxy-stlib.klnpa.org/login?url=$@",
     "location": {
       "lng": -76.8838428,
       "lat": 40.2665447
@@ -8290,7 +8290,7 @@
   },
   {
     "name": "Stellenbosch University",
-    "url": "http://ez.sun.ac.za/login?url=",
+    "url": "http://ez.sun.ac.za/login?url=$@",
     "location": {
       "lng": 18.864447,
       "lat": -33.9328078
@@ -8299,7 +8299,7 @@
   },
   {
     "name": "Stephen F. Austin State University",
-    "url": "http://steenproxy.sfasu.edu:2048/login?url=",
+    "url": "http://steenproxy.sfasu.edu:2048/login?url=$@",
     "location": {
       "lng": -94.64664379999999,
       "lat": 31.6216141
@@ -8308,7 +8308,7 @@
   },
   {
     "name": "Stevens Institute of Technology",
-    "url": "http://www.stevens.edu/ezproxy/login?url=",
+    "url": "http://www.stevens.edu/ezproxy/login?url=$@",
     "location": {
       "lng": -74.0256485,
       "lat": 40.74482030000001
@@ -8317,7 +8317,7 @@
   },
   {
     "name": "Stevenson University",
-    "url": "https://ezproxy.stevenson.edu/login?url=",
+    "url": "https://ezproxy.stevenson.edu/login?url=$@",
     "location": {
       "lng": -76.7798238427994,
       "lat": 39.428483288859766
@@ -8326,7 +8326,7 @@
   },
   {
     "name": "Stockholm University",
-    "url": "http://ezp.sub.su.se/login?url=",
+    "url": "http://ezp.sub.su.se/login?url=$@",
     "location": {
       "lng": 18.0550487,
       "lat": 59.3652343
@@ -8335,7 +8335,7 @@
   },
   {
     "name": "Stockton",
-    "url": "http://ezproxy.stockton.edu:2048/login?url=",
+    "url": "http://ezproxy.stockton.edu:2048/login?url=$@",
     "location": {
       "lng": -121.2907796,
       "lat": 37.9577016
@@ -8344,7 +8344,7 @@
   },
   {
     "name": "Stony Brook University",
-    "url": "http://ezproxy.hsclib.sunysb.edu/login?url=",
+    "url": "http://ezproxy.hsclib.sunysb.edu/login?url=$@",
     "location": {
       "lng": -73.1204032,
       "lat": 40.908119
@@ -8353,7 +8353,7 @@
   },
   {
     "name": "Stony Brook University West Campus",
-    "url": "http://proxy.library.stonybrook.edu/login?url=",
+    "url": "http://proxy.library.stonybrook.edu/login?url=$@",
     "location": {
       "lng": -73.1204032,
       "lat": 40.908119
@@ -8362,7 +8362,7 @@
   },
   {
     "name": "Stowers Institute for Medical Research",
-    "url": "https://ezproxy.stowers.org/login?url=",
+    "url": "https://ezproxy.stowers.org/login?url=$@",
     "location": {
       "lng": -94.5742972,
       "lat": 39.0365098
@@ -8371,7 +8371,7 @@
   },
   {
     "name": "Strathmore",
-    "url": "https://ezproxy.library.strathmore.edu/login?url=",
+    "url": "https://ezproxy.library.strathmore.edu/login?url=$@",
     "location": {
       "lng": -77.1032704,
       "lat": 39.0314872
@@ -8380,7 +8380,7 @@
   },
   {
     "name": "Sultan Qaboos University",
-    "url": "http://ezproxysrv.squ.edu.om:2048/login?url=",
+    "url": "http://ezproxysrv.squ.edu.om:2048/login?url=$@",
     "location": {
       "lng": 58.17354719999999,
       "lat": 23.5896334
@@ -8389,7 +8389,7 @@
   },
   {
     "name": "Sungkyunkwan University, Campus of Natural Science",
-    "url": "https://sa.skku.edu:8443/link.n2s?url=",
+    "url": "https://sa.skku.edu:8443/link.n2s?url=$@",
     "location": {
       "lng": 126.993606,
       "lat": 37.588227
@@ -8398,7 +8398,7 @@
   },
   {
     "name": "Sungkyunkwan University, Humanities/Social Science Campus",
-    "url": "https://ca.skku.edu:8443/link.n2s?url=",
+    "url": "https://ca.skku.edu:8443/link.n2s?url=$@",
     "location": {
       "lng": 126.993606,
       "lat": 37.588227
@@ -8407,7 +8407,7 @@
   },
   {
     "name": "Sunway University",
-    "url": "http://ezproxy.sunway.edu.my/login?url=",
+    "url": "http://ezproxy.sunway.edu.my/login?url=$@",
     "location": {
       "lng": 101.603841,
       "lat": 3.0672267
@@ -8416,7 +8416,7 @@
   },
   {
     "name": "SUNY at Geneseo",
-    "url": "http://proxy.geneseo.edu:2048/login?url=",
+    "url": "http://proxy.geneseo.edu:2048/login?url=$@",
     "location": {
       "lng": -77.82386269999999,
       "lat": 42.79600689999999
@@ -8425,7 +8425,7 @@
   },
   {
     "name": "SUNY at Oswego",
-    "url": "http://ezproxy.oswego.edu:2048/login?url=",
+    "url": "http://ezproxy.oswego.edu:2048/login?url=$@",
     "location": {
       "lng": -76.5104973,
       "lat": 43.4553461
@@ -8434,7 +8434,7 @@
   },
   {
     "name": "SUNY Buffalo State",
-    "url": "http://proxy.buffalostate.edu:2048/login?url=",
+    "url": "http://proxy.buffalostate.edu:2048/login?url=$@",
     "location": {
       "lng": -78.87901889999999,
       "lat": 42.9325073
@@ -8443,7 +8443,7 @@
   },
   {
     "name": "SUNY Cobleskill",
-    "url": "http://ezproxy.cobleskill.edu:2048/login?url=",
+    "url": "http://ezproxy.cobleskill.edu:2048/login?url=$@",
     "location": {
       "lng": -74.49735629999999,
       "lat": 42.6737238
@@ -8452,7 +8452,7 @@
   },
   {
     "name": "SUNY Corning Community College",
-    "url": "http://ezproxy.corning-cc.edu:2048/login?url=",
+    "url": "http://ezproxy.corning-cc.edu:2048/login?url=$@",
     "location": {
       "lng": -77.0758942590317,
       "lat": 42.117082291751025
@@ -8461,7 +8461,7 @@
   },
   {
     "name": "SUNY Cortland",
-    "url": "http://libproxy.cortland.edu/login?url=",
+    "url": "http://libproxy.cortland.edu/login?url=$@",
     "location": {
       "lng": -76.187797,
       "lat": 42.599001
@@ -8470,7 +8470,7 @@
   },
   {
     "name": "SUNY Downstate",
-    "url": "http://newproxy.downstate.edu/login?url=",
+    "url": "http://newproxy.downstate.edu/login?url=$@",
     "location": {
       "lng": -73.94558649999999,
       "lat": 40.6555364
@@ -8479,7 +8479,7 @@
   },
   {
     "name": "SUNY Dutchess",
-    "url": "http://is-ezproxy01.sunydutchess.edu:2048/login?url=",
+    "url": "http://is-ezproxy01.sunydutchess.edu:2048/login?url=$@",
     "location": {
       "lng": -73.9050871,
       "lat": 41.7267034
@@ -8488,7 +8488,7 @@
   },
   {
     "name": "SUNY Empire State",
-    "url": "http://library.esc.edu/login?url=",
+    "url": "http://library.esc.edu/login?url=$@",
     "location": {
       "lng": -73.78239669999999,
       "lat": 43.0773483
@@ -8497,7 +8497,7 @@
   },
   {
     "name": "SUNY Environmental Science and Forestry",
-    "url": "https://esf.idm.oclc.org/login?url=",
+    "url": "https://esf.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -76.1366182,
       "lat": 43.0345102
@@ -8506,7 +8506,7 @@
   },
   {
     "name": "SUNY Farmingdale State",
-    "url": "http://hs1.farmingdale.edu:2048/login?url=",
+    "url": "http://hs1.farmingdale.edu:2048/login?url=$@",
     "location": {
       "lng": -73.4266988,
       "lat": 40.7529167
@@ -8515,7 +8515,7 @@
   },
   {
     "name": "SUNY Jefferson",
-    "url": "http://jccweb.sunyjefferson.edu:2048/login?url=",
+    "url": "http://jccweb.sunyjefferson.edu:2048/login?url=$@",
     "location": {
       "lng": -75.934691,
       "lat": 43.992231
@@ -8524,7 +8524,7 @@
   },
   {
     "name": "SUNY New Paltz",
-    "url": "https://libdatabase.newpaltz.edu/login?url=",
+    "url": "https://libdatabase.newpaltz.edu/login?url=$@",
     "location": {
       "lng": -74.085197,
       "lat": 41.73856199999999
@@ -8533,7 +8533,7 @@
   },
   {
     "name": "SUNY Onondaga",
-    "url": "http://ezproxy.sunyocc.edu:2048/login?url=",
+    "url": "http://ezproxy.sunyocc.edu:2048/login?url=$@",
     "location": {
       "lng": -76.1981087649764,
       "lat": 43.004495216327996
@@ -8542,7 +8542,7 @@
   },
   {
     "name": "SUNY Polytechnic Institute",
-    "url": "http://ezproxy.sunyit.edu/login?url=",
+    "url": "http://ezproxy.sunyit.edu/login?url=$@",
     "location": {
       "lng": -75.22732226529101,
       "lat": 43.137653063759736
@@ -8551,7 +8551,7 @@
   },
   {
     "name": "SUNY Rockland",
-    "url": "http://ezproxy.sunyrockland.edu:2048/login?url=",
+    "url": "http://ezproxy.sunyrockland.edu:2048/login?url=$@",
     "location": {
       "lng": -73.98300290000002,
       "lat": 41.1489458
@@ -8560,7 +8560,7 @@
   },
   {
     "name": "SUNY Schenectady County",
-    "url": "http://libproxy.sunysccc.edu/login?url=",
+    "url": "http://libproxy.sunysccc.edu/login?url=$@",
     "location": {
       "lng": -73.949913,
       "lat": 42.81469449999999
@@ -8569,7 +8569,7 @@
   },
   {
     "name": "SUNY University at Albany",
-    "url": "https://libproxy.albany.edu/login?url=",
+    "url": "https://libproxy.albany.edu/login?url=$@",
     "location": {
       "lng": -73.8247903,
       "lat": 42.6850273
@@ -8578,7 +8578,7 @@
   },
   {
     "name": "Swarthmore",
-    "url": "http://proxy.swarthmore.edu/login?url=",
+    "url": "http://proxy.swarthmore.edu/login?url=$@",
     "location": {
       "lng": -75.3499123,
       "lat": 39.9020565
@@ -8587,7 +8587,7 @@
   },
   {
     "name": "Swedish Defence University",
-    "url": "https://login.proxy.annalindhbiblioteket.se/login?url=",
+    "url": "https://login.proxy.annalindhbiblioteket.se/login?url=$@",
     "location": {
       "lng": 18.0694157,
       "lat": 59.3490856
@@ -8596,7 +8596,7 @@
   },
   {
     "name": "Swinburne University",
-    "url": "https://go.openathens.net/redirector/swin.edu.au?url=",
+    "url": "https://go.openathens.net/redirector/swin.edu.au?url=$@",
     "location": {
       "lng": 145.0389546,
       "lat": -37.8221504
@@ -8605,7 +8605,7 @@
   },
   {
     "name": "Syracuse",
-    "url": "http://libezproxy.syr.edu/login?url=",
+    "url": "http://libezproxy.syr.edu/login?url=$@",
     "location": {
       "lng": -76.14742439999999,
       "lat": 43.0481221
@@ -8614,7 +8614,7 @@
   },
   {
     "name": "Syracuse University",
-    "url": "https://login.libezproxy2.syr.edu/login?url=",
+    "url": "https://login.libezproxy2.syr.edu/login?url=$@",
     "location": {
       "lng": -76.1351158,
       "lat": 43.0391534
@@ -8623,7 +8623,7 @@
   },
   {
     "name": "Tallinna Ulikool",
-    "url": "http://ezproxy.tlu.ee/login?url=",
+    "url": "http://ezproxy.tlu.ee/login?url=$@",
     "location": {
       "lng": 24.7713836,
       "lat": 59.4387321
@@ -8632,7 +8632,7 @@
   },
   {
     "name": "Tarrant County",
-    "url": "http://ezp.tccd.edu/login?url=",
+    "url": "http://ezp.tccd.edu/login?url=$@",
     "location": {
       "lng": -97.35165579999999,
       "lat": 32.7732044
@@ -8641,7 +8641,7 @@
   },
   {
     "name": "Tartu Ulikooli",
-    "url": "https://ezproxy.utlib.ut.ee/login?url=",
+    "url": "https://ezproxy.utlib.ut.ee/login?url=$@",
     "location": {
       "lng": 26.7290383,
       "lat": 58.37798299999999
@@ -8650,7 +8650,7 @@
   },
   {
     "name": "Tatung university",
-    "url": "http://ezproxy.ttu.edu.tw/login?url=",
+    "url": "http://ezproxy.ttu.edu.tw/login?url=$@",
     "location": {
       "lng": 121.5217972,
       "lat": 25.0671976
@@ -8659,7 +8659,7 @@
   },
   {
     "name": "Taylor's University",
-    "url": "http://ezproxy.taylors.edu.my/login?url=",
+    "url": "http://ezproxy.taylors.edu.my/login?url=$@",
     "location": {
       "lng": 101.6168101,
       "lat": 3.064785
@@ -8668,7 +8668,7 @@
   },
   {
     "name": "Technical University of Denmark",
-    "url": "http://proxy.findit.cvt.dk/login?url=",
+    "url": "http://proxy.findit.cvt.dk/login?url=$@",
     "location": {
       "lng": 12.521381,
       "lat": 55.7855742
@@ -8677,7 +8677,7 @@
   },
   {
     "name": "Technion",
-    "url": "http://ezlibrary.technion.ac.il/login?url=",
+    "url": "http://ezlibrary.technion.ac.il/login?url=$@",
     "location": {
       "lng": 35.0231271,
       "lat": 32.7767783
@@ -8686,7 +8686,7 @@
   },
   {
     "name": "Technische Hochschule Ingolstadt",
-    "url": "http://thi.idm.oclc.org/login?url=",
+    "url": "http://thi.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 11.4319822,
       "lat": 48.7668196
@@ -8695,7 +8695,7 @@
   },
   {
     "name": "Technische Uni Munchen",
-    "url": "https://eaccess.ub.tum.de:2443/login?url=",
+    "url": "https://eaccess.ub.tum.de:2443/login?url=$@",
     "location": {
       "lng": 11.5678602,
       "lat": 48.14966
@@ -8704,7 +8704,7 @@
   },
   {
     "name": "Technische Universiteit Delft",
-    "url": "http://tudelft.idm.oclc.org/login?url=",
+    "url": "http://tudelft.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 4.3735766,
       "lat": 52.0021919
@@ -8713,7 +8713,7 @@
   },
   {
     "name": "Technische Universität München",
-    "url": "https://eaccess.ub.tum.de/login?url=",
+    "url": "https://eaccess.ub.tum.de/login?url=$@",
     "location": {
       "lng": 11.5678602,
       "lat": 48.14966
@@ -8722,7 +8722,7 @@
   },
   {
     "name": "Tel Aviv University (TAU)",
-    "url": "http://rproxy.tau.ac.il/login?url=",
+    "url": "http://rproxy.tau.ac.il/login?url=$@",
     "location": {
       "lng": 34.8043877,
       "lat": 32.1133141
@@ -8731,7 +8731,7 @@
   },
   {
     "name": "Temple University",
-    "url": "http://libproxy.temple.edu/login?url=",
+    "url": "http://libproxy.temple.edu/login?url=$@",
     "location": {
       "lng": -75.1553563,
       "lat": 39.9811911
@@ -8740,7 +8740,7 @@
   },
   {
     "name": "Tennessee Tech",
-    "url": "https://login.ezproxy.tntech.edu/login?qurl=",
+    "url": "https://login.ezproxy.tntech.edu/login?qurl=$@",
     "location": {
       "lng": -85.50910859999999,
       "lat": 36.1763138
@@ -8749,7 +8749,7 @@
   },
   {
     "name": "Texas A M",
-    "url": "http://lib-ezproxy.tamu.edu:2048/login?url=",
+    "url": "http://lib-ezproxy.tamu.edu:2048/login?url=$@",
     "location": {
       "lng": -96.33646549999999,
       "lat": 30.6186806
@@ -8758,7 +8758,7 @@
   },
   {
     "name": "Texas A&M University - Texarkana",
-    "url": "http://dbproxy.tamut.edu/login?url=",
+    "url": "http://dbproxy.tamut.edu/login?url=$@",
     "location": {
       "lng": -96.33646549999999,
       "lat": 30.6186806
@@ -8767,7 +8767,7 @@
   },
   {
     "name": "Texas A&M University School of Law",
-    "url": "http://lawresearch.tamu.edu/login?url=",
+    "url": "http://lawresearch.tamu.edu/login?url=$@",
     "location": {
       "lng": -96.33646549999999,
       "lat": 30.6186806
@@ -8776,7 +8776,7 @@
   },
   {
     "name": "Texas A&M University-Commerce",
-    "url": "https://login.proxy.tamuc.edu/login?url=",
+    "url": "https://login.proxy.tamuc.edu/login?url=$@",
     "location": {
       "lng": -96.33646549999999,
       "lat": 30.6186806
@@ -8785,7 +8785,7 @@
   },
   {
     "name": "Texas A&M University-Texarkana",
-    "url": "https://login.tamut.idm.oclc.org/login?qurl=",
+    "url": "https://login.tamut.idm.oclc.org/login?qurl=$@",
     "location": {
       "lng": -96.33646549999999,
       "lat": 30.6186806
@@ -8794,7 +8794,7 @@
   },
   {
     "name": "Texas A&M Universtiy",
-    "url": "http://ezproxy.library.tamu.edu/login?url=",
+    "url": "http://ezproxy.library.tamu.edu/login?url=$@",
     "location": {
       "lng": -96.33646549999999,
       "lat": 30.6186806
@@ -8803,7 +8803,7 @@
   },
   {
     "name": "Texas State University",
-    "url": "https://login.libproxy.txstate.edu/login?qurl=",
+    "url": "https://login.libproxy.txstate.edu/login?qurl=$@",
     "location": {
       "lng": -97.938351,
       "lat": 29.888411
@@ -8812,7 +8812,7 @@
   },
   {
     "name": "Texas Tech",
-    "url": "http://ezp.lib.ttu.edu/login?url=",
+    "url": "http://ezp.lib.ttu.edu/login?url=$@",
     "location": {
       "lng": -101.8782822,
       "lat": 33.5842591
@@ -8821,7 +8821,7 @@
   },
   {
     "name": "Texas Tech University Health Sciences Center",
-    "url": "http://ezproxy.ttuhsc.edu/login?url=",
+    "url": "http://ezproxy.ttuhsc.edu/login?url=$@",
     "location": {
       "lng": -101.8912035,
       "lat": 33.5901499
@@ -8830,7 +8830,7 @@
   },
   {
     "name": "Texas Wesleyan",
-    "url": "https://ejwl.idm.oclc.org/login?url=",
+    "url": "https://ejwl.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -97.28020699999999,
       "lat": 32.7323764
@@ -8839,7 +8839,7 @@
   },
   {
     "name": "Texas Woman's University",
-    "url": "http://ezp.twu.edu/login?url=",
+    "url": "http://ezp.twu.edu/login?url=$@",
     "location": {
       "lng": -97.12705199999999,
       "lat": 33.2272211
@@ -8848,7 +8848,7 @@
   },
   {
     "name": "Texas Womans",
-    "url": "http://ezproxy.twu.edu:2048/login?url=",
+    "url": "http://ezproxy.twu.edu:2048/login?url=$@",
     "location": {
       "lng": -97.12705199999999,
       "lat": 33.2272211
@@ -8857,7 +8857,7 @@
   },
   {
     "name": "Thammasat University",
-    "url": "https://ezproxy.tulibs.net/login?url=",
+    "url": "https://ezproxy.tulibs.net/login?url=$@",
     "location": {
       "lng": 100.60298781742311,
       "lat": 14.129506395353289
@@ -8866,7 +8866,7 @@
   },
   {
     "name": "The American College of Greece",
-    "url": "https://acg.idm.oclc.org/login?url=",
+    "url": "https://acg.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 23.8303395,
       "lat": 38.0036919
@@ -8875,7 +8875,7 @@
   },
   {
     "name": "The Chinese University of Hong Kong",
-    "url": "http://easyaccess.lib.cuhk.edu.hk/login?url=",
+    "url": "http://easyaccess.lib.cuhk.edu.hk/login?url=$@",
     "location": {
       "lng": 114.2067606,
       "lat": 22.419625
@@ -8884,7 +8884,7 @@
   },
   {
     "name": "The College at Brockport",
-    "url": "http://ezproxy.drake.brockport.edu:2048/login?url=",
+    "url": "http://ezproxy.drake.brockport.edu:2048/login?url=$@",
     "location": {
       "lng": -77.95108309999999,
       "lat": 43.2103817
@@ -8893,7 +8893,7 @@
   },
   {
     "name": "The Education University of Hong Kong",
-    "url": "https://ezproxy.eduhk.hk/login?qurl=",
+    "url": "https://ezproxy.eduhk.hk/login?qurl=$@",
     "location": {
       "lng": 114.1936333,
       "lat": 22.4670285
@@ -8902,7 +8902,7 @@
   },
   {
     "name": "The George Washington University",
-    "url": "http://proxygw.wrlc.org/login?url=",
+    "url": "http://proxygw.wrlc.org/login?url=$@",
     "location": {
       "lng": -77.0485992,
       "lat": 38.8997145
@@ -8911,7 +8911,7 @@
   },
   {
     "name": "The Hong Kong Polytechnic University",
-    "url": "https://ezproxy.lb.polyu.edu.hk/login?url=",
+    "url": "https://ezproxy.lb.polyu.edu.hk/login?url=$@",
     "location": {
       "lng": 114.1798118,
       "lat": 22.3042407
@@ -8920,7 +8920,7 @@
   },
   {
     "name": "The Jackson Laboratory",
-    "url": "http://ezproxy.jax.org/login?url=",
+    "url": "http://ezproxy.jax.org/login?url=$@",
     "location": {
       "lng": -68.20073836543226,
       "lat": 44.506799852553584
@@ -8929,7 +8929,7 @@
   },
   {
     "name": "The Jackson Laboratory for Genomic Medicine",
-    "url": "https://login.ezproxy.jax.org/login?url=",
+    "url": "https://login.ezproxy.jax.org/login?url=$@",
     "location": {
       "lng": -72.7934038,
       "lat": 41.7322837
@@ -8938,7 +8938,7 @@
   },
   {
     "name": "The London School of Economics and Political Science (LSE)",
-    "url": "https://gate2.library.lse.ac.uk/login?url=",
+    "url": "https://gate2.library.lse.ac.uk/login?url=$@",
     "location": {
       "lng": -0.1164513,
       "lat": 51.5144388
@@ -8947,7 +8947,7 @@
   },
   {
     "name": "The New School",
-    "url": "http://libproxy.newschool.edu/login?url=",
+    "url": "http://libproxy.newschool.edu/login?url=$@",
     "location": {
       "lng": -73.9971361,
       "lat": 40.7354925
@@ -8956,7 +8956,7 @@
   },
   {
     "name": "The Royal College of Surgeons in Ireland",
-    "url": "https://login.proxy.library.rcsi.ie/login?url=",
+    "url": "https://login.proxy.library.rcsi.ie/login?url=$@",
     "location": {
       "lng": -6.263110999999999,
       "lat": 53.3391467
@@ -8965,7 +8965,7 @@
   },
   {
     "name": "The University at Buffalo",
-    "url": "https://gate.lib.buffalo.edu/login?url=",
+    "url": "https://gate.lib.buffalo.edu/login?url=$@",
     "location": {
       "lng": -78.7889697,
       "lat": 43.0008093
@@ -8974,7 +8974,7 @@
   },
   {
     "name": "The University of Alabama at Birmingham",
-    "url": "http://ezproxy3.lhl.uab.edu/login?url=",
+    "url": "http://ezproxy3.lhl.uab.edu/login?url=$@",
     "location": {
       "lng": -86.80574949999999,
       "lat": 33.5020323
@@ -8983,7 +8983,7 @@
   },
   {
     "name": "The University of Manchester",
-    "url": "http://manchester.idm.oclc.org/login?url=",
+    "url": "http://manchester.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -2.2338837,
       "lat": 53.4668498
@@ -8992,7 +8992,7 @@
   },
   {
     "name": "The Wikipedia Library",
-    "url": "https://wikipedialibrary.idm.oclc.org/login?auth=production&url=",
+    "url": "https://wikipedialibrary.idm.oclc.org/login?auth=production&url=$@",
     "location": {
       "lng": -122.4022865025427,
       "lat": 37.78943853012844
@@ -9001,7 +9001,7 @@
   },
   {
     "name": "Thomas More",
-    "url": "http://library.thomasmore.edu:2048/login?url=",
+    "url": "http://library.thomasmore.edu:2048/login?url=$@",
     "location": {
       "lng": -84.58710197194668,
       "lat": 39.13796015015666
@@ -9010,7 +9010,7 @@
   },
   {
     "name": "Toronto Metropolitan University",
-    "url": "https://ezproxy.lib.torontomu.ca/login?url=",
+    "url": "https://ezproxy.lib.torontomu.ca/login?url=$@",
     "location": {
       "lng": -79.3788017,
       "lat": 43.6576585
@@ -9019,7 +9019,7 @@
   },
   {
     "name": "Trent University",
-    "url": "http://web2.trentu.ca:2048/login?url=",
+    "url": "http://web2.trentu.ca:2048/login?url=$@",
     "location": {
       "lng": -78.2905232,
       "lat": 44.3576781
@@ -9028,7 +9028,7 @@
   },
   {
     "name": "Trent University",
-    "url": "http://cat1.lib.trentu.ca:2048/login?url=",
+    "url": "http://cat1.lib.trentu.ca:2048/login?url=$@",
     "location": {
       "lng": -78.29062294212818,
       "lat": 44.358354457586834
@@ -9037,7 +9037,7 @@
   },
   {
     "name": "Trinity College Dublin, Ireland",
-    "url": "http://elib.tcd.ie/login?url=",
+    "url": "http://elib.tcd.ie/login?url=$@",
     "location": {
       "lng": -6.254571599999999,
       "lat": 53.3437935
@@ -9046,7 +9046,7 @@
   },
   {
     "name": "Trinity University",
-    "url": "http://libproxy.trinity.edu/login?url=",
+    "url": "http://libproxy.trinity.edu/login?url=$@",
     "location": {
       "lng": -98.4816717139737,
       "lat": 29.460359894160632
@@ -9055,7 +9055,7 @@
   },
   {
     "name": "Tufts University",
-    "url": "http://ezproxy.library.tufts.edu/login?url=",
+    "url": "http://ezproxy.library.tufts.edu/login?url=$@",
     "location": {
       "lng": -71.1182729,
       "lat": 42.4085371
@@ -9064,7 +9064,7 @@
   },
   {
     "name": "Tulane",
-    "url": "https://login.libproxy.tulane.edu/login?qurl=",
+    "url": "https://login.libproxy.tulane.edu/login?qurl=$@",
     "location": {
       "lng": -90.12031669999999,
       "lat": 29.9407282
@@ -9073,7 +9073,7 @@
   },
   {
     "name": "Tulane University",
-    "url": "http://libproxy.tulane.edu:2048/login?url=",
+    "url": "http://libproxy.tulane.edu:2048/login?url=$@",
     "location": {
       "lng": -90.12031669999999,
       "lat": 29.9407282
@@ -9082,7 +9082,7 @@
   },
   {
     "name": "Turun yliopisto",
-    "url": "http://ezproxy.utu.fi:2048/login?url=",
+    "url": "http://ezproxy.utu.fi:2048/login?url=$@",
     "location": {
       "lng": 22.284785,
       "lat": 60.45422669999999
@@ -9091,7 +9091,7 @@
   },
   {
     "name": "Tyndale University College Seminary",
-    "url": "http://ezproxy.mytyndale.ca:2048/login?url=",
+    "url": "http://ezproxy.mytyndale.ca:2048/login?url=$@",
     "location": {
       "lng": -79.39220639999999,
       "lat": 43.7971607
@@ -9100,7 +9100,7 @@
   },
   {
     "name": "U S Army Medical Department Center and School",
-    "url": "http://stimson.idm.oclc.org/login?url=",
+    "url": "http://stimson.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -95.712891,
       "lat": 37.09024
@@ -9109,7 +9109,7 @@
   },
   {
     "name": "UC Berkeley",
-    "url": "https://libproxy.berkeley.edu/login?url=",
+    "url": "https://libproxy.berkeley.edu/login?url=$@",
     "location": {
       "lng": -122.2594606,
       "lat": 37.87015100000001
@@ -9118,7 +9118,7 @@
   },
   {
     "name": "UC Hastings College of the Law",
-    "url": "http://uchastings.idm.oclc.org/login?url=",
+    "url": "http://uchastings.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.4157619,
       "lat": 37.7811225
@@ -9127,7 +9127,7 @@
   },
   {
     "name": "UC San Diego",
-    "url": "http://proxy.library.ucsd.edu:2048/login?url=",
+    "url": "http://proxy.library.ucsd.edu:2048/login?url=$@",
     "location": {
       "lng": -117.2340135,
       "lat": 32.8800604
@@ -9136,7 +9136,7 @@
   },
   {
     "name": "UC Santa Cruz",
-    "url": "http://oca.ucsc.edu/login?url=",
+    "url": "http://oca.ucsc.edu/login?url=$@",
     "location": {
       "lng": -122.0584354,
       "lat": 36.9905322
@@ -9145,7 +9145,7 @@
   },
   {
     "name": "UIC Peoria Library",
-    "url": "https://proxy.cc.uic.edu/login?url=",
+    "url": "https://proxy.cc.uic.edu/login?url=$@",
     "location": {
       "lng": -89.5972747,
       "lat": 40.6984596
@@ -9154,7 +9154,7 @@
   },
   {
     "name": "Umea University",
-    "url": "http://proxy.ub.umu.se/login?url=",
+    "url": "http://proxy.ub.umu.se/login?url=$@",
     "location": {
       "lng": 20.3054461,
       "lat": 63.82022240000001
@@ -9163,7 +9163,7 @@
   },
   {
     "name": "UNED",
-    "url": "http://ezproxy.uned.es/login?url=",
+    "url": "http://ezproxy.uned.es/login?url=$@",
     "location": {
       "lng": -3.7040528,
       "lat": 40.4380164
@@ -9172,7 +9172,7 @@
   },
   {
     "name": "Uni Heidelberg",
-    "url": "http://ubproxy.ub.uni-heidelberg.de/login?qurl=",
+    "url": "http://ubproxy.ub.uni-heidelberg.de/login?qurl=$@",
     "location": {
       "lng": 8.6702507,
       "lat": 49.4190991
@@ -9181,7 +9181,7 @@
   },
   {
     "name": "Uni Heidelberg Medizinischen Fakultat Mannheim",
-    "url": "http://ezproxy.medma.uni-heidelberg.de/login?url=",
+    "url": "http://ezproxy.medma.uni-heidelberg.de/login?url=$@",
     "location": {
       "lng": 8.6702507,
       "lat": 49.4190991
@@ -9190,7 +9190,7 @@
   },
   {
     "name": "Uni Passau",
-    "url": "http://docweb.rz.uni-passau.de:2048/login?url=",
+    "url": "http://docweb.rz.uni-passau.de:2048/login?url=$@",
     "location": {
       "lng": 13.4527974,
       "lat": 48.5677779
@@ -9199,7 +9199,7 @@
   },
   {
     "name": "Uni Zurich",
-    "url": "http://ezproxy.uzh.ch/login?url=",
+    "url": "http://ezproxy.uzh.ch/login?url=$@",
     "location": {
       "lng": 8.5486629,
       "lat": 47.3745896
@@ -9208,7 +9208,7 @@
   },
   {
     "name": "Uniformed Services",
-    "url": "http://lrc1.usuhs.edu/login?url=",
+    "url": "http://lrc1.usuhs.edu/login?url=$@",
     "location": {
       "lng": -98.44018395832336,
       "lat": 29.458764300608614
@@ -9217,7 +9217,7 @@
   },
   {
     "name": "Union College",
-    "url": "https://linus.ucollege.edu:8443/login?url=",
+    "url": "https://linus.ucollege.edu:8443/login?url=$@",
     "location": {
       "lng": -96.65243256977679,
       "lat": 40.77355371239728
@@ -9226,7 +9226,7 @@
   },
   {
     "name": "United Nations Office at Geneva",
-    "url": "http://lib-ezproxy.unog.ch/login?url=",
+    "url": "http://lib-ezproxy.unog.ch/login?url=$@",
     "location": {
       "lng": 6.140292199999999,
       "lat": 46.2266738
@@ -9235,7 +9235,7 @@
   },
   {
     "name": "Univeristy of New Mexico",
-    "url": "http://libproxy.unm.edu/login?url=",
+    "url": "http://libproxy.unm.edu/login?url=$@",
     "location": {
       "lng": -105.8700901,
       "lat": 34.5199402
@@ -9244,7 +9244,7 @@
   },
   {
     "name": "Universal College of Learning",
-    "url": "http://ezproxy.ucol.ac.nz/login?url=",
+    "url": "http://ezproxy.ucol.ac.nz/login?url=$@",
     "location": {
       "lng": 175.6134364,
       "lat": -40.3522695
@@ -9253,7 +9253,7 @@
   },
   {
     "name": "Universidad Alfonso X El Sabio",
-    "url": "https://login.ezproxy.uax.es/login?url=",
+    "url": "https://login.ezproxy.uax.es/login?url=$@",
     "location": {
       "lng": -3.5614483977684137,
       "lat": 40.624031690762735
@@ -9262,7 +9262,7 @@
   },
   {
     "name": "Universidad Autonoma Metropolitana",
-    "url": "http://www.bidi.uam.mx:2048/login?url=",
+    "url": "http://www.bidi.uam.mx:2048/login?url=$@",
     "location": {
       "lng": -99.1368474,
       "lat": 19.2870551
@@ -9271,7 +9271,7 @@
   },
   {
     "name": "Universidad Autónoma Metropolitana",
-    "url": "https://bidi.uam.mx:2048/login?url=",
+    "url": "https://bidi.uam.mx:2048/login?url=$@",
     "location": {
       "lng": -99.1368474,
       "lat": 19.2870551
@@ -9280,7 +9280,7 @@
   },
   {
     "name": "Universidad Carlos III de Madrid",
-    "url": "https://strauss.uc3m.es:2443/login?url=",
+    "url": "https://strauss.uc3m.es:2443/login?url=$@",
     "location": {
       "lng": -3.730530787359002,
       "lat": 40.33200858610548
@@ -9289,7 +9289,7 @@
   },
   {
     "name": "Universidad Catolica del Norte",
-    "url": "http://ezproxy.ucn.cl/login?url=",
+    "url": "http://ezproxy.ucn.cl/login?url=$@",
     "location": {
       "lng": -68.1995587,
       "lat": -22.9099822
@@ -9298,7 +9298,7 @@
   },
   {
     "name": "Universidad Complutense de Madrid",
-    "url": "http://bucm.idm.oclc.org/login?url=",
+    "url": "http://bucm.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -3.7299424,
       "lat": 40.4454368
@@ -9307,7 +9307,7 @@
   },
   {
     "name": "Universidad Cooperativa de Colombia",
-    "url": "http://bbibliograficas.ucc.edu.co/login?url=",
+    "url": "http://bbibliograficas.ucc.edu.co/login?url=$@",
     "location": {
       "lng": -75.54555221975593,
       "lat": 6.837254128453907
@@ -9316,7 +9316,7 @@
   },
   {
     "name": "Universidad de Chile",
-    "url": "https://uchile.idm.oclc.org/login?url=",
+    "url": "https://uchile.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -70.6509277,
       "lat": -33.4445204
@@ -9325,7 +9325,7 @@
   },
   {
     "name": "Universidad de Concepción",
-    "url": "http://ezproxy.udec.cl/login?url=",
+    "url": "http://ezproxy.udec.cl/login?url=$@",
     "location": {
       "lng": -73.0341825,
       "lat": -36.8294765
@@ -9334,7 +9334,7 @@
   },
   {
     "name": "Universidad de Costa Rica",
-    "url": "http://ezproxy.sibdi.ucr.ac.cr:2048/login?url=",
+    "url": "http://ezproxy.sibdi.ucr.ac.cr:2048/login?url=$@",
     "location": {
       "lng": -84.0503749,
       "lat": 9.937380899999999
@@ -9343,7 +9343,7 @@
   },
   {
     "name": "Universidad de Guadalajara",
-    "url": "https://login.wdg.biblio.udg.mx:8443/login?url=",
+    "url": "https://login.wdg.biblio.udg.mx:8443/login?url=$@",
     "location": {
       "lng": -103.3589843,
       "lat": 20.6748238
@@ -9352,7 +9352,7 @@
   },
   {
     "name": "Universidad de Lleida",
-    "url": "http://proxy.alumnes.udl.cat:8080/log=",
+    "url": "http://proxy.alumnes.udl.cat:8080/log=$@",
     "location": {
       "lng": 0.6196167,
       "lat": 41.6147654
@@ -9361,7 +9361,7 @@
   },
   {
     "name": "Universidad de los Andes",
-    "url": "https://login.ezproxy.uniandes.edu.co:8443/login?url=",
+    "url": "https://login.ezproxy.uniandes.edu.co:8443/login?url=$@",
     "location": {
       "lng": -74.0661334,
       "lat": 4.601458099999999
@@ -9370,7 +9370,7 @@
   },
   {
     "name": "Universidad de Navarra",
-    "url": "http://ezproxy.unav.es:2048/login?url=",
+    "url": "http://ezproxy.unav.es:2048/login?url=$@",
     "location": {
       "lng": -75.38034871029625,
       "lat": 3.3748728756568958
@@ -9379,7 +9379,7 @@
   },
   {
     "name": "Universidad de Oviedo",
-    "url": "http://uniovi.idm.oclc.org/login?url=",
+    "url": "http://uniovi.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -5.8463007,
       "lat": 43.36194649999999
@@ -9388,7 +9388,7 @@
   },
   {
     "name": "Universidad del Valle",
-    "url": "http://bd.univalle.edu.co/login?url=",
+    "url": "http://bd.univalle.edu.co/login?url=$@",
     "location": {
       "lng": -76.5222438089478,
       "lat": 3.4271129544677175
@@ -9397,7 +9397,7 @@
   },
   {
     "name": "Universidad EAFIT",
-    "url": "http://ezproxy.eafit.edu.co/login?url=",
+    "url": "http://ezproxy.eafit.edu.co/login?url=$@",
     "location": {
       "lng": -75.5792681,
       "lat": 6.1997094
@@ -9406,7 +9406,7 @@
   },
   {
     "name": "Universidad Industrial de Santander",
-    "url": "http://ezproxy.uis.edu.co:2048/login?url=",
+    "url": "http://ezproxy.uis.edu.co:2048/login?url=$@",
     "location": {
       "lng": -73.05371177230583,
       "lat": 7.742045158351845
@@ -9415,7 +9415,7 @@
   },
   {
     "name": "Universidad Interamericana de Puerto Rico Recinto de Arecibo",
-    "url": "http://ezproxy.arecibo.inter.edu:2048/login?url=",
+    "url": "http://ezproxy.arecibo.inter.edu:2048/login?url=$@",
     "location": {
       "lng": -66.75943819999999,
       "lat": 18.4757179
@@ -9424,7 +9424,7 @@
   },
   {
     "name": "Universidad Nacional Autónoma de México",
-    "url": "http://pbidi.unam.mx:8080/login?url=",
+    "url": "http://pbidi.unam.mx:8080/login?url=$@",
     "location": {
       "lng": -99.1876103,
       "lat": 19.332795
@@ -9433,7 +9433,7 @@
   },
   {
     "name": "Universidad Nacional Autónoma de México Campus Morelos",
-    "url": "https://biblioteca.ibt.unam.mx:8080/login?url=",
+    "url": "https://biblioteca.ibt.unam.mx:8080/login?url=$@",
     "location": {
       "lng": -99.1013498,
       "lat": 18.6813049
@@ -9442,7 +9442,7 @@
   },
   {
     "name": "Universidad Nacional de Colombia",
-    "url": "http://ezproxy.unal.edu.co/login?url=",
+    "url": "http://ezproxy.unal.edu.co/login?url=$@",
     "location": {
       "lng": -74.08404639999999,
       "lat": 4.6381938
@@ -9451,7 +9451,7 @@
   },
   {
     "name": "Universidad Nacional de Villa María",
-    "url": "http://ezproxy.unvm.edu.ar/login?url=",
+    "url": "http://ezproxy.unvm.edu.ar/login?url=$@",
     "location": {
       "lng": -63.2607983,
       "lat": -32.3822336
@@ -9460,7 +9460,7 @@
   },
   {
     "name": "Universidad Técnica Federico Santa María (UTFSM)",
-    "url": "https://login.usm.idm.oclc.org/login?url=",
+    "url": "https://login.usm.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -71.5967794,
       "lat": -33.0352386
@@ -9469,7 +9469,7 @@
   },
   {
     "name": "Universidade da Coruña (UdC)",
-    "url": "https://accedys.udc.es/login?url=",
+    "url": "https://accedys.udc.es/login?url=$@",
     "location": {
       "lng": -8.4115401,
       "lat": 43.3623436
@@ -9478,7 +9478,7 @@
   },
   {
     "name": "Universidade de Santiago de Compostela (BUSC)",
-    "url": "https://ezbusc.usc.gal/login?url=",
+    "url": "https://ezbusc.usc.gal/login?url=$@",
     "location": {
       "lng": -8.5452013,
       "lat": 42.87912360000001
@@ -9487,7 +9487,7 @@
   },
   {
     "name": "Universidade Federal do Rio de Janeiro (UFRJ)",
-    "url": "http://ez29.periodicos.capes.gov.br/login?url=",
+    "url": "http://ez29.periodicos.capes.gov.br/login?url=$@",
     "location": {
       "lng": -43.2234737,
       "lat": -22.8625345
@@ -9496,7 +9496,7 @@
   },
   {
     "name": "Universidade Federal do Rio Grande do Sul",
-    "url": "https://http://Ez45.periodicos.capes.gov.br/login?=",
+    "url": "https://http://Ez45.periodicos.capes.gov.br/login?=$@",
     "location": {
       "lng": -51.2190483,
       "lat": -30.0339726
@@ -9505,7 +9505,7 @@
   },
   {
     "name": "Universita degli studi di Milano",
-    "url": "http://ezproxy.pros.lib.unimi.it/login?url=",
+    "url": "http://ezproxy.pros.lib.unimi.it/login?url=$@",
     "location": {
       "lng": 9.189982,
       "lat": 45.4642035
@@ -9514,7 +9514,7 @@
   },
   {
     "name": "Universita degli Studi di Sassari",
-    "url": "http://proxysba.uniss.it:2048/login?url=",
+    "url": "http://proxysba.uniss.it:2048/login?url=$@",
     "location": {
       "lng": 8.5596912,
       "lat": 40.7248609
@@ -9523,7 +9523,7 @@
   },
   {
     "name": "Universita degli Studi di Siena",
-    "url": "http://asbproxy.unisi.it:2048/login?url=",
+    "url": "http://asbproxy.unisi.it:2048/login?url=$@",
     "location": {
       "lng": 11.3328421,
       "lat": 43.3191155
@@ -9532,7 +9532,7 @@
   },
   {
     "name": "Universita degli Studi di Trento",
-    "url": "http://ezp.biblio.unitn.it/login?url=",
+    "url": "http://ezp.biblio.unitn.it/login?url=$@",
     "location": {
       "lng": 11.1231091,
       "lat": 46.0668672
@@ -9541,7 +9541,7 @@
   },
   {
     "name": "Universita degli Studi G dAnnunzio Chieti",
-    "url": "http://biblioproxy.unich.it/login?url=",
+    "url": "http://biblioproxy.unich.it/login?url=$@",
     "location": {
       "lng": 14.1360532,
       "lat": 42.3498508
@@ -9550,7 +9550,7 @@
   },
   {
     "name": "Universitas Indonesia",
-    "url": "http://remote-lib.ui.ac.id/login?url=",
+    "url": "http://remote-lib.ui.ac.id/login?url=$@",
     "location": {
       "lng": 106.8272343,
       "lat": -6.3606229
@@ -9559,7 +9559,7 @@
   },
   {
     "name": "Universitat Autonoma de Barcelona",
-    "url": "https://login.are.uab.cat/login?url=",
+    "url": "https://login.are.uab.cat/login?url=$@",
     "location": {
       "lng": 2.1038536,
       "lat": 41.5021421
@@ -9568,7 +9568,7 @@
   },
   {
     "name": "Universitat Politècnica de Catalunya",
-    "url": "http://recursos.biblioteca.upc.edu/login?url=",
+    "url": "http://recursos.biblioteca.upc.edu/login?url=$@",
     "location": {
       "lng": 2.1157401,
       "lat": 41.3892675
@@ -9577,7 +9577,7 @@
   },
   {
     "name": "Universitatea Tehnică Gheorghe Asachi din Iași",
-    "url": "http://am.e-nformation.ro/login?url=",
+    "url": "http://am.e-nformation.ro/login?url=$@",
     "location": {
       "lng": 27.599396,
       "lat": 47.1545977
@@ -9586,7 +9586,7 @@
   },
   {
     "name": "Universite catholique de Louvain",
-    "url": "http://proxy.bib.ucl.ac.be:888/login?url=",
+    "url": "http://proxy.bib.ucl.ac.be:888/login?url=$@",
     "location": {
       "lng": 4.615875,
       "lat": 50.6696767
@@ -9595,7 +9595,7 @@
   },
   {
     "name": "Universite dAngers",
-    "url": "http://buadistant.univ-angers.fr/login?url=",
+    "url": "http://buadistant.univ-angers.fr/login?url=$@",
     "location": {
       "lng": -0.5499261999999999,
       "lat": 47.4771248
@@ -9604,7 +9604,7 @@
   },
   {
     "name": "Universite de Bourgogne",
-    "url": "http://proxy-scd.u-bourgogne.fr/login?url=",
+    "url": "http://proxy-scd.u-bourgogne.fr/login?url=$@",
     "location": {
       "lng": 5.0713319,
       "lat": 47.3119618
@@ -9613,7 +9613,7 @@
   },
   {
     "name": "Universite de la Reunion",
-    "url": "http://elgebar.univ-reunion.fr/login?url=",
+    "url": "http://elgebar.univ-reunion.fr/login?url=$@",
     "location": {
       "lng": 55.48522209999999,
       "lat": -20.9017358
@@ -9622,7 +9622,7 @@
   },
   {
     "name": "Universite de Lille 1",
-    "url": "http://docproxy.univ-lille1.fr/login?url=",
+    "url": "http://docproxy.univ-lille1.fr/login?url=$@",
     "location": {
       "lng": 3.1417556,
       "lat": 50.6085867
@@ -9631,7 +9631,7 @@
   },
   {
     "name": "Universite de Limoges",
-    "url": "http://ezproxy.unilim.fr/login?url=",
+    "url": "http://ezproxy.unilim.fr/login?url=$@",
     "location": {
       "lng": 1.2600835,
       "lat": 45.8245713
@@ -9640,7 +9640,7 @@
   },
   {
     "name": "Universite de Lorraine",
-    "url": "http://bases-doc.univ-lorraine.fr/login?url=",
+    "url": "http://bases-doc.univ-lorraine.fr/login?url=$@",
     "location": {
       "lng": 6.1765379,
       "lat": 48.6961769
@@ -9649,7 +9649,7 @@
   },
   {
     "name": "Universite de Moncton",
-    "url": "http://proxy.cm.umoncton.ca/login?url=",
+    "url": "http://proxy.cm.umoncton.ca/login?url=$@",
     "location": {
       "lng": -64.78176189999999,
       "lat": 46.1050904
@@ -9658,7 +9658,7 @@
   },
   {
     "name": "Universite de Nice Sophia Antipolis",
-    "url": "http://proxy.unice.fr/login?url=",
+    "url": "http://proxy.unice.fr/login?url=$@",
     "location": {
       "lng": 7.244464002644414,
       "lat": 43.696173476554364
@@ -9667,7 +9667,7 @@
   },
   {
     "name": "Universite de technologie de Troyes",
-    "url": "http://proxy.utt.fr/login?url=",
+    "url": "http://proxy.utt.fr/login?url=$@",
     "location": {
       "lng": 4.066776100000001,
       "lat": 48.26916199999999
@@ -9676,7 +9676,7 @@
   },
   {
     "name": "Universite du Quebec a Chicoutimi",
-    "url": "http://sbiproxy.uqac.ca/login?url=",
+    "url": "http://sbiproxy.uqac.ca/login?url=$@",
     "location": {
       "lng": -71.052621,
       "lat": 48.419008
@@ -9685,7 +9685,7 @@
   },
   {
     "name": "Universite du Quebec a Montreal",
-    "url": "http://proxy.bibliotheques.uqam.ca:2048/login?url=",
+    "url": "http://proxy.bibliotheques.uqam.ca:2048/login?url=$@",
     "location": {
       "lng": -73.5602937,
       "lat": 45.5131547
@@ -9694,7 +9694,7 @@
   },
   {
     "name": "Universite Lille 2",
-    "url": "http://doc-distant.univ-lille2.fr/login?url=",
+    "url": "http://doc-distant.univ-lille2.fr/login?url=$@",
     "location": {
       "lng": 3.057256,
       "lat": 50.62925
@@ -9703,7 +9703,7 @@
   },
   {
     "name": "Universite Ouest Nanterre La Defense",
-    "url": "http://faraway.u-paris10.fr/login?url=",
+    "url": "http://faraway.u-paris10.fr/login?url=$@",
     "location": {
       "lng": 2.2418428,
       "lat": 48.8897359
@@ -9712,7 +9712,7 @@
   },
   {
     "name": "Universite Paris 1 Pantheon-Sorbonne",
-    "url": "http://ezproxy.univ-paris1.fr/login?url=",
+    "url": "http://ezproxy.univ-paris1.fr/login?url=$@",
     "location": {
       "lng": 2.3448603,
       "lat": 48.8468057
@@ -9721,7 +9721,7 @@
   },
   {
     "name": "Universite Paris Diderot",
-    "url": "http://rproxy.sc.univ-paris-diderot.fr:80/login?url=",
+    "url": "http://rproxy.sc.univ-paris-diderot.fr:80/login?url=$@",
     "location": {
       "lng": 2.3434592,
       "lat": 48.8483803
@@ -9730,7 +9730,7 @@
   },
   {
     "name": "Universite Rennes 2",
-    "url": "http://distant.bu.univ-rennes2.fr/login?url=",
+    "url": "http://distant.bu.univ-rennes2.fr/login?url=$@",
     "location": {
       "lng": -1.7028658,
       "lat": 48.1179154
@@ -9739,7 +9739,7 @@
   },
   {
     "name": "Universiteit Hasselt",
-    "url": "https://login.bib-proxy.uhasselt.be/login?url=",
+    "url": "https://login.bib-proxy.uhasselt.be/login?url=$@",
     "location": {
       "lng": 5.3419586,
       "lat": 50.9334607
@@ -9748,7 +9748,7 @@
   },
   {
     "name": "Universiteit Leiden",
-    "url": "http://ezproxy.leidenuniv.nl:2048/login?url=",
+    "url": "http://ezproxy.leidenuniv.nl:2048/login?url=$@",
     "location": {
       "lng": 4.4863129,
       "lat": 52.1565752
@@ -9757,7 +9757,7 @@
   },
   {
     "name": "Universiteit van Amsterdam",
-    "url": "http://proxy.uba.uva.nl:2048/login?url=",
+    "url": "http://proxy.uba.uva.nl:2048/login?url=$@",
     "location": {
       "lng": 4.955726299999999,
       "lat": 52.35581819999999
@@ -9766,7 +9766,7 @@
   },
   {
     "name": "Universitetet i Bergen",
-    "url": "https://login.pva.uib.no/login?url=",
+    "url": "https://login.pva.uib.no/login?url=$@",
     "location": {
       "lng": 5.3217549,
       "lat": 60.3878586
@@ -9775,7 +9775,7 @@
   },
   {
     "name": "Universiti Malaya",
-    "url": "http://ezproxy.um.edu.my/login.htm?url=",
+    "url": "http://ezproxy.um.edu.my/login.htm?url=$@",
     "location": {
       "lng": 101.6536844,
       "lat": 3.1217233
@@ -9784,7 +9784,7 @@
   },
   {
     "name": "Universiti Malaysia Pahang",
-    "url": "https://ezproxy.ump.edu.my/login?url=",
+    "url": "https://ezproxy.ump.edu.my/login?url=$@",
     "location": {
       "lng": 103.4288926,
       "lat": 3.5436412
@@ -9793,7 +9793,7 @@
   },
   {
     "name": "Universiti Malaysia Perlis",
-    "url": "http://ezproxy.unimap.edu.my/login?url=",
+    "url": "http://ezproxy.unimap.edu.my/login?url=$@",
     "location": {
       "lng": 100.351832,
       "lat": 6.4604292
@@ -9802,7 +9802,7 @@
   },
   {
     "name": "Universiti Putra Malaysia",
-    "url": "http://ezproxy.upm.edu.my/login?url=",
+    "url": "http://ezproxy.upm.edu.my/login?url=$@",
     "location": {
       "lng": 101.7056305,
       "lat": 2.999541
@@ -9811,7 +9811,7 @@
   },
   {
     "name": "Universiti Sains Malaysia",
-    "url": "https://ezproxy.usm.my/login?url=",
+    "url": "https://ezproxy.usm.my/login?url=$@",
     "location": {
       "lng": 100.3025177,
       "lat": 5.3559337
@@ -9820,7 +9820,7 @@
   },
   {
     "name": "Universiti Teknologi MARA",
-    "url": "http://ezaccess.library.uitm.edu.my/login?url=",
+    "url": "http://ezaccess.library.uitm.edu.my/login?url=$@",
     "location": {
       "lng": 101.5036823,
       "lat": 3.0697652
@@ -9829,7 +9829,7 @@
   },
   {
     "name": "Universiti Tun Hussein Onn Malaysia (UTHM)",
-    "url": "https://ezproxy.uthm.edu.my/login?url=",
+    "url": "https://ezproxy.uthm.edu.my/login?url=$@",
     "location": {
       "lng": 103.0820799,
       "lat": 1.8572606
@@ -9838,7 +9838,7 @@
   },
   {
     "name": "Universiti Tunku Abdul Rahman",
-    "url": "https://libezp.utar.edu.my/login?url=",
+    "url": "https://libezp.utar.edu.my/login?url=$@",
     "location": {
       "lng": 101.1351317,
       "lat": 4.3348363
@@ -9847,7 +9847,7 @@
   },
   {
     "name": "University at Albany, State University of New York (SUNY)",
-    "url": "https://libproxy.albany.edu/login?url=",
+    "url": "https://libproxy.albany.edu/login?url=$@",
     "location": {
       "lng": -73.8247903,
       "lat": 42.6850273
@@ -9856,7 +9856,7 @@
   },
   {
     "name": "University College Cork",
-    "url": "http://ucc.idm.oclc.org/login?url=",
+    "url": "http://ucc.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -8.492070499999999,
       "lat": 51.893486
@@ -9865,7 +9865,7 @@
   },
   {
     "name": "University College London",
-    "url": "https://libproxy.ucl.ac.uk/login?url=",
+    "url": "https://libproxy.ucl.ac.uk/login?url=$@",
     "location": {
       "lng": -0.1340401,
       "lat": 51.52455920000001
@@ -9874,7 +9874,7 @@
   },
   {
     "name": "University for the Creative Arts",
-    "url": "https://ucreative.idm.oclc.org/login?url=",
+    "url": "https://ucreative.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -0.805373,
       "lat": 51.2150866
@@ -9883,7 +9883,7 @@
   },
   {
     "name": "University Giessen",
-    "url": "https://ezproxy.uni-giessen.de/login?url=",
+    "url": "https://ezproxy.uni-giessen.de/login?url=$@",
     "location": {
       "lng": 8.6771403,
       "lat": 50.5804674
@@ -9892,7 +9892,7 @@
   },
   {
     "name": "University of Adelaide",
-    "url": "https://proxy.library.adelaide.edu.au/login?url=",
+    "url": "https://proxy.library.adelaide.edu.au/login?url=$@",
     "location": {
       "lng": 138.60629182100143,
       "lat": -34.919333123847764
@@ -9901,7 +9901,7 @@
   },
   {
     "name": "University of Akron",
-    "url": "http://ezproxy.uakron.edu:2048/login?url=",
+    "url": "http://ezproxy.uakron.edu:2048/login?url=$@",
     "location": {
       "lng": -81.5123424,
       "lat": 41.0753688
@@ -9910,7 +9910,7 @@
   },
   {
     "name": "University of Alabama",
-    "url": "http://libdata.lib.ua.edu/login?url=",
+    "url": "http://libdata.lib.ua.edu/login?url=$@",
     "location": {
       "lng": -87.5356121,
       "lat": 33.2152668
@@ -9919,7 +9919,7 @@
   },
   {
     "name": "University of Alabama in Huntsville",
-    "url": "https://elib.uah.edu/login?url=",
+    "url": "https://elib.uah.edu/login?url=$@",
     "location": {
       "lng": -86.6404712,
       "lat": 34.7251606
@@ -9928,7 +9928,7 @@
   },
   {
     "name": "University of Alaska Anchorage",
-    "url": "http://proxy.consortiumlibrary.org/login?url=",
+    "url": "http://proxy.consortiumlibrary.org/login?url=$@",
     "location": {
       "lng": -149.8195598,
       "lat": 61.1910421
@@ -9937,7 +9937,7 @@
   },
   {
     "name": "University of Alaska Southeast",
-    "url": "http://egandb.uas.alaska.edu:2048/login?url=",
+    "url": "http://egandb.uas.alaska.edu:2048/login?url=$@",
     "location": {
       "lng": -134.6407459,
       "lat": 58.38552139999999
@@ -9946,7 +9946,7 @@
   },
   {
     "name": "University of Alberta",
-    "url": "http://login.ezproxy.library.ualberta.ca/login?url=",
+    "url": "http://login.ezproxy.library.ualberta.ca/login?url=$@",
     "location": {
       "lng": -113.5263186,
       "lat": 53.5232189
@@ -9955,7 +9955,7 @@
   },
   {
     "name": "University of Amsterdam",
-    "url": "https://proxy.uba.uva.nl:2443/login?url=",
+    "url": "https://proxy.uba.uva.nl:2443/login?url=$@",
     "location": {
       "lng": 4.955726299999999,
       "lat": 52.35581819999999
@@ -9964,7 +9964,7 @@
   },
   {
     "name": "University of Applied Sciences Upper Austria",
-    "url": "https://fhooe.idm.oclc.org/login?url=",
+    "url": "https://fhooe.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 14.0267157,
       "lat": 48.1610538
@@ -9973,7 +9973,7 @@
   },
   {
     "name": "University of Arizona",
-    "url": "http://ezproxy.library.arizona.edu/login?url=",
+    "url": "http://ezproxy.library.arizona.edu/login?url=$@",
     "location": {
       "lng": -110.9501094,
       "lat": 32.2318851
@@ -9982,7 +9982,7 @@
   },
   {
     "name": "University of Arkansas for Medical Sciences",
-    "url": "http://ezproxy.libproxy.uams.edu/login?url=",
+    "url": "http://ezproxy.libproxy.uams.edu/login?url=$@",
     "location": {
       "lng": -92.3204416,
       "lat": 34.7490846
@@ -9991,7 +9991,7 @@
   },
   {
     "name": "University of Auckland",
-    "url": "http://ezproxy.auckland.ac.nz/login?url=",
+    "url": "http://ezproxy.auckland.ac.nz/login?url=$@",
     "location": {
       "lng": 174.7644881,
       "lat": -36.85088270000001
@@ -10000,7 +10000,7 @@
   },
   {
     "name": "University of Bath",
-    "url": "http://libproxy.bath.ac.uk/login?url=",
+    "url": "http://libproxy.bath.ac.uk/login?url=$@",
     "location": {
       "lng": -2.3263987,
       "lat": 51.3782228
@@ -10009,7 +10009,7 @@
   },
   {
     "name": "University of Birmingham",
-    "url": "http://ezproxy.bham.ac.uk/login?url=",
+    "url": "http://ezproxy.bham.ac.uk/login?url=$@",
     "location": {
       "lng": -1.9305135,
       "lat": 52.4508168
@@ -10018,7 +10018,7 @@
   },
   {
     "name": "University of Bradford",
-    "url": "https://brad.idm.oclc.org/login?url=",
+    "url": "https://brad.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -1.766069,
       "lat": 53.7914677
@@ -10027,7 +10027,7 @@
   },
   {
     "name": "University of Brighton",
-    "url": "http://ezproxy.brighton.ac.uk/login?url=",
+    "url": "http://ezproxy.brighton.ac.uk/login?url=$@",
     "location": {
       "lng": -0.1362672,
       "lat": 50.8229402
@@ -10036,7 +10036,7 @@
   },
   {
     "name": "University of Bristol",
-    "url": "http://bris.idm.oclc.org/login?url=",
+    "url": "http://bris.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -2.6021758,
       "lat": 51.4585376
@@ -10045,7 +10045,7 @@
   },
   {
     "name": "University of British Columbia",
-    "url": "http://ezproxy.library.ubc.ca/login?url=",
+    "url": "http://ezproxy.library.ubc.ca/login?url=$@",
     "location": {
       "lng": -123.2459939,
       "lat": 49.26060520000001
@@ -10054,7 +10054,7 @@
   },
   {
     "name": "University of Calgary",
-    "url": "https://login.ezproxy.lib.ucalgary.ca/login?url=",
+    "url": "https://login.ezproxy.lib.ucalgary.ca/login?url=$@",
     "location": {
       "lng": -114.1346659,
       "lat": 51.0783739
@@ -10063,7 +10063,7 @@
   },
   {
     "name": "University of California San Francisco",
-    "url": "https://ucsf.idm.oclc.org/login?qurl=",
+    "url": "https://ucsf.idm.oclc.org/login?qurl=$@",
     "location": {
       "lng": -122.4587106,
       "lat": 37.7626459
@@ -10072,7 +10072,7 @@
   },
   {
     "name": "University of California Santa Barbara",
-    "url": "http://proxy.library.ucsb.edu:2048/login?url=",
+    "url": "http://proxy.library.ucsb.edu:2048/login?url=$@",
     "location": {
       "lng": -119.848947,
       "lat": 34.4139629
@@ -10081,7 +10081,7 @@
   },
   {
     "name": "University of California, Santa Cruz",
-    "url": "https://login.oca.ucsc.edu/login?url=",
+    "url": "https://login.oca.ucsc.edu/login?url=$@",
     "location": {
       "lng": -122.0584354,
       "lat": 36.9905322
@@ -10090,7 +10090,7 @@
   },
   {
     "name": "University of Cambridge",
-    "url": "http://ezproxy.lib.cam.ac.uk:2048/login?url=",
+    "url": "http://ezproxy.lib.cam.ac.uk:2048/login?url=$@",
     "location": {
       "lng": 0.113168,
       "lat": 52.205356
@@ -10099,7 +10099,7 @@
   },
   {
     "name": "University of Canberra",
-    "url": "https://login.ezproxy.canberra.edu.au/login?url=",
+    "url": "https://login.ezproxy.canberra.edu.au/login?url=$@",
     "location": {
       "lng": 149.0838384,
       "lat": -35.2381421
@@ -10108,7 +10108,7 @@
   },
   {
     "name": "University of Canterbury, NZ",
-    "url": "http://ezproxy.canterbury.ac.nz/login?url=",
+    "url": "http://ezproxy.canterbury.ac.nz/login?url=$@",
     "location": {
       "lng": 172.5794354,
       "lat": -43.5224836
@@ -10117,7 +10117,7 @@
   },
   {
     "name": "University of Cape Town",
-    "url": "http://ezproxy.uct.ac.za/login?url=",
+    "url": "http://ezproxy.uct.ac.za/login?url=$@",
     "location": {
       "lng": 18.4611991,
       "lat": -33.957652
@@ -10126,7 +10126,7 @@
   },
   {
     "name": "University of Central Florida",
-    "url": "https://go.openathens.net/redirector/ucf.edu?url=",
+    "url": "https://go.openathens.net/redirector/ucf.edu?url=$@",
     "location": {
       "lng": -81.2000599,
       "lat": 28.6024274
@@ -10135,7 +10135,7 @@
   },
   {
     "name": "University of Central Missouri",
-    "url": "https://login.cyrano.ucmo.edu/login?url=",
+    "url": "https://login.cyrano.ucmo.edu/login?url=$@",
     "location": {
       "lng": -93.7405067,
       "lat": 38.7565603
@@ -10144,7 +10144,7 @@
   },
   {
     "name": "University of Chicago",
-    "url": "http://proxy.uchicago.edu/login?url=",
+    "url": "http://proxy.uchicago.edu/login?url=$@",
     "location": {
       "lng": -87.5987133,
       "lat": 41.7886079
@@ -10153,7 +10153,7 @@
   },
   {
     "name": "University of Cincinnati",
-    "url": "https://uc.idm.oclc.org/login?url=",
+    "url": "https://uc.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -84.51495039999999,
       "lat": 39.1329219
@@ -10162,7 +10162,7 @@
   },
   {
     "name": "University of Colorado Anschutz Medical Campus",
-    "url": "http://proxy.hsl.ucdenver.edu/login?url=",
+    "url": "http://proxy.hsl.ucdenver.edu/login?url=$@",
     "location": {
       "lng": -104.8378882,
       "lat": 39.7453568
@@ -10171,7 +10171,7 @@
   },
   {
     "name": "University of Colorado Boulder",
-    "url": "https://colorado.idm.oclc.org/login?url=",
+    "url": "https://colorado.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -105.2659417,
       "lat": 40.00758099999999
@@ -10180,7 +10180,7 @@
   },
   {
     "name": "University of Colorado Colorado Springs",
-    "url": "https://libproxy.uccs.edu/login?url=",
+    "url": "https://libproxy.uccs.edu/login?url=$@",
     "location": {
       "lng": -104.8048874,
       "lat": 38.8965518
@@ -10189,7 +10189,7 @@
   },
   {
     "name": "University of Colorado Denver",
-    "url": "https://hsl-ezproxy.ucdenver.edu/login?url=",
+    "url": "https://hsl-ezproxy.ucdenver.edu/login?url=$@",
     "location": {
       "lng": -105.002342,
       "lat": 39.7463596
@@ -10198,7 +10198,7 @@
   },
   {
     "name": "University of Connecticut",
-    "url": "http://ezproxy.lib.uconn.edu/login?url=",
+    "url": "http://ezproxy.lib.uconn.edu/login?url=$@",
     "location": {
       "lng": -72.25396435165646,
       "lat": 41.80786956340674
@@ -10207,7 +10207,7 @@
   },
   {
     "name": "University of Connecticut Health",
-    "url": "https://online.uchc.edu/login?qurl=",
+    "url": "https://online.uchc.edu/login?qurl=$@",
     "location": {
       "lng": -72.79146159999999,
       "lat": 41.7322247
@@ -10216,7 +10216,7 @@
   },
   {
     "name": "University of Dayton",
-    "url": "http://libproxy.udayton.edu/login?url=",
+    "url": "http://libproxy.udayton.edu/login?url=$@",
     "location": {
       "lng": -84.17904449999999,
       "lat": 39.7401454
@@ -10225,7 +10225,7 @@
   },
   {
     "name": "University of Delaware Newark",
-    "url": "https://udel.idm.oclc.org/login?url=",
+    "url": "https://udel.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -75.74965720000002,
       "lat": 39.6837226
@@ -10234,7 +10234,7 @@
   },
   {
     "name": "University of Delhi",
-    "url": "https://du.remotlog.com/login/#login",
+    "url": "https://du.remotlog.com/login/#login$@",
     "location": {
       "lng": 77.1638282,
       "lat": 28.5842523
@@ -10243,7 +10243,7 @@
   },
   {
     "name": "University of Denver",
-    "url": "http://du.idm.oclc.org/login?url=",
+    "url": "http://du.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -104.9652808,
       "lat": 39.6748442
@@ -10252,7 +10252,7 @@
   },
   {
     "name": "University of Derby",
-    "url": "http://ezproxy.derby.ac.uk/login?url=",
+    "url": "http://ezproxy.derby.ac.uk/login?url=$@",
     "location": {
       "lng": -1.4971764,
       "lat": 52.9378882
@@ -10261,7 +10261,7 @@
   },
   {
     "name": "University of Detroit Mercy",
-    "url": "https://ezproxy.libraries.udmercy.edu/login?url=",
+    "url": "https://ezproxy.libraries.udmercy.edu/login?url=$@",
     "location": {
       "lng": -83.1379388,
       "lat": 42.4140847
@@ -10270,7 +10270,7 @@
   },
   {
     "name": "University of Dubuque",
-    "url": "http://ezproxy.dbq.edu:2048/login?url=",
+    "url": "http://ezproxy.dbq.edu:2048/login?url=$@",
     "location": {
       "lng": -90.6952695,
       "lat": 42.495403
@@ -10279,7 +10279,7 @@
   },
   {
     "name": "University of Dundee",
-    "url": "http://libproxy.dundee.ac.uk/login?url=",
+    "url": "http://libproxy.dundee.ac.uk/login?url=$@",
     "location": {
       "lng": -2.9821428,
       "lat": 56.45824469999999
@@ -10288,7 +10288,7 @@
   },
   {
     "name": "University of East Anglia",
-    "url": "http://ezproxy.sts.uea.ac.uk/adfs/ls=",
+    "url": "http://ezproxy.sts.uea.ac.uk/adfs/ls=$@",
     "location": {
       "lng": 1.2410838,
       "lat": 52.6220523
@@ -10297,7 +10297,7 @@
   },
   {
     "name": "University of Eastern Finland",
-    "url": "https://ezproxy.uef.fi:2443/login?url=",
+    "url": "https://ezproxy.uef.fi:2443/login?url=$@",
     "location": {
       "lng": 27.6327062,
       "lat": 62.89027650000001
@@ -10306,7 +10306,7 @@
   },
   {
     "name": "University of Edinburgh",
-    "url": "http://ezproxy.is.ed.ac.uk/login?url=",
+    "url": "http://ezproxy.is.ed.ac.uk/login?url=$@",
     "location": {
       "lng": -3.1892413,
       "lat": 55.9445158
@@ -10315,7 +10315,7 @@
   },
   {
     "name": "University of Florida",
-    "url": "https://login.lp.hscl.ufl.edu/login?url=",
+    "url": "https://login.lp.hscl.ufl.edu/login?url=$@",
     "location": {
       "lng": -82.3549302,
       "lat": 29.6436325
@@ -10324,7 +10324,7 @@
   },
   {
     "name": "University of Georgia",
-    "url": "http://proxy-remote.galib.uga.edu/login?url=",
+    "url": "http://proxy-remote.galib.uga.edu/login?url=$@",
     "location": {
       "lng": -83.375192,
       "lat": 33.9566656
@@ -10333,7 +10333,7 @@
   },
   {
     "name": "University of Ghana",
-    "url": "http://ezproxy.ug.edu.gh:2100/login?url=",
+    "url": "http://ezproxy.ug.edu.gh:2100/login?url=$@",
     "location": {
       "lng": -0.1962244,
       "lat": 5.650562
@@ -10342,7 +10342,7 @@
   },
   {
     "name": "University of Glasgow",
-    "url": "https://ezproxy.lib.gla.ac.uk/login?url=",
+    "url": "https://ezproxy.lib.gla.ac.uk/login?url=$@",
     "location": {
       "lng": -4.2900009,
       "lat": 55.8724256
@@ -10351,7 +10351,7 @@
   },
   {
     "name": "University of Gothenburg",
-    "url": "http://ezproxy.ub.gu.se/login?url=",
+    "url": "http://ezproxy.ub.gu.se/login?url=$@",
     "location": {
       "lng": 11.9715823,
       "lat": 57.6983855
@@ -10360,7 +10360,7 @@
   },
   {
     "name": "University of Great Falls",
-    "url": "http://ezproxy.ugf.edu:2048/login?url=",
+    "url": "http://ezproxy.ugf.edu:2048/login?url=$@",
     "location": {
       "lng": -111.2707539,
       "lat": 47.4906921
@@ -10369,7 +10369,7 @@
   },
   {
     "name": "University of Groningen",
-    "url": "https://login.proxy-ub.rug.nl/login?url=",
+    "url": "https://login.proxy-ub.rug.nl/login?url=$@",
     "location": {
       "lng": 6.562987199999999,
       "lat": 53.2192634
@@ -10378,7 +10378,7 @@
   },
   {
     "name": "University of Guelph",
-    "url": "http://subzero.lib.uoguelph.ca/login?url=",
+    "url": "http://subzero.lib.uoguelph.ca/login?url=$@",
     "location": {
       "lng": -80.22618039999999,
       "lat": 43.5327217
@@ -10387,7 +10387,7 @@
   },
   {
     "name": "University of Haifa",
-    "url": "https://ezproxy.haifa.ac.il/login?url=",
+    "url": "https://ezproxy.haifa.ac.il/login?url=$@",
     "location": {
       "lng": 35.0195184,
       "lat": 32.7614296
@@ -10396,7 +10396,7 @@
   },
   {
     "name": "University of Hartford",
-    "url": "http://libill.hartford.edu:2048/login?url=",
+    "url": "http://libill.hartford.edu:2048/login?url=$@",
     "location": {
       "lng": -72.7138039,
       "lat": 41.7984942
@@ -10405,7 +10405,7 @@
   },
   {
     "name": "University of Hawaii",
-    "url": "http://micro189.lib3.hawaii.edu:2048/login?url=",
+    "url": "http://micro189.lib3.hawaii.edu:2048/login?url=$@",
     "location": {
       "lng": -157.8148228,
       "lat": 21.299824
@@ -10414,7 +10414,7 @@
   },
   {
     "name": "University of Hawaii, Manoa",
-    "url": "http://eres.library.manoa.hawaii.edu/login?url=",
+    "url": "http://eres.library.manoa.hawaii.edu/login?url=$@",
     "location": {
       "lng": -157.8148228,
       "lat": 21.299824
@@ -10423,7 +10423,7 @@
   },
   {
     "name": "University of Hong Kong Libraries",
-    "url": "http://eproxy.lib.hku.hk/login?url=",
+    "url": "http://eproxy.lib.hku.hk/login?url=$@",
     "location": {
       "lng": 114.1365621,
       "lat": 22.2830891
@@ -10432,7 +10432,7 @@
   },
   {
     "name": "University of Houston",
-    "url": "http://ezproxy.lib.uh.edu/login?url=",
+    "url": "http://ezproxy.lib.uh.edu/login?url=$@",
     "location": {
       "lng": -95.3422334,
       "lat": 29.7199489
@@ -10441,7 +10441,7 @@
   },
   {
     "name": "University of Houston - Clear Lake",
-    "url": "http://libproxy.uhcl.edu/login?url=",
+    "url": "http://libproxy.uhcl.edu/login?url=$@",
     "location": {
       "lng": -95.0989342,
       "lat": 29.5824608
@@ -10450,7 +10450,7 @@
   },
   {
     "name": "University of Idaho",
-    "url": "http://ida.lib.uidaho.edu:2048/login?url=",
+    "url": "http://ida.lib.uidaho.edu:2048/login?url=$@",
     "location": {
       "lng": -117.0126084,
       "lat": 46.7288124
@@ -10459,7 +10459,7 @@
   },
   {
     "name": "University of Illinois at Chicago",
-    "url": "http://proxy.cc.uic.edu/login?url=",
+    "url": "http://proxy.cc.uic.edu/login?url=$@",
     "location": {
       "lng": -87.6484497,
       "lat": 41.8685636
@@ -10468,7 +10468,7 @@
   },
   {
     "name": "University of Illinois at Urbana-Champaign",
-    "url": "https://proxy2.library.illinois.edu/login?url=",
+    "url": "https://proxy2.library.illinois.edu/login?url=$@",
     "location": {
       "lng": -88.2271615,
       "lat": 40.1019523
@@ -10477,7 +10477,7 @@
   },
   {
     "name": "University of Illinois Springfield",
-    "url": "http://login.ezproxy.uis.edu/login?url=",
+    "url": "http://login.ezproxy.uis.edu/login?url=$@",
     "location": {
       "lng": -89.6176711,
       "lat": 39.7305338
@@ -10486,7 +10486,7 @@
   },
   {
     "name": "University of Indiaia",
-    "url": "http://ezproxy.lib.indiana.edu/login?url=",
+    "url": "http://ezproxy.lib.indiana.edu/login?url=$@",
     "location": {
       "lng": -86.52300729999999,
       "lat": 39.1682449
@@ -10495,7 +10495,7 @@
   },
   {
     "name": "University of Indianapolis",
-    "url": "https://ezproxy.uindy.edu/login?url=",
+    "url": "https://ezproxy.uindy.edu/login?url=$@",
     "location": {
       "lng": -86.1346712,
       "lat": 39.7095679
@@ -10504,7 +10504,7 @@
   },
   {
     "name": "University of Iowa",
-    "url": "https://login.proxy.lib.uiowa.edu/login?qurl=",
+    "url": "https://login.proxy.lib.uiowa.edu/login?qurl=$@",
     "location": {
       "lng": -91.5549771,
       "lat": 41.66270780000001
@@ -10513,7 +10513,7 @@
   },
   {
     "name": "University of Jordan",
-    "url": "http://ezlibrary.ju.edu.jo/login?url=",
+    "url": "http://ezlibrary.ju.edu.jo/login?url=$@",
     "location": {
       "lng": 35.8695456,
       "lat": 32.0161048
@@ -10522,7 +10522,7 @@
   },
   {
     "name": "University of Kansas",
-    "url": "http://www2.lib.ku.edu:2048/login?url=",
+    "url": "http://www2.lib.ku.edu:2048/login?url=$@",
     "location": {
       "lng": -95.2557961,
       "lat": 38.9543439
@@ -10531,7 +10531,7 @@
   },
   {
     "name": "University of Kansas Medical Center",
-    "url": "https://login.proxy.kumc.edu/login?qurl=",
+    "url": "https://login.proxy.kumc.edu/login?qurl=$@",
     "location": {
       "lng": -94.60966789999999,
       "lat": 39.0573742
@@ -10540,7 +10540,7 @@
   },
   {
     "name": "University of Kent",
-    "url": "http://chain.kent.ac.uk/login?url=",
+    "url": "http://chain.kent.ac.uk/login?url=$@",
     "location": {
       "lng": 1.0630042,
       "lat": 51.2967395
@@ -10549,7 +10549,7 @@
   },
   {
     "name": "University of Kentucky",
-    "url": "http://ezproxy.uky.edu/login?url=",
+    "url": "http://ezproxy.uky.edu/login?url=$@",
     "location": {
       "lng": -84.5039697,
       "lat": 38.0306511
@@ -10558,7 +10558,7 @@
   },
   {
     "name": "University of KwaZulu Natal",
-    "url": "https://ezproxy.ukzn.ac.za:2443/login?url=",
+    "url": "https://ezproxy.ukzn.ac.za:2443/login?url=$@",
     "location": {
       "lng": 30.9807272,
       "lat": -29.8674219
@@ -10567,7 +10567,7 @@
   },
   {
     "name": "University of Leeds",
-    "url": "https://go.openathens.net/redirector/leeds.ac.uk?url=",
+    "url": "https://go.openathens.net/redirector/leeds.ac.uk?url=$@",
     "location": {
       "lng": -1.5550328,
       "lat": 53.8066815
@@ -10576,7 +10576,7 @@
   },
   {
     "name": "University of Leicester",
-    "url": "http://ezproxy.lib.le.ac.uk/login?url=",
+    "url": "http://ezproxy.lib.le.ac.uk/login?url=$@",
     "location": {
       "lng": -1.1246325,
       "lat": 52.6211393
@@ -10585,7 +10585,7 @@
   },
   {
     "name": "University of Lethbridge",
-    "url": "https://ezproxy.uleth.ca/login?url=",
+    "url": "https://ezproxy.uleth.ca/login?url=$@",
     "location": {
       "lng": -112.8601177,
       "lat": 49.6786156
@@ -10594,7 +10594,7 @@
   },
   {
     "name": "University of Limerick",
-    "url": "https://login.proxy.lib.ul.ie/login?url=",
+    "url": "https://login.proxy.lib.ul.ie/login?url=$@",
     "location": {
       "lng": -8.5719129,
       "lat": 52.6737944
@@ -10603,7 +10603,7 @@
   },
   {
     "name": "University of Lincoln (UK)",
-    "url": "http://proxy.library.lincoln.ac.uk/login?url=",
+    "url": "http://proxy.library.lincoln.ac.uk/login?url=$@",
     "location": {
       "lng": -3.435973,
       "lat": 55.378051
@@ -10612,7 +10612,7 @@
   },
   {
     "name": "University of Liverpool",
-    "url": "https://liverpool.idm.oclc.org/login?url=",
+    "url": "https://liverpool.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -2.965299,
       "lat": 53.40478239999999
@@ -10621,7 +10621,7 @@
   },
   {
     "name": "University of Louisiana at Lafayette",
-    "url": "http://ezproxy.ucs.louisiana.edu:2048/login?url=",
+    "url": "http://ezproxy.ucs.louisiana.edu:2048/login?url=$@",
     "location": {
       "lng": -92.019914,
       "lat": 30.211991
@@ -10630,7 +10630,7 @@
   },
   {
     "name": "University of Louisville",
-    "url": "http://echo.louisville.edu/login?url=",
+    "url": "http://echo.louisville.edu/login?url=$@",
     "location": {
       "lng": -85.75850229999999,
       "lat": 38.2122761
@@ -10639,7 +10639,7 @@
   },
   {
     "name": "University of Macau",
-    "url": "http://libezproxy.umac.mo/login?url=",
+    "url": "http://libezproxy.umac.mo/login?url=$@",
     "location": {
       "lng": 113.5457795,
       "lat": 22.130002
@@ -10648,7 +10648,7 @@
   },
   {
     "name": "University of Maine System",
-    "url": "http://www.library.umaine.edu/auth/EZProxy/test/authej.asp?url=",
+    "url": "http://www.library.umaine.edu/auth/EZProxy/test/authej.asp?url=$@",
     "location": {
       "lng": -70.14744089999999,
       "lat": 44.6675867
@@ -10657,7 +10657,7 @@
   },
   {
     "name": "University of Malta",
-    "url": "https://ejournals.um.edu.mt/login/?url=",
+    "url": "https://ejournals.um.edu.mt/login/?url=$@",
     "location": {
       "lng": 14.4847432,
       "lat": 35.90232
@@ -10666,7 +10666,7 @@
   },
   {
     "name": "University of Manitoba",
-    "url": "https://uml.idm.oclc.org/login?url=",
+    "url": "https://uml.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -98.81387629999999,
       "lat": 53.7608608
@@ -10675,7 +10675,7 @@
   },
   {
     "name": "University of Maryland",
-    "url": "http://ezproxy.law.umaryland.edu/login?auth=Library&url=",
+    "url": "http://ezproxy.law.umaryland.edu/login?auth=Library&url=$@",
     "location": {
       "lng": -76.9425543,
       "lat": 38.9869183
@@ -10684,7 +10684,7 @@
   },
   {
     "name": "University of Maryland University",
-    "url": "http://ezproxy.umuc.edu/login?url=",
+    "url": "http://ezproxy.umuc.edu/login?url=$@",
     "location": {
       "lng": -76.9425543,
       "lat": 38.9869183
@@ -10693,7 +10693,7 @@
   },
   {
     "name": "University of Maryland, Baltimore County (UMBC)",
-    "url": "http://proxy-bc.researchport.umd.edu/login?url=",
+    "url": "http://proxy-bc.researchport.umd.edu/login?url=$@",
     "location": {
       "lng": -76.7114685,
       "lat": 39.2497768
@@ -10702,7 +10702,7 @@
   },
   {
     "name": "University of Maryland, College Park",
-    "url": "http://proxy-um.researchport.umd.edu/login?url=",
+    "url": "http://proxy-um.researchport.umd.edu/login?url=$@",
     "location": {
       "lng": -76.9425543,
       "lat": 38.9869183
@@ -10711,7 +10711,7 @@
   },
   {
     "name": "University of Massachusetts Amherst",
-    "url": "http://silk.library.umass.edu:2048/login?url=",
+    "url": "http://silk.library.umass.edu:2048/login?url=$@",
     "location": {
       "lng": -72.5300515,
       "lat": 42.3867598
@@ -10720,7 +10720,7 @@
   },
   {
     "name": "University of Massachusetts Boston",
-    "url": "http://ezproxy.lib.umb.edu/login?url=",
+    "url": "http://ezproxy.lib.umb.edu/login?url=$@",
     "location": {
       "lng": -71.0419953,
       "lat": 42.3141992
@@ -10729,7 +10729,7 @@
   },
   {
     "name": "University of Massachusetts Dartmouth",
-    "url": "http://libproxy.umassd.edu/login?url=",
+    "url": "http://libproxy.umassd.edu/login?url=$@",
     "location": {
       "lng": -71.0054336,
       "lat": 41.6269122
@@ -10738,7 +10738,7 @@
   },
   {
     "name": "University of Massachusetts Lowell",
-    "url": "http://libproxy.uml.edu/login?url=",
+    "url": "http://libproxy.uml.edu/login?url=$@",
     "location": {
       "lng": -71.3247164,
       "lat": 42.6552587
@@ -10747,7 +10747,7 @@
   },
   {
     "name": "University of Massachusetts Medical School",
-    "url": "http://ezproxy.umassmed.edu/login?url=",
+    "url": "http://ezproxy.umassmed.edu/login?url=$@",
     "location": {
       "lng": -71.7633073,
       "lat": 42.2786007
@@ -10756,7 +10756,7 @@
   },
   {
     "name": "University of Massachusetts, Amherst",
-    "url": "http://silk.library.umass.edu/login?url=",
+    "url": "http://silk.library.umass.edu/login?url=$@",
     "location": {
       "lng": -72.5300515,
       "lat": 42.3867598
@@ -10765,7 +10765,7 @@
   },
   {
     "name": "University of Melbourne",
-    "url": "https://ezp.lib.unimelb.edu.au/login?url=",
+    "url": "https://ezp.lib.unimelb.edu.au/login?url=$@",
     "location": {
       "lng": 144.960974,
       "lat": -37.7983459
@@ -10774,7 +10774,7 @@
   },
   {
     "name": "University of Miami",
-    "url": "http://access.library.miami.edu/login?url=",
+    "url": "http://access.library.miami.edu/login?url=$@",
     "location": {
       "lng": -80.2781262,
       "lat": 25.7173947
@@ -10783,7 +10783,7 @@
   },
   {
     "name": "University of Michigan",
-    "url": "http://proxy.lib.umich.edu/login?url=",
+    "url": "http://proxy.lib.umich.edu/login?url=$@",
     "location": {
       "lng": -83.74097979999999,
       "lat": 42.2790522
@@ -10792,7 +10792,7 @@
   },
   {
     "name": "University of Michigan-Flint",
-    "url": "http://libproxy.umflint.edu/login?url=",
+    "url": "http://libproxy.umflint.edu/login?url=$@",
     "location": {
       "lng": -83.6894611,
       "lat": 43.0194791
@@ -10801,7 +10801,7 @@
   },
   {
     "name": "University of Minnesota",
-    "url": "https://login.ezproxy.lib.umn.edu/login?url=",
+    "url": "https://login.ezproxy.lib.umn.edu/login?url=$@",
     "location": {
       "lng": -93.2277285,
       "lat": 44.97399
@@ -10810,7 +10810,7 @@
   },
   {
     "name": "University of Minnesota Duluth",
-    "url": "https://login.libpdb.d.umn.edu:2443/login?url=",
+    "url": "https://login.libpdb.d.umn.edu:2443/login?url=$@",
     "location": {
       "lng": -92.0843306,
       "lat": 46.8187754
@@ -10819,7 +10819,7 @@
   },
   {
     "name": "University of Minnesota Morris",
-    "url": "http://ezproxy.morris.umn.edu/login?url=",
+    "url": "http://ezproxy.morris.umn.edu/login?url=$@",
     "location": {
       "lng": -95.8969661,
       "lat": 45.58903170000001
@@ -10828,7 +10828,7 @@
   },
   {
     "name": "University of Mississippi",
-    "url": "http://umiss.idm.oclc.org/login?url=",
+    "url": "http://umiss.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -89.5383818,
       "lat": 34.3647349
@@ -10837,7 +10837,7 @@
   },
   {
     "name": "University of Mississippi Medial Center",
-    "url": "http://ezproxy2.umc.edu/login?url=",
+    "url": "http://ezproxy2.umc.edu/login?url=$@",
     "location": {
       "lng": -89.5383818,
       "lat": 34.3647349
@@ -10846,7 +10846,7 @@
   },
   {
     "name": "University of Missouri",
-    "url": "http://proxy.mul.missouri.edu/login?url=",
+    "url": "http://proxy.mul.missouri.edu/login?url=$@",
     "location": {
       "lng": -92.32773750000001,
       "lat": 38.9403808
@@ -10855,7 +10855,7 @@
   },
   {
     "name": "University of Missouri - St. Louis",
-    "url": "http://ezproxy.umsl.edu/login?url=",
+    "url": "http://ezproxy.umsl.edu/login?url=$@",
     "location": {
       "lng": -90.3083223,
       "lat": 38.7092187
@@ -10864,7 +10864,7 @@
   },
   {
     "name": "University of Missouri-Kansas City",
-    "url": "http://proxy.library.umkc.edu/login?url=",
+    "url": "http://proxy.library.umkc.edu/login?url=$@",
     "location": {
       "lng": -94.58342739999999,
       "lat": 39.0343551
@@ -10873,7 +10873,7 @@
   },
   {
     "name": "University of Montana",
-    "url": "http://weblib.lib.umt.edu:8080/login?url=",
+    "url": "http://weblib.lib.umt.edu:8080/login?url=$@",
     "location": {
       "lng": -113.9845969,
       "lat": 46.8619309
@@ -10882,7 +10882,7 @@
   },
   {
     "name": "University of Montevallo",
-    "url": "http://ezproxy.montevallo.edu:2048/login?url=",
+    "url": "http://ezproxy.montevallo.edu:2048/login?url=$@",
     "location": {
       "lng": -86.86541679999999,
       "lat": 33.1067187
@@ -10891,7 +10891,7 @@
   },
   {
     "name": "University of Nebraska - Lincoln",
-    "url": "https://login.libproxy.unl.edu/login?url=",
+    "url": "https://login.libproxy.unl.edu/login?url=$@",
     "location": {
       "lng": -96.70047629999999,
       "lat": 40.8201966
@@ -10900,7 +10900,7 @@
   },
   {
     "name": "University of Nebraska Medical Center",
-    "url": "http://library1.unmc.edu:2048/login?url=",
+    "url": "http://library1.unmc.edu:2048/login?url=$@",
     "location": {
       "lng": -95.9759002,
       "lat": 41.2548733
@@ -10909,7 +10909,7 @@
   },
   {
     "name": "University of Nevada Reno",
-    "url": "https://unr.idm.oclc.org/login?url=",
+    "url": "https://unr.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -119.8141582,
       "lat": 39.5437205
@@ -10918,7 +10918,7 @@
   },
   {
     "name": "University of Nevada, Las Vegas",
-    "url": "https://login.ezproxy.library.unlv.edu/login?url=",
+    "url": "https://login.ezproxy.library.unlv.edu/login?url=$@",
     "location": {
       "lng": -115.1435252,
       "lat": 36.107496
@@ -10927,7 +10927,7 @@
   },
   {
     "name": "University of New Brunswick",
-    "url": "https://login.proxy.hil.unb.ca/login?url=",
+    "url": "https://login.proxy.hil.unb.ca/login?url=$@",
     "location": {
       "lng": -66.64295761934224,
       "lat": 45.944855857498474
@@ -10936,7 +10936,7 @@
   },
   {
     "name": "University of New England",
-    "url": "https://une.idm.oclc.org/login?url=",
+    "url": "https://une.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -70.3865402,
       "lat": 43.4582904
@@ -10945,7 +10945,7 @@
   },
   {
     "name": "University of New England (Australia)",
-    "url": "http://ezproxy.une.edu.au/login?url=",
+    "url": "http://ezproxy.une.edu.au/login?url=$@",
     "location": {
       "lng": 151.6410199,
       "lat": -30.4899535
@@ -10954,7 +10954,7 @@
   },
   {
     "name": "University of New Haven",
-    "url": "http://unh-proxy.newhaven.edu:2048/login?url=",
+    "url": "http://unh-proxy.newhaven.edu:2048/login?url=$@",
     "location": {
       "lng": -72.96189919999999,
       "lat": 41.2921105
@@ -10963,7 +10963,7 @@
   },
   {
     "name": "University of New Orleans",
-    "url": "http://ezproxy.uno.edu/login?url=",
+    "url": "http://ezproxy.uno.edu/login?url=$@",
     "location": {
       "lng": -90.0680105,
       "lat": 30.0273134
@@ -10972,7 +10972,7 @@
   },
   {
     "name": "University of New South Wales",
-    "url": "http://wwwproxy0.nun.unsw.edu.au/login?url=",
+    "url": "http://wwwproxy0.nun.unsw.edu.au/login?url=$@",
     "location": {
       "lng": 151.2312675,
       "lat": -33.917347
@@ -10981,7 +10981,7 @@
   },
   {
     "name": "University of New South Wales (UNSW)",
-    "url": "https://login.wwwproxy1.library.unsw.edu.au/login?qurl=",
+    "url": "https://login.wwwproxy1.library.unsw.edu.au/login?qurl=$@",
     "location": {
       "lng": 151.2312675,
       "lat": -33.917347
@@ -10990,7 +10990,7 @@
   },
   {
     "name": "University of Newcastle",
-    "url": "http://ezproxy.newcastle.edu.au/login?url=",
+    "url": "http://ezproxy.newcastle.edu.au/login?url=$@",
     "location": {
       "lng": 151.7041775,
       "lat": -32.8927718
@@ -10999,7 +10999,7 @@
   },
   {
     "name": "University of Newcastle, Australia",
-    "url": "https://login.ezproxy.newcastle.edu.au/login?url=",
+    "url": "https://login.ezproxy.newcastle.edu.au/login?url=$@",
     "location": {
       "lng": 151.7041775,
       "lat": -32.8927718
@@ -11008,7 +11008,7 @@
   },
   {
     "name": "University of North Alabama",
-    "url": "https://ezproxy.una.edu/login?url=",
+    "url": "https://ezproxy.una.edu/login?url=$@",
     "location": {
       "lng": -87.6804676,
       "lat": 34.807836
@@ -11017,7 +11017,7 @@
   },
   {
     "name": "University of North Carolina at Chapel Hill",
-    "url": "http://libproxy.lib.unc.edu/login?url=",
+    "url": "http://libproxy.lib.unc.edu/login?url=$@",
     "location": {
       "lng": -79.0469134,
       "lat": 35.9049122
@@ -11026,7 +11026,7 @@
   },
   {
     "name": "University of North Carolina at Charlotte",
-    "url": "https://librarylink.uncc.edu/login?url=",
+    "url": "https://librarylink.uncc.edu/login?url=$@",
     "location": {
       "lng": -80.735164,
       "lat": 35.3070929
@@ -11035,7 +11035,7 @@
   },
   {
     "name": "University of North Carolina at Greensboro",
-    "url": "http://login.libproxy.uncg.edu/login?url=",
+    "url": "http://login.libproxy.uncg.edu/login?url=$@",
     "location": {
       "lng": -79.8101976,
       "lat": 36.0689296
@@ -11044,7 +11044,7 @@
   },
   {
     "name": "University of North Carolina Wilmington",
-    "url": "http://liblink.uncw.edu/login?url=",
+    "url": "http://liblink.uncw.edu/login?url=$@",
     "location": {
       "lng": -77.8696036,
       "lat": 34.223874
@@ -11053,7 +11053,7 @@
   },
   {
     "name": "University of North Dakota",
-    "url": "https://login.ezproxy.library.und.edu/login?url=",
+    "url": "https://login.ezproxy.library.und.edu/login?url=$@",
     "location": {
       "lng": -97.0768014,
       "lat": 47.922891
@@ -11062,7 +11062,7 @@
   },
   {
     "name": "University of North Florida",
-    "url": "https://login.dax.lib.unf.edu/login?url=",
+    "url": "https://login.dax.lib.unf.edu/login?url=$@",
     "location": {
       "lng": -81.50723140000001,
       "lat": 30.2661204
@@ -11071,7 +11071,7 @@
   },
   {
     "name": "University of North Texas",
-    "url": "https://libproxy.library.unt.edu/login?url=",
+    "url": "https://libproxy.library.unt.edu/login?url=$@",
     "location": {
       "lng": -97.1525862,
       "lat": 33.207488
@@ -11080,7 +11080,7 @@
   },
   {
     "name": "University of North Texas Health Science Center",
-    "url": "https://proxy.hsc.unt.edu/login?url=",
+    "url": "https://proxy.hsc.unt.edu/login?url=$@",
     "location": {
       "lng": -97.3694771,
       "lat": 32.7496982
@@ -11089,7 +11089,7 @@
   },
   {
     "name": "University of Northampton",
-    "url": "https://ezproxy.northampton.ac.uk/login?url=",
+    "url": "https://ezproxy.northampton.ac.uk/login?url=$@",
     "location": {
       "lng": -0.8869818,
       "lat": 52.2304823
@@ -11098,7 +11098,7 @@
   },
   {
     "name": "University of Northern Iowa",
-    "url": "http://login.proxy.lib.uni.edu/login?url=",
+    "url": "http://login.proxy.lib.uni.edu/login?url=$@",
     "location": {
       "lng": -92.46464689999999,
       "lat": 42.5121517
@@ -11107,7 +11107,7 @@
   },
   {
     "name": "University of Nottingham",
-    "url": "http://ezproxy.nottingham.ac.uk/login?url=",
+    "url": "http://ezproxy.nottingham.ac.uk/login?url=$@",
     "location": {
       "lng": -1.1981057,
       "lat": 52.9387922
@@ -11116,7 +11116,7 @@
   },
   {
     "name": "University of Oklahoma",
-    "url": "http://ezproxy.lib.ou.edu/login?url=",
+    "url": "http://ezproxy.lib.ou.edu/login?url=$@",
     "location": {
       "lng": -97.4448963,
       "lat": 35.1987162
@@ -11125,7 +11125,7 @@
   },
   {
     "name": "University of Oklahoma Health Sciences Center",
-    "url": "http://webproxy.ouhsc.edu/login?url=",
+    "url": "http://webproxy.ouhsc.edu/login?url=$@",
     "location": {
       "lng": -97.5006758,
       "lat": 35.4796467
@@ -11134,7 +11134,7 @@
   },
   {
     "name": "University of Ontario Institute of Technology",
-    "url": "http://uproxy.library.dc-uoit.ca/login?url=",
+    "url": "http://uproxy.library.dc-uoit.ca/login?url=$@",
     "location": {
       "lng": -78.8967866,
       "lat": 43.94564279999999
@@ -11143,7 +11143,7 @@
   },
   {
     "name": "University of Oregon",
-    "url": "https://uoregon.idm.oclc.org/login?url=",
+    "url": "https://uoregon.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -123.0726055,
       "lat": 44.0448302
@@ -11152,7 +11152,7 @@
   },
   {
     "name": "University of Oslo",
-    "url": "https://login.ezproxy.uio.no/login?url=",
+    "url": "https://login.ezproxy.uio.no/login?url=$@",
     "location": {
       "lng": 10.7217496,
       "lat": 59.9399586
@@ -11161,7 +11161,7 @@
   },
   {
     "name": "University of Otago",
-    "url": "https://www.otago.ac.nz/library/ezproxy/ezproxy_auth.php?url=",
+    "url": "https://www.otago.ac.nz/library/ezproxy/ezproxy_auth.php?url=$@",
     "location": {
       "lng": 170.5144227,
       "lat": -45.8646835
@@ -11170,7 +11170,7 @@
   },
   {
     "name": "University of Otago Dunedin",
-    "url": "https://ezproxy.otago.ac.nz/login?url=",
+    "url": "https://ezproxy.otago.ac.nz/login?url=$@",
     "location": {
       "lng": 170.5005957,
       "lat": -45.8795455
@@ -11179,7 +11179,7 @@
   },
   {
     "name": "University of Otago Wellington",
-    "url": "https://wmezproxy.wnmeds.ac.nz/login?url=",
+    "url": "https://wmezproxy.wnmeds.ac.nz/login?url=$@",
     "location": {
       "lng": 174.7810326,
       "lat": -41.3098922
@@ -11188,7 +11188,7 @@
   },
   {
     "name": "University of Otago, Christchurch",
-    "url": "https://cmezproxy.chmeds.ac.nz/login?url=",
+    "url": "https://cmezproxy.chmeds.ac.nz/login?url=$@",
     "location": {
       "lng": 172.6259732,
       "lat": -43.5345179
@@ -11197,7 +11197,7 @@
   },
   {
     "name": "University of Ottawa",
-    "url": "https://login.proxy.bib.uottawa.ca/login?url=",
+    "url": "https://login.proxy.bib.uottawa.ca/login?url=$@",
     "location": {
       "lng": -75.68313289999999,
       "lat": 45.42310639999999
@@ -11206,7 +11206,7 @@
   },
   {
     "name": "University of Oxford",
-    "url": "https://ezproxy-prd.bodleian.ox.ac.uk/login?url=",
+    "url": "https://ezproxy-prd.bodleian.ox.ac.uk/login?url=$@",
     "location": {
       "lng": -1.2543668,
       "lat": 51.7548164
@@ -11215,7 +11215,7 @@
   },
   {
     "name": "University of Pennsylvania",
-    "url": "https://proxy.library.upenn.edu/login?url=",
+    "url": "https://proxy.library.upenn.edu/login?url=$@",
     "location": {
       "lng": -75.1932137,
       "lat": 39.9522188
@@ -11224,7 +11224,7 @@
   },
   {
     "name": "University of Phoenix",
-    "url": "http://contentproxy.phoenix.edu/login?url=",
+    "url": "http://contentproxy.phoenix.edu/login?url=$@",
     "location": {
       "lng": -112.0128315,
       "lat": 33.4113377
@@ -11233,7 +11233,7 @@
   },
   {
     "name": "University of Pittsburgh",
-    "url": "http://pitt.idm.oclc.org/login?url=",
+    "url": "http://pitt.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -79.960835,
       "lat": 40.4443533
@@ -11242,7 +11242,7 @@
   },
   {
     "name": "University of Portland",
-    "url": "https://login.uportland.idm.oclc.org/login?url=",
+    "url": "https://login.uportland.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -122.7275712,
       "lat": 45.5732046
@@ -11251,7 +11251,7 @@
   },
   {
     "name": "University of Pretoria",
-    "url": "https://uplib.idm.oclc.org/login?url=",
+    "url": "https://uplib.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 28.2314476,
       "lat": -25.7545492
@@ -11260,7 +11260,7 @@
   },
   {
     "name": "University of Prince Edward Island",
-    "url": "http://proxy.library.upei.ca/login?url=",
+    "url": "http://proxy.library.upei.ca/login?url=$@",
     "location": {
       "lng": -63.13890780000001,
       "lat": 46.2568931
@@ -11269,7 +11269,7 @@
   },
   {
     "name": "University of Puget Sound",
-    "url": "http://ezproxy.ups.edu/login?url=",
+    "url": "http://ezproxy.ups.edu/login?url=$@",
     "location": {
       "lng": -122.4814442,
       "lat": 47.2617495
@@ -11278,7 +11278,7 @@
   },
   {
     "name": "University of Queensland",
-    "url": "http://ezproxy.library.uq.edu.au/login?url=",
+    "url": "http://ezproxy.library.uq.edu.au/login?url=$@",
     "location": {
       "lng": 153.0136905,
       "lat": -27.4975028
@@ -11287,7 +11287,7 @@
   },
   {
     "name": "University of Regina",
-    "url": "http://libproxy.uregina.ca:2048/login?url=",
+    "url": "http://libproxy.uregina.ca:2048/login?url=$@",
     "location": {
       "lng": -104.5878302,
       "lat": 50.4154542
@@ -11296,7 +11296,7 @@
   },
   {
     "name": "University of Rhode Island",
-    "url": "http://uri.idm.oclc.org/login?url=",
+    "url": "http://uri.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -71.53067879999999,
       "lat": 41.4862328
@@ -11305,7 +11305,7 @@
   },
   {
     "name": "University of Richmond",
-    "url": "https://newman.richmond.edu/login?url=",
+    "url": "https://newman.richmond.edu/login?url=$@",
     "location": {
       "lng": -77.5397192,
       "lat": 37.5758243
@@ -11314,7 +11314,7 @@
   },
   {
     "name": "University of Rochester",
-    "url": "http://ezp.lib.rochester.edu/login?url=",
+    "url": "http://ezp.lib.rochester.edu/login?url=$@",
     "location": {
       "lng": -77.6260033,
       "lat": 43.1305531
@@ -11323,7 +11323,7 @@
   },
   {
     "name": "University of Saint Joseph (Macau)",
-    "url": "https://ezproxy.usj.edu.mo:9443/login?url=",
+    "url": "https://ezproxy.usj.edu.mo:9443/login?url=$@",
     "location": {
       "lng": 113.5389114,
       "lat": 22.2111388
@@ -11332,7 +11332,7 @@
   },
   {
     "name": "University of San Carlos",
-    "url": "https://ezproxy.usc.edu.ph/login?url=",
+    "url": "https://ezproxy.usc.edu.ph/login?url=$@",
     "location": {
       "lng": 123.9132676,
       "lat": 10.3521222
@@ -11341,7 +11341,7 @@
   },
   {
     "name": "University of San Diego",
-    "url": "https://sandiego.idm.oclc.org/login?url=",
+    "url": "https://sandiego.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -117.1888625,
       "lat": 32.7721681
@@ -11350,7 +11350,7 @@
   },
   {
     "name": "University of Santo Tomas",
-    "url": "http://ezproxy.ust.edu.ph/login?url=",
+    "url": "http://ezproxy.ust.edu.ph/login?url=$@",
     "location": {
       "lng": 120.9893297,
       "lat": 14.6100492
@@ -11359,7 +11359,7 @@
   },
   {
     "name": "University of Saskatchewan",
-    "url": "http://cyber.usask.ca/login?url=",
+    "url": "http://cyber.usask.ca/login?url=$@",
     "location": {
       "lng": -106.6313582,
       "lat": 52.1334003
@@ -11368,7 +11368,7 @@
   },
   {
     "name": "University of Sheffield",
-    "url": "https://sheffield.idm.oclc.org/login?url=",
+    "url": "https://sheffield.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -1.4884229,
       "lat": 53.3813502
@@ -11377,7 +11377,7 @@
   },
   {
     "name": "University of Siena",
-    "url": "https://www.ezproxy.unisi.it/login?url=",
+    "url": "https://www.ezproxy.unisi.it/login?url=$@",
     "location": {
       "lng": 11.3328421,
       "lat": 43.3191155
@@ -11386,7 +11386,7 @@
   },
   {
     "name": "University of South Alabama",
-    "url": "https://libproxy.usouthal.edu/login?url=",
+    "url": "https://libproxy.usouthal.edu/login?url=$@",
     "location": {
       "lng": -88.184236,
       "lat": 30.6959406
@@ -11395,7 +11395,7 @@
   },
   {
     "name": "University of South Australia",
-    "url": "https://login.ezlibproxy.unisa.edu.au/login?url=",
+    "url": "https://login.ezlibproxy.unisa.edu.au/login?url=$@",
     "location": {
       "lng": 136.2091547,
       "lat": -30.0002315
@@ -11404,7 +11404,7 @@
   },
   {
     "name": "University of South Australia ",
-    "url": "https://access.library.unisa.edu.au/login?url=",
+    "url": "https://access.library.unisa.edu.au/login?url=$@",
     "location": {
       "lng": 136.2091547,
       "lat": -30.0002315
@@ -11413,7 +11413,7 @@
   },
   {
     "name": "University of South Carolina",
-    "url": "https://pallas2.tcl.sc.edu/login?url=",
+    "url": "https://pallas2.tcl.sc.edu/login?url=$@",
     "location": {
       "lng": -81.0299186,
       "lat": 33.9937575
@@ -11422,7 +11422,7 @@
   },
   {
     "name": "University of South Carolina Upstate",
-    "url": "http://proxy.uscupstate.edu:2048/login?url=",
+    "url": "http://proxy.uscupstate.edu:2048/login?url=$@",
     "location": {
       "lng": -81.9711555,
       "lat": 34.9996102
@@ -11431,7 +11431,7 @@
   },
   {
     "name": "University of South Dakota",
-    "url": "http://ezproxy.usd.edu/login?url=",
+    "url": "http://ezproxy.usd.edu/login?url=$@",
     "location": {
       "lng": -96.92533809999999,
       "lat": 42.7883015
@@ -11440,7 +11440,7 @@
   },
   {
     "name": "University of South Florida",
-    "url": "http://ezproxy.lib.usf.edu/login?url=",
+    "url": "http://ezproxy.lib.usf.edu/login?url=$@",
     "location": {
       "lng": -82.41385389999999,
       "lat": 28.0587031
@@ -11449,7 +11449,7 @@
   },
   {
     "name": "University of Southern California",
-    "url": "https://libproxy.usc.edu/login?url=",
+    "url": "https://libproxy.usc.edu/login?url=$@",
     "location": {
       "lng": -118.285117,
       "lat": 34.0223519
@@ -11458,7 +11458,7 @@
   },
   {
     "name": "University of Southern Denmark",
-    "url": "http://proxy1-bib.sdu.dk:2048/login?url=",
+    "url": "http://proxy1-bib.sdu.dk:2048/login?url=$@",
     "location": {
       "lng": 10.4282364,
       "lat": 55.3689827
@@ -11467,7 +11467,7 @@
   },
   {
     "name": "University of Southern Mississippi",
-    "url": "http://lynx.lib.usm.edu/login?url=",
+    "url": "http://lynx.lib.usm.edu/login?url=$@",
     "location": {
       "lng": -89.33345349999999,
       "lat": 31.3298668
@@ -11476,7 +11476,7 @@
   },
   {
     "name": "University of Southern Queensland",
-    "url": "http://ezproxy.usq.edu.au/login?url=",
+    "url": "http://ezproxy.usq.edu.au/login?url=$@",
     "location": {
       "lng": 151.9302108,
       "lat": -27.6045414
@@ -11485,7 +11485,7 @@
   },
   {
     "name": "University of St Andrews",
-    "url": "http://ezproxy.st-andrews.ac.uk/login?url=",
+    "url": "http://ezproxy.st-andrews.ac.uk/login?url=$@",
     "location": {
       "lng": -2.7942674,
       "lat": 56.3417136
@@ -11494,7 +11494,7 @@
   },
   {
     "name": "University of St Francis",
-    "url": "http://ezproxy.stfrancis.edu/login?url=",
+    "url": "http://ezproxy.stfrancis.edu/login?url=$@",
     "location": {
       "lng": -88.09758579999999,
       "lat": 41.5332096
@@ -11503,7 +11503,7 @@
   },
   {
     "name": "University of St Thomas Houston",
-    "url": "http://ezproxy.stthom.edu:2048/login?url=",
+    "url": "http://ezproxy.stthom.edu:2048/login?url=$@",
     "location": {
       "lng": -95.39346800000001,
       "lat": 29.7366605
@@ -11512,7 +11512,7 @@
   },
   {
     "name": "University of St. Thomas",
-    "url": "https://login.ezproxy.stthomas.edu/login?url=",
+    "url": "https://login.ezproxy.stthomas.edu/login?url=$@",
     "location": {
       "lng": -93.1897082,
       "lat": 44.943096
@@ -11521,7 +11521,7 @@
   },
   {
     "name": "University of Stavanger",
-    "url": "https://ezproxy.uis.no/login?url=",
+    "url": "https://ezproxy.uis.no/login?url=$@",
     "location": {
       "lng": 5.697201,
       "lat": 58.93729899999999
@@ -11530,7 +11530,7 @@
   },
   {
     "name": "University of Stirling",
-    "url": "http://ezproxy.stir.ac.uk/login?url=",
+    "url": "http://ezproxy.stir.ac.uk/login?url=$@",
     "location": {
       "lng": -3.9177579,
       "lat": 56.146092
@@ -11539,7 +11539,7 @@
   },
   {
     "name": "University of Strathclyde",
-    "url": "http://proxy.lib.strath.ac.uk/login?url=",
+    "url": "http://proxy.lib.strath.ac.uk/login?url=$@",
     "location": {
       "lng": -4.2423901,
       "lat": 55.8621114
@@ -11548,7 +11548,7 @@
   },
   {
     "name": "University of Sunshine Coast",
-    "url": "http://ezproxy.usc.edu.au:2048/login?url=",
+    "url": "http://ezproxy.usc.edu.au:2048/login?url=$@",
     "location": {
       "lng": 153.0658032,
       "lat": -26.7169935
@@ -11557,7 +11557,7 @@
   },
   {
     "name": "University of Sussex",
-    "url": "http://ezproxy.sussex.ac.uk/login?url=",
+    "url": "http://ezproxy.sussex.ac.uk/login?url=$@",
     "location": {
       "lng": -0.0875492,
       "lat": 50.8677123
@@ -11566,7 +11566,7 @@
   },
   {
     "name": "University of Sydney",
-    "url": "http://ezproxy.library.usyd.edu.au/login?url=",
+    "url": "http://ezproxy.library.usyd.edu.au/login?url=$@",
     "location": {
       "lng": 151.1873494,
       "lat": -33.8885748
@@ -11575,7 +11575,7 @@
   },
   {
     "name": "University of Tartu",
-    "url": "http://ezproxy.utlib.ee/login?url=",
+    "url": "http://ezproxy.utlib.ee/login?url=$@",
     "location": {
       "lng": 26.7290383,
       "lat": 58.37798299999999
@@ -11584,7 +11584,7 @@
   },
   {
     "name": "University of Tasmania",
-    "url": "http://ezproxy.utas.edu.au/login?url=",
+    "url": "http://ezproxy.utas.edu.au/login?url=$@",
     "location": {
       "lng": 147.3247503,
       "lat": -42.9041118
@@ -11593,7 +11593,7 @@
   },
   {
     "name": "University of Technology, Sydney",
-    "url": "http://ezproxy.lib.uts.edu.au/login?url=",
+    "url": "http://ezproxy.lib.uts.edu.au/login?url=$@",
     "location": {
       "lng": 151.2006119,
       "lat": -33.8836537
@@ -11602,7 +11602,7 @@
   },
   {
     "name": "University of Tennessee at Martin",
-    "url": "http://ezproxy.utm.edu/login?url=",
+    "url": "http://ezproxy.utm.edu/login?url=$@",
     "location": {
       "lng": -88.86433319999999,
       "lat": 36.3429724
@@ -11611,7 +11611,7 @@
   },
   {
     "name": "University of Tennessee Chattanooga",
-    "url": "http://proxy.lib.utc.edu/login?url=",
+    "url": "http://proxy.lib.utc.edu/login?url=$@",
     "location": {
       "lng": -85.2953072,
       "lat": 35.0458509
@@ -11620,7 +11620,7 @@
   },
   {
     "name": "University of Tennessee Health Science Center",
-    "url": "https://login.ezproxy.uthsc.edu/login?qurl=",
+    "url": "https://login.ezproxy.uthsc.edu/login?qurl=$@",
     "location": {
       "lng": -90.03061609999999,
       "lat": 35.1408087
@@ -11629,7 +11629,7 @@
   },
   {
     "name": "University of Tennessee Health Science Center ( UTHSC )",
-    "url": "https://ezproxy.uthsc.edu/login?url=",
+    "url": "https://ezproxy.uthsc.edu/login?url=$@",
     "location": {
       "lng": -90.03061609999999,
       "lat": 35.1408087
@@ -11638,7 +11638,7 @@
   },
   {
     "name": "University of Tennessee Knoxville",
-    "url": "https://login.proxy.lib.utk.edu:2050/login?url=",
+    "url": "https://login.proxy.lib.utk.edu:2050/login?url=$@",
     "location": {
       "lng": -83.92945639999999,
       "lat": 35.9544013
@@ -11647,7 +11647,7 @@
   },
   {
     "name": "University of Tennessee, Knoxville",
-    "url": "https://utk.idm.oclc.org/login?url=",
+    "url": "https://utk.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -83.92945639999999,
       "lat": 35.9544013
@@ -11656,7 +11656,7 @@
   },
   {
     "name": "University of Tennessee, Knoxville (Alternative)",
-    "url": "https://login.proxy.lib.utk.edu/login?qurl=",
+    "url": "https://login.proxy.lib.utk.edu/login?qurl=$@",
     "location": {
       "lng": -83.92945639999999,
       "lat": 35.9544013
@@ -11665,7 +11665,7 @@
   },
   {
     "name": "University of Texas at Austin",
-    "url": "http://ezproxy.lib.utexas.edu/login?url=",
+    "url": "http://ezproxy.lib.utexas.edu/login?url=$@",
     "location": {
       "lng": -97.7340567,
       "lat": 30.2849185
@@ -11674,7 +11674,7 @@
   },
   {
     "name": "University of Texas at Brownsville",
-    "url": "http://pathfinder.utb.edu:2048/login?url=",
+    "url": "http://pathfinder.utb.edu:2048/login?url=$@",
     "location": {
       "lng": -97.4974838,
       "lat": 25.9017472
@@ -11683,7 +11683,7 @@
   },
   {
     "name": "University of Texas at Dallas",
-    "url": "http://libproxy.utdallas.edu:80/login?url=",
+    "url": "http://libproxy.utdallas.edu:80/login?url=$@",
     "location": {
       "lng": -96.75024739999999,
       "lat": 32.9856974
@@ -11692,7 +11692,7 @@
   },
   {
     "name": "University of Texas at San Antonio",
-    "url": "https://login.libweb.lib.utsa.edu/login?url=",
+    "url": "https://login.libweb.lib.utsa.edu/login?url=$@",
     "location": {
       "lng": -98.4945922,
       "lat": 29.4251905
@@ -11701,7 +11701,7 @@
   },
   {
     "name": "University of Texas at Tyler",
-    "url": "http://ezproxy.uttyler.edu:2048/login?url=",
+    "url": "http://ezproxy.uttyler.edu:2048/login?url=$@",
     "location": {
       "lng": -95.30106239999999,
       "lat": 32.3512601
@@ -11710,7 +11710,7 @@
   },
   {
     "name": "University of Texas Medical Branch",
-    "url": "http://libux.utmb.edu/login?url=",
+    "url": "http://libux.utmb.edu/login?url=$@",
     "location": {
       "lng": -99.9018131,
       "lat": 31.9685988
@@ -11719,7 +11719,7 @@
   },
   {
     "name": "University of Texas Pan American",
-    "url": "http://ezhost.panam.edu:2048/login?url=",
+    "url": "http://ezhost.panam.edu:2048/login?url=$@",
     "location": {
       "lng": -98.17401579999999,
       "lat": 26.3081983
@@ -11728,7 +11728,7 @@
   },
   {
     "name": "University of Texas Rio Grande Valley",
-    "url": "http://ezhost.utrgv.edu:2048/login?url=",
+    "url": "http://ezhost.utrgv.edu:2048/login?url=$@",
     "location": {
       "lng": -98.17401579999999,
       "lat": 26.3081983
@@ -11737,7 +11737,7 @@
   },
   {
     "name": "University of the Cumberlands",
-    "url": "http://uc2.ucumberlands.edu:2048/login?url=",
+    "url": "http://uc2.ucumberlands.edu:2048/login?url=$@",
     "location": {
       "lng": -84.1635877,
       "lat": 36.7367315
@@ -11746,7 +11746,7 @@
   },
   {
     "name": "University of the Fraser Valley",
-    "url": "http://proxy.ufv.ca:2048/login?url=",
+    "url": "http://proxy.ufv.ca:2048/login?url=$@",
     "location": {
       "lng": -122.2852935,
       "lat": 49.0286216
@@ -11755,7 +11755,7 @@
   },
   {
     "name": "University of the Incarnate Word",
-    "url": "https://uiwtx.idm.oclc.org/login?url=",
+    "url": "https://uiwtx.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -98.4676824,
       "lat": 29.4675393
@@ -11764,7 +11764,7 @@
   },
   {
     "name": "University of the Pacific",
-    "url": "http://ezproxy.pacific.edu/login?url=",
+    "url": "http://ezproxy.pacific.edu/login?url=$@",
     "location": {
       "lng": -121.3128577,
       "lat": 37.9798869
@@ -11773,7 +11773,7 @@
   },
   {
     "name": "University of the Philippines College of Engineering",
-    "url": "http://ezproxy.engglib.upd.edu.ph/login?url=",
+    "url": "http://ezproxy.engglib.upd.edu.ph/login?url=$@",
     "location": {
       "lng": 121.0696293,
       "lat": 14.6565387
@@ -11782,7 +11782,7 @@
   },
   {
     "name": "University of the West Indies at Mona",
-    "url": "http://rproxy.uwimona.edu.jm/login?url=",
+    "url": "http://rproxy.uwimona.edu.jm/login?url=$@",
     "location": {
       "lng": -66.4108475,
       "lat": 18.2345027
@@ -11791,7 +11791,7 @@
   },
   {
     "name": "University of the West of England",
-    "url": "http://ezproxy.uwe.ac.uk/login?url=",
+    "url": "http://ezproxy.uwe.ac.uk/login?url=$@",
     "location": {
       "lng": -2.5474318,
       "lat": 51.5006497
@@ -11800,7 +11800,7 @@
   },
   {
     "name": "University of the Witwatersrand",
-    "url": "https://innopac.wits.ac.za/validate?url=",
+    "url": "https://innopac.wits.ac.za/validate?url=$@",
     "location": {
       "lng": 28.0304733,
       "lat": -26.1928836
@@ -11809,7 +11809,7 @@
   },
   {
     "name": "University of Tokyo (UTOKYO)",
-    "url": "https://utokyo.idm.oclc.org/login?url=",
+    "url": "https://utokyo.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 139.761989,
       "lat": 35.7126775
@@ -11818,7 +11818,7 @@
   },
   {
     "name": "University of Toronto",
-    "url": "http://myaccess.library.utoronto.ca/login?url=",
+    "url": "http://myaccess.library.utoronto.ca/login?url=$@",
     "location": {
       "lng": -79.39565640000001,
       "lat": 43.6628917
@@ -11827,7 +11827,7 @@
   },
   {
     "name": "University of Tsukuba",
-    "url": "http://ezproxy.tulips.tsukuba.ac.jp/login?url=",
+    "url": "http://ezproxy.tulips.tsukuba.ac.jp/login?url=$@",
     "location": {
       "lng": 140.1020979,
       "lat": 36.1038666
@@ -11836,7 +11836,7 @@
   },
   {
     "name": "University of Utah",
-    "url": "https://login.ezproxy.lib.utah.edu/login?url=",
+    "url": "https://login.ezproxy.lib.utah.edu/login?url=$@",
     "location": {
       "lng": -111.8421021,
       "lat": 40.7649368
@@ -11845,7 +11845,7 @@
   },
   {
     "name": "University of Vermont",
-    "url": "https://login.ezproxy.uvm.edu/login?url=",
+    "url": "https://login.ezproxy.uvm.edu/login?url=$@",
     "location": {
       "lng": -73.1964637,
       "lat": 44.4778528
@@ -11854,7 +11854,7 @@
   },
   {
     "name": "University of Victoria",
-    "url": "http://login.ezproxy.library.uvic.ca/login?url=",
+    "url": "http://login.ezproxy.library.uvic.ca/login?url=$@",
     "location": {
       "lng": -123.3116935,
       "lat": 48.4634067
@@ -11863,7 +11863,7 @@
   },
   {
     "name": "University of Virginia",
-    "url": "http://proxy.its.virginia.edu/login?url=",
+    "url": "http://proxy.its.virginia.edu/login?url=$@",
     "location": {
       "lng": -78.5079772,
       "lat": 38.0335529
@@ -11872,7 +11872,7 @@
   },
   {
     "name": "University of Waikato",
-    "url": "http://ezproxy.waikato.ac.nz/login?url=",
+    "url": "http://ezproxy.waikato.ac.nz/login?url=$@",
     "location": {
       "lng": 175.3184579,
       "lat": -37.7868611
@@ -11881,7 +11881,7 @@
   },
   {
     "name": "University of Wales",
-    "url": "http://ezproxy.wales.ac.uk:2048/login?url=",
+    "url": "http://ezproxy.wales.ac.uk:2048/login?url=$@",
     "location": {
       "lng": -3.1809939,
       "lat": 51.48559789999999
@@ -11890,7 +11890,7 @@
   },
   {
     "name": "University of Wales Trinity St Davids",
-    "url": "https://ezproxy.uwtsd.ac.uk/login?url=",
+    "url": "https://ezproxy.uwtsd.ac.uk/login?url=$@",
     "location": {
       "lng": -4.0753536,
       "lat": 52.11439129999999
@@ -11899,7 +11899,7 @@
   },
   {
     "name": "University of Warwick",
-    "url": "https://pugwash.lib.warwick.ac.uk/wamvalidate?url=",
+    "url": "https://pugwash.lib.warwick.ac.uk/wamvalidate?url=$@",
     "location": {
       "lng": -1.5614704,
       "lat": 52.3792525
@@ -11908,7 +11908,7 @@
   },
   {
     "name": "University of Washington",
-    "url": "http://offcampus.lib.washington.edu/login?url=",
+    "url": "http://offcampus.lib.washington.edu/login?url=$@",
     "location": {
       "lng": -122.30463761519987,
       "lat": 47.6598432241655
@@ -11917,7 +11917,7 @@
   },
   {
     "name": "University of Waterloo",
-    "url": "http://proxy.lib.uwaterloo.ca/login?url=",
+    "url": "http://proxy.lib.uwaterloo.ca/login?url=$@",
     "location": {
       "lng": -80.5448576,
       "lat": 43.4722854
@@ -11926,7 +11926,7 @@
   },
   {
     "name": "University of West London",
-    "url": "https://ezproxy.uwl.ac.uk/login?url=",
+    "url": "https://ezproxy.uwl.ac.uk/login?url=$@",
     "location": {
       "lng": -0.3032026,
       "lat": 51.5068853
@@ -11935,7 +11935,7 @@
   },
   {
     "name": "University of Western Australia",
-    "url": "http://ezproxy.library.uwa.edu.au/login?url=",
+    "url": "http://ezproxy.library.uwa.edu.au/login?url=$@",
     "location": {
       "lng": 115.8180721,
       "lat": -31.9789061
@@ -11944,7 +11944,7 @@
   },
   {
     "name": "University of Western Cape",
-    "url": "http://ezproxy.uwc.ac.za/login?url=",
+    "url": "http://ezproxy.uwc.ac.za/login?url=$@",
     "location": {
       "lng": 18.627958,
       "lat": -33.9335203
@@ -11953,7 +11953,7 @@
   },
   {
     "name": "University of Western Ontario",
-    "url": "https://www.lib.uwo.ca/cgi-bin/ezpauthn.cgi?url=",
+    "url": "https://www.lib.uwo.ca/cgi-bin/ezpauthn.cgi?url=$@",
     "location": {
       "lng": -81.2737336,
       "lat": 43.0095971
@@ -11962,7 +11962,7 @@
   },
   {
     "name": "University of Western Sydney",
-    "url": "https://login.ezproxy.uws.edu.au/login?url=",
+    "url": "https://login.ezproxy.uws.edu.au/login?url=$@",
     "location": {
       "lng": 151.0673376972992,
       "lat": -33.817815713497254
@@ -11971,7 +11971,7 @@
   },
   {
     "name": "University of Westminster",
-    "url": "https://ezproxy.westminster.ac.uk/login?url=",
+    "url": "https://ezproxy.westminster.ac.uk/login?url=$@",
     "location": {
       "lng": -0.143179,
       "lat": 51.51698409999999
@@ -11980,7 +11980,7 @@
   },
   {
     "name": "University of Windsor",
-    "url": "http://ezproxy.uwindsor.ca/login?url=",
+    "url": "http://ezproxy.uwindsor.ca/login?url=$@",
     "location": {
       "lng": -83.06603899999999,
       "lat": 42.3043142
@@ -11989,7 +11989,7 @@
   },
   {
     "name": "University of Winnipeg",
-    "url": "http://libproxy.uwinnipeg.ca/login?url=",
+    "url": "http://libproxy.uwinnipeg.ca/login?url=$@",
     "location": {
       "lng": -97.15355600000001,
       "lat": 49.891786
@@ -11998,7 +11998,7 @@
   },
   {
     "name": "University of Wisconsin",
-    "url": "https://ezproxy.uwc.edu/login?url=",
+    "url": "https://ezproxy.uwc.edu/login?url=$@",
     "location": {
       "lng": -89.4124875,
       "lat": 43.076592
@@ -12007,7 +12007,7 @@
   },
   {
     "name": "University of Wisconsin - Milwaukee",
-    "url": "https://ezproxy.lib.uwm.edu/login?url=",
+    "url": "https://ezproxy.lib.uwm.edu/login?url=$@",
     "location": {
       "lng": -87.8819686,
       "lat": 43.078263
@@ -12016,7 +12016,7 @@
   },
   {
     "name": "University of Wisconsin - Superior",
-    "url": "https://link.uwsuper.edu:9433/login?url=",
+    "url": "https://link.uwsuper.edu:9433/login?url=$@",
     "location": {
       "lng": -92.0881522,
       "lat": 46.7177476
@@ -12025,7 +12025,7 @@
   },
   {
     "name": "University of Wisconsin Madison",
-    "url": "http://ezproxy.library.wisc.edu/login?url=",
+    "url": "http://ezproxy.library.wisc.edu/login?url=$@",
     "location": {
       "lng": -89.4124875,
       "lat": 43.076592
@@ -12034,7 +12034,7 @@
   },
   {
     "name": "University of Wisconsin Oshkosh",
-    "url": "http://www.remote.uwosh.edu/login?url=",
+    "url": "http://www.remote.uwosh.edu/login?url=$@",
     "location": {
       "lng": -88.55081559999999,
       "lat": 44.0262095
@@ -12043,7 +12043,7 @@
   },
   {
     "name": "University of Wisconsin Whitewater",
-    "url": "https://libproxy.uww.edu:9443/login?url=",
+    "url": "https://libproxy.uww.edu:9443/login?url=$@",
     "location": {
       "lng": -88.7427628,
       "lat": 42.8416843
@@ -12052,7 +12052,7 @@
   },
   {
     "name": "University of Wisconsin-Eau Claire",
-    "url": "https://login.proxy.uwec.edu/login?qurl=",
+    "url": "https://login.proxy.uwec.edu/login?qurl=$@",
     "location": {
       "lng": -91.5038225,
       "lat": 44.7956278
@@ -12061,7 +12061,7 @@
   },
   {
     "name": "University of Wisconsin-Green Bay",
-    "url": "https://ezproxy.uwgb.edu:2443/login?url=",
+    "url": "https://ezproxy.uwgb.edu:2443/login?url=$@",
     "location": {
       "lng": -87.9210482,
       "lat": 44.5313196
@@ -12070,7 +12070,7 @@
   },
   {
     "name": "University of Wisconsin-La Crosse",
-    "url": "https://libweb.uwlax.edu/login?url=",
+    "url": "https://libweb.uwlax.edu/login?url=$@",
     "location": {
       "lng": -91.23115330000002,
       "lat": 43.8159885
@@ -12079,7 +12079,7 @@
   },
   {
     "name": "University of Wisconsin-Parkside",
-    "url": "http://libraryproxy.uwp.edu:2048/login?url=",
+    "url": "http://libraryproxy.uwp.edu:2048/login?url=$@",
     "location": {
       "lng": -87.85174099999999,
       "lat": 42.6450059
@@ -12088,7 +12088,7 @@
   },
   {
     "name": "University of Wisconsin-Platteville",
-    "url": "https://login.ezproxy.uwplatt.edu/login?url=",
+    "url": "https://login.ezproxy.uwplatt.edu/login?url=$@",
     "location": {
       "lng": -90.48782140000002,
       "lat": 42.7331994
@@ -12097,7 +12097,7 @@
   },
   {
     "name": "University of Wisconsin-River Falls",
-    "url": "http://ezproxy.uwrf.edu:2048/login?url=",
+    "url": "http://ezproxy.uwrf.edu:2048/login?url=$@",
     "location": {
       "lng": -92.6222324,
       "lat": 44.8530003
@@ -12106,7 +12106,7 @@
   },
   {
     "name": "University of Wollongong",
-    "url": "http://ezproxy.uow.edu.au/login?url=",
+    "url": "http://ezproxy.uow.edu.au/login?url=$@",
     "location": {
       "lng": 150.87843,
       "lat": -34.4054039
@@ -12115,7 +12115,7 @@
   },
   {
     "name": "University of Wolverhampton",
-    "url": "http://ezproxy.wlv.ac.uk/login?url=",
+    "url": "http://ezproxy.wlv.ac.uk/login?url=$@",
     "location": {
       "lng": -2.1274831,
       "lat": 52.5880528
@@ -12124,7 +12124,7 @@
   },
   {
     "name": "University of Wyoming",
-    "url": "http://libproxy.uwyo.edu/login?url=",
+    "url": "http://libproxy.uwyo.edu/login?url=$@",
     "location": {
       "lng": -105.5665744,
       "lat": 41.3148754
@@ -12133,7 +12133,7 @@
   },
   {
     "name": "University of York",
-    "url": "http://ezproxy.york.ac.uk/login?url=",
+    "url": "http://ezproxy.york.ac.uk/login?url=$@",
     "location": {
       "lng": -1.0517718,
       "lat": 53.9461089
@@ -12142,7 +12142,7 @@
   },
   {
     "name": "University of Zaragoza",
-    "url": "http://roble.unizar.es:9090/login?url=",
+    "url": "http://roble.unizar.es:9090/login?url=$@",
     "location": {
       "lng": -0.9015065,
       "lat": 41.6420639
@@ -12151,7 +12151,7 @@
   },
   {
     "name": "University Rennes 1",
-    "url": "http://passerelle.univ-rennes1.fr/login?url=",
+    "url": "http://passerelle.univ-rennes1.fr/login?url=$@",
     "location": {
       "lng": -1.673112,
       "lat": 48.11574599999999
@@ -12160,7 +12160,7 @@
   },
   {
     "name": "University Teknologi Malaysia",
-    "url": "http://ezproxy.psz.utm.my/login?url=",
+    "url": "http://ezproxy.psz.utm.my/login?url=$@",
     "location": {
       "lng": 103.6378169,
       "lat": 1.5584681
@@ -12169,7 +12169,7 @@
   },
   {
     "name": "University West",
-    "url": "http://ezproxy.server.hv.se/login?url=",
+    "url": "http://ezproxy.server.hv.se/login?url=$@",
     "location": {
       "lng": 12.2939585,
       "lat": 58.2832436
@@ -12178,7 +12178,7 @@
   },
   {
     "name": "Università degli Studi dell'Aquila",
-    "url": "https://login.univaq.idm.oclc.org/login?url=",
+    "url": "https://login.univaq.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 13.397299,
       "lat": 42.3514296
@@ -12187,7 +12187,7 @@
   },
   {
     "name": "Università degli Studi dell'Insubria",
-    "url": "https://login.insubria.idm.oclc.org/login?qurl=",
+    "url": "https://login.insubria.idm.oclc.org/login?qurl=$@",
     "location": {
       "lng": 8.8275388,
       "lat": 45.8144164
@@ -12196,7 +12196,7 @@
   },
   {
     "name": "Università degli Studi di Bari Aldo Moro ",
-    "url": "https://login.ezproxy.uniba.it/login?url=",
+    "url": "https://login.ezproxy.uniba.it/login?url=$@",
     "location": {
       "lng": 16.8684745,
       "lat": 41.1205546
@@ -12205,7 +12205,7 @@
   },
   {
     "name": "Università della Calabria",
-    "url": "https://proxy.biblioteche.unical.it/login?url=",
+    "url": "https://proxy.biblioteche.unical.it/login?url=$@",
     "location": {
       "lng": 16.2261297,
       "lat": 39.3617989
@@ -12214,7 +12214,7 @@
   },
   {
     "name": "Università di Bologna - Alma Mater Studiorum",
-    "url": "https://www.ezproxy.unibo.it/login?url=",
+    "url": "https://www.ezproxy.unibo.it/login?url=$@",
     "location": {
       "lng": 11.354157,
       "lat": 44.4962318
@@ -12223,7 +12223,7 @@
   },
   {
     "name": "Università di Trento",
-    "url": "https://www.ezp.biblio.unitn.it/login?url=",
+    "url": "https://www.ezp.biblio.unitn.it/login?url=$@",
     "location": {
       "lng": 11.1231091,
       "lat": 46.0668672
@@ -12232,7 +12232,7 @@
   },
   {
     "name": "Università di Trieste",
-    "url": "http://px.units.it/login?url=",
+    "url": "http://px.units.it/login?url=$@",
     "location": {
       "lng": 13.7947478,
       "lat": 45.6595455
@@ -12241,7 +12241,7 @@
   },
   {
     "name": "Université Bretagne Sud",
-    "url": "http://ezproxy.univ-ubs.fr/login?url=",
+    "url": "http://ezproxy.univ-ubs.fr/login?url=$@",
     "location": {
       "lng": -2.9326435,
       "lat": 48.2020471
@@ -12250,7 +12250,7 @@
   },
   {
     "name": "Université Clermont Auvergne",
-    "url": "https://www.ezproxy.uca.fr/login?url=",
+    "url": "https://www.ezproxy.uca.fr/login?url=$@",
     "location": {
       "lng": 3.0917058,
       "lat": 45.7757949
@@ -12259,7 +12259,7 @@
   },
   {
     "name": "Université d'Artois",
-    "url": "http://ezproxy.univ-artois.fr/login?url=",
+    "url": "http://ezproxy.univ-artois.fr/login?url=$@",
     "location": {
       "lng": 2.792248,
       "lat": 50.283639
@@ -12268,7 +12268,7 @@
   },
   {
     "name": "Université de Bordeaux",
-    "url": "http://docelec.u-bordeaux.fr/login?url=",
+    "url": "http://docelec.u-bordeaux.fr/login?url=$@",
     "location": {
       "lng": -0.6059053,
       "lat": 44.8244914
@@ -12277,7 +12277,7 @@
   },
   {
     "name": "Université de Bretagne Occidentale (UBO)",
-    "url": "https://cas.univ-brest.fr/cas/login?url=",
+    "url": "https://cas.univ-brest.fr/cas/login?url=$@",
     "location": {
       "lng": -4.5074935,
       "lat": 48.39806189999999
@@ -12286,7 +12286,7 @@
   },
   {
     "name": "Université de Lille",
-    "url": "http://ressources-electroniques.univ-lille.fr/login?url=",
+    "url": "http://ressources-electroniques.univ-lille.fr/login?url=$@",
     "location": {
       "lng": 3.0752632,
       "lat": 50.6320414
@@ -12295,7 +12295,7 @@
   },
   {
     "name": "Université de Québec à Montréal",
-    "url": "http://proxy.bibliotheques.uqam.ca/login?url=",
+    "url": "http://proxy.bibliotheques.uqam.ca/login?url=$@",
     "location": {
       "lng": -73.5602937,
       "lat": 45.5131547
@@ -12304,7 +12304,7 @@
   },
   {
     "name": "Université de Rennes 2",
-    "url": "http://distant.bu.univ-rennes1.fr/connect?url=",
+    "url": "http://distant.bu.univ-rennes1.fr/connect?url=$@",
     "location": {
       "lng": -1.7028658,
       "lat": 48.1179154
@@ -12313,7 +12313,7 @@
   },
   {
     "name": "Université de Sherbrooke",
-    "url": "https://ezproxy.usherbrooke.ca/login?URL=",
+    "url": "https://ezproxy.usherbrooke.ca/login?URL=$@",
     "location": {
       "lng": -71.89367399999999,
       "lat": 45.4042669
@@ -12322,7 +12322,7 @@
   },
   {
     "name": "Université de Strasbourg",
-    "url": "https://scd-rproxy.u-strasbg.fr/login?url=",
+    "url": "https://scd-rproxy.u-strasbg.fr/login?url=$@",
     "location": {
       "lng": 7.766454499999999,
       "lat": 48.5790692
@@ -12331,7 +12331,7 @@
   },
   {
     "name": "Université Grenoble Alpes",
-    "url": "https://login.sid2nomade-1.grenet.fr/login?url=",
+    "url": "https://login.sid2nomade-1.grenet.fr/login?url=$@",
     "location": {
       "lng": 5.7672336,
       "lat": 45.1915639
@@ -12340,7 +12340,7 @@
   },
   {
     "name": "Université Gustave Eiffel (GHU-Paris)",
-    "url": "https://univ-eiffel.idm.oclc.org/login?url=",
+    "url": "https://univ-eiffel.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 2.5877098,
       "lat": 48.8426391
@@ -12349,7 +12349,7 @@
   },
   {
     "name": "Université Laval",
-    "url": "http://acces.bibl.ulaval.ca/login?url=",
+    "url": "http://acces.bibl.ulaval.ca/login?url=$@",
     "location": {
       "lng": -71.2747424,
       "lat": 46.78174629999999
@@ -12358,7 +12358,7 @@
   },
   {
     "name": "Université Libre de Bruxelles",
-    "url": "https://ezproxy.ulb.ac.be/login?url=",
+    "url": "https://ezproxy.ulb.ac.be/login?url=$@",
     "location": {
       "lng": 4.3822222,
       "lat": 50.8132068
@@ -12367,7 +12367,7 @@
   },
   {
     "name": "Université Libre de Bruxelles (ULB)",
-    "url": "https://www.ezproxy.ulb.ac.be/login?url=",
+    "url": "https://www.ezproxy.ulb.ac.be/login?url=$@",
     "location": {
       "lng": 4.3822222,
       "lat": 50.8132068
@@ -12376,7 +12376,7 @@
   },
   {
     "name": "Université Lille 1",
-    "url": "http://buproxy.univ-lille1.fr/login?url=",
+    "url": "http://buproxy.univ-lille1.fr/login?url=$@",
     "location": {
       "lng": 3.1417556,
       "lat": 50.6085867
@@ -12385,7 +12385,7 @@
   },
   {
     "name": "Université Paris 6 et 7 - Mathématiques Informatique Recherche",
-    "url": "http://ezproxy.math-info-paris.cnrs.fr/login?url=",
+    "url": "http://ezproxy.math-info-paris.cnrs.fr/login?url=$@",
     "location": {
       "lng": 2.357499,
       "lat": 48.8471036
@@ -12394,7 +12394,7 @@
   },
   {
     "name": "Université Paris Cité",
-    "url": "https://ezproxy.u-paris.fr/login?url=",
+    "url": "https://ezproxy.u-paris.fr/login?url=$@",
     "location": {
       "lng": 2.3318026778200607,
       "lat": 48.85676231053687
@@ -12403,7 +12403,7 @@
   },
   {
     "name": "Université Paris-Saclay",
-    "url": "http://ezproxy.universite-paris-saclay.fr/login?url=",
+    "url": "http://ezproxy.universite-paris-saclay.fr/login?url=$@",
     "location": {
       "lng": 2.1666978,
       "lat": 48.7098718
@@ -12412,7 +12412,7 @@
   },
   {
     "name": "Université Pierre et Marie Curie - Paris 6",
-    "url": "http://accesdistant.upmc.fr/login?url=",
+    "url": "http://accesdistant.upmc.fr/login?url=$@",
     "location": {
       "lng": 2.357499,
       "lat": 48.8471036
@@ -12421,7 +12421,7 @@
   },
   {
     "name": "Université Polytechnique Hauts-de-France",
-    "url": "https://login.ezproxy.uphf.fr/login?url=",
+    "url": "https://login.ezproxy.uphf.fr/login?url=$@",
     "location": {
       "lng": 3.5168432,
       "lat": 50.3262594
@@ -12430,7 +12430,7 @@
   },
   {
     "name": "Université Saint Jospeh Beirut",
-    "url": "https://ezproxy.usj.edu.lb/login?url=",
+    "url": "https://ezproxy.usj.edu.lb/login?url=$@",
     "location": {
       "lng": 35.508674,
       "lat": 33.891593
@@ -12439,7 +12439,7 @@
   },
   {
     "name": "Université Toulouse II Jean Jaurès",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=",
+    "url": "https://gorgone.univ-toulouse.fr/login?url=$@",
     "location": {
       "lng": 1.4020557,
       "lat": 43.5763289
@@ -12448,7 +12448,7 @@
   },
   {
     "name": "Univerza v Ljubljani",
-    "url": "http://cmk-proxy.mf.uni-lj.si:2048/login?url=",
+    "url": "http://cmk-proxy.mf.uni-lj.si:2048/login?url=$@",
     "location": {
       "lng": 14.5041552,
       "lat": 46.0491938
@@ -12457,7 +12457,7 @@
   },
   {
     "name": "Univerzita Karlova v Praze",
-    "url": "https://login.ezproxy.is.cuni.cz/login?url=",
+    "url": "https://login.ezproxy.is.cuni.cz/login?url=$@",
     "location": {
       "lng": 14.4234889,
       "lat": 50.0871106
@@ -12466,7 +12466,7 @@
   },
   {
     "name": "Univerzita Tomase Bati ve Zline",
-    "url": "http://proxy.k.utb.cz/login?url=",
+    "url": "http://proxy.k.utb.cz/login?url=$@",
     "location": {
       "lng": 17.664866,
       "lat": 49.222624
@@ -12475,7 +12475,7 @@
   },
   {
     "name": "Uppsala University",
-    "url": "http://ezproxy.its.uu.se/login?url=",
+    "url": "http://ezproxy.its.uu.se/login?url=$@",
     "location": {
       "lng": 17.6300093,
       "lat": 59.85090049999999
@@ -12484,7 +12484,7 @@
   },
   {
     "name": "Ural Federal University (URFU)",
-    "url": "https://ezproxy.urfu.ru/login?url=",
+    "url": "https://ezproxy.urfu.ru/login?url=$@",
     "location": {
       "lng": 60.6160252,
       "lat": 56.8403246
@@ -12493,7 +12493,7 @@
   },
   {
     "name": "UT Health Center San Antonio",
-    "url": "http://libproxy.uthscsa.edu/login?url=",
+    "url": "http://libproxy.uthscsa.edu/login?url=$@",
     "location": {
       "lng": -98.4945922,
       "lat": 29.4251905
@@ -12502,7 +12502,7 @@
   },
   {
     "name": "Utah State University",
-    "url": "http://dist.lib.usu.edu/login?url=",
+    "url": "http://dist.lib.usu.edu/login?url=$@",
     "location": {
       "lng": -111.8097425,
       "lat": 41.745161
@@ -12511,7 +12511,7 @@
   },
   {
     "name": "Utah Valley",
-    "url": "https://ezproxy.uvu.edu/login?qurl=",
+    "url": "https://ezproxy.uvu.edu/login?qurl=$@",
     "location": {
       "lng": -111.7153739,
       "lat": 40.2787626
@@ -12520,7 +12520,7 @@
   },
   {
     "name": "UTCC",
-    "url": "https://login.ezproxy.utcc.ac.th/login?url=",
+    "url": "https://login.ezproxy.utcc.ac.th/login?url=$@",
     "location": {
       "lng": 100.5600899,
       "lat": 13.7785495
@@ -12529,7 +12529,7 @@
   },
   {
     "name": "Utica",
-    "url": "https://ezproxy.utica.edu/login?url=",
+    "url": "https://ezproxy.utica.edu/login?url=$@",
     "location": {
       "lng": -75.232664,
       "lat": 43.100903
@@ -12538,7 +12538,7 @@
   },
   {
     "name": "Utrecht University",
-    "url": "https://login.proxy.library.uu.nl/login?url=",
+    "url": "https://login.proxy.library.uu.nl/login?url=$@",
     "location": {
       "lng": 5.1757062,
       "lat": 52.08518249999999
@@ -12547,7 +12547,7 @@
   },
   {
     "name": "Valley City State",
-    "url": "https://library.vcsu.edu:2443/login?url=",
+    "url": "https://library.vcsu.edu:2443/login?url=$@",
     "location": {
       "lng": -98.0028198,
       "lat": 46.9186274
@@ -12556,7 +12556,7 @@
   },
   {
     "name": "Valparaiso",
-    "url": "http://ezproxy.valpo.edu/login?url=",
+    "url": "http://ezproxy.valpo.edu/login?url=$@",
     "location": {
       "lng": -71.61268849999999,
       "lat": -33.047238
@@ -12565,7 +12565,7 @@
   },
   {
     "name": "Van Hall Larenstein",
-    "url": "http://hvhl.idm.oclc.org/login?url=",
+    "url": "http://hvhl.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 5.8042998,
       "lat": 53.19421759999999
@@ -12574,7 +12574,7 @@
   },
   {
     "name": "Vancouver Island",
-    "url": "http://ezproxy.viu.ca/login?url=",
+    "url": "http://ezproxy.viu.ca/login?url=$@",
     "location": {
       "lng": -125.4493906,
       "lat": 49.6506376
@@ -12583,7 +12583,7 @@
   },
   {
     "name": "Vanderbilt University",
-    "url": "http://proxy.library.vanderbilt.edu/login?url=",
+    "url": "http://proxy.library.vanderbilt.edu/login?url=$@",
     "location": {
       "lng": -86.8026551,
       "lat": 36.1447034
@@ -12592,7 +12592,7 @@
   },
   {
     "name": "Vanguard University",
-    "url": "https://vanguard.idm.oclc.org/login?url=",
+    "url": "https://vanguard.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -117.89434400590231,
       "lat": 33.77516276589112
@@ -12601,7 +12601,7 @@
   },
   {
     "name": "Vassar",
-    "url": "http://libproxy.vassar.edu/login?url=",
+    "url": "http://libproxy.vassar.edu/login?url=$@",
     "location": {
       "lng": -73.8936812,
       "lat": 41.68667809999999
@@ -12610,7 +12610,7 @@
   },
   {
     "name": "Victoria University",
-    "url": "http://wallaby.vu.edu.au:5678/login?url=",
+    "url": "http://wallaby.vu.edu.au:5678/login?url=$@",
     "location": {
       "lng": 144.96434503852703,
       "lat": -37.81518569294075
@@ -12619,7 +12619,7 @@
   },
   {
     "name": "Victoria University of Wellington",
-    "url": "https://login.helicon.vuw.ac.nz/login?url=",
+    "url": "https://login.helicon.vuw.ac.nz/login?url=$@",
     "location": {
       "lng": 174.7678789,
       "lat": -41.2901075
@@ -12628,7 +12628,7 @@
   },
   {
     "name": "Victoria University | Melbourne Australia",
-    "url": "http://wallaby.vu.edu.au:2048/login?url=",
+    "url": "http://wallaby.vu.edu.au:2048/login?url=$@",
     "location": {
       "lng": 144.9630576,
       "lat": -37.8136276
@@ -12637,7 +12637,7 @@
   },
   {
     "name": "VID vitenskapelige høgskole",
-    "url": "https://ezproxy.vid.no/login?url=",
+    "url": "https://ezproxy.vid.no/login?url=$@",
     "location": {
       "lng": 10.7051483,
       "lat": 59.9366728
@@ -12646,7 +12646,7 @@
   },
   {
     "name": "Vienna University Library ",
-    "url": "http://uaccess.univie.ac.at/login?url=",
+    "url": "http://uaccess.univie.ac.at/login?url=$@",
     "location": {
       "lng": 16.36027,
       "lat": 48.2133938
@@ -12655,7 +12655,7 @@
   },
   {
     "name": "Villanova",
-    "url": "http://ezp1.villanova.edu:80/login?url=",
+    "url": "http://ezp1.villanova.edu:80/login?url=$@",
     "location": {
       "lng": -75.3491813,
       "lat": 40.0375832
@@ -12664,7 +12664,7 @@
   },
   {
     "name": "Virginia Commonwealth University",
-    "url": "https://proxy.library.vcu.edu/login?url=",
+    "url": "https://proxy.library.vcu.edu/login?url=$@",
     "location": {
       "lng": -77.4527359,
       "lat": 37.5526695
@@ -12673,7 +12673,7 @@
   },
   {
     "name": "Virginia Tech",
-    "url": "https://login.ezproxy.lib.vt.edu/login?qurl=",
+    "url": "https://login.ezproxy.lib.vt.edu/login?qurl=$@",
     "location": {
       "lng": -80.42341669999999,
       "lat": 37.22838429999999
@@ -12682,7 +12682,7 @@
   },
   {
     "name": "Vrije Universiteit Amsterdam",
-    "url": "https://vu-nl.idm.oclc.org/login?url=",
+    "url": "https://vu-nl.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 4.8657199,
       "lat": 52.3337568
@@ -12691,7 +12691,7 @@
   },
   {
     "name": "Vrije Universiteit Brussel (VUB)",
-    "url": "https://myezproxy.vub.ac.be/login?url=",
+    "url": "https://myezproxy.vub.ac.be/login?url=$@",
     "location": {
       "lng": 4.3802052,
       "lat": 50.8260453
@@ -12700,7 +12700,7 @@
   },
   {
     "name": "Wageningen UR",
-    "url": "http://ezproxy.library.wur.nl/login?url=",
+    "url": "http://ezproxy.library.wur.nl/login?url=$@",
     "location": {
       "lng": 5.6680191,
       "lat": 51.9863475
@@ -12709,7 +12709,7 @@
   },
   {
     "name": "Waiariki Bay of Plenty Polytechnic",
-    "url": "http://ezproxy.waiariki.ac.nz:2048/login?url=",
+    "url": "http://ezproxy.waiariki.ac.nz:2048/login?url=$@",
     "location": {
       "lng": 175.8743607845435,
       "lat": -38.21747790944405
@@ -12718,7 +12718,7 @@
   },
   {
     "name": "Wake Forest",
-    "url": "http://ezproxy.wfu.edu/login?url=",
+    "url": "http://ezproxy.wfu.edu/login?url=$@",
     "location": {
       "lng": -80.2792887,
       "lat": 36.1354887
@@ -12727,7 +12727,7 @@
   },
   {
     "name": "Wake Technical",
-    "url": "http://ezproxy.waketech.edu/login?url=",
+    "url": "http://ezproxy.waketech.edu/login?url=$@",
     "location": {
       "lng": -78.70471789999999,
       "lat": 35.6515968
@@ -12736,7 +12736,7 @@
   },
   {
     "name": "Walden University",
-    "url": "http://ezp.waldenulibrary.org/login?url=",
+    "url": "http://ezp.waldenulibrary.org/login?url=$@",
     "location": {
       "lng": -93.2655624,
       "lat": 44.9811267
@@ -12745,7 +12745,7 @@
   },
   {
     "name": "Walla Walla",
-    "url": "http://ezproxy.wwcc.edu:2048/login?url=",
+    "url": "http://ezproxy.wwcc.edu:2048/login?url=$@",
     "location": {
       "lng": -118.3430209,
       "lat": 46.0645809
@@ -12754,7 +12754,7 @@
   },
   {
     "name": "Warner Pacific",
-    "url": "http://ezproxy.warnerpacific.edu:2048/login?url=",
+    "url": "http://ezproxy.warnerpacific.edu:2048/login?url=$@",
     "location": {
       "lng": -122.5932083,
       "lat": 45.5062217
@@ -12763,7 +12763,7 @@
   },
   {
     "name": "Waseda University",
-    "url": "https://waseda.idm.oclc.org/login?url=",
+    "url": "https://waseda.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 139.7196485,
       "lat": 35.7087334
@@ -12772,7 +12772,7 @@
   },
   {
     "name": "Washington State",
-    "url": "https://ntserver1.wsulibs.wsu.edu:6443/login?url=",
+    "url": "https://ntserver1.wsulibs.wsu.edu:6443/login?url=$@",
     "location": {
       "lng": -120.7401386,
       "lat": 47.7510741
@@ -12781,7 +12781,7 @@
   },
   {
     "name": "Washington University in St. Louis",
-    "url": "http://libproxy.wustl.edu/login?url=",
+    "url": "http://libproxy.wustl.edu/login?url=$@",
     "location": {
       "lng": -90.31079620000001,
       "lat": 38.6487895
@@ -12790,7 +12790,7 @@
   },
   {
     "name": "Washington University School of Medicine",
-    "url": "https://beckerproxy.wustl.edu/login?url=",
+    "url": "https://beckerproxy.wustl.edu/login?url=$@",
     "location": {
       "lng": -90.26292889999999,
       "lat": 38.6351441
@@ -12799,7 +12799,7 @@
   },
   {
     "name": "Washtenaw",
-    "url": "https://login.ezproxy.wccnet.edu/login?url=",
+    "url": "https://login.ezproxy.wccnet.edu/login?url=$@",
     "location": {
       "lng": -83.8473015,
       "lat": 42.3076493
@@ -12808,7 +12808,7 @@
   },
   {
     "name": "Waterford Institute of Technology",
-    "url": "http://ezproxy.wit.ie:2048/login?url=",
+    "url": "http://ezproxy.wit.ie:2048/login?url=$@",
     "location": {
       "lng": -7.138704499999999,
       "lat": 52.2460592
@@ -12817,7 +12817,7 @@
   },
   {
     "name": "Waubonsee",
-    "url": "https://dewey.waubonsee.edu/login?url=",
+    "url": "https://dewey.waubonsee.edu/login?url=$@",
     "location": {
       "lng": -88.4584655,
       "lat": 41.7952983
@@ -12826,7 +12826,7 @@
   },
   {
     "name": "Wayne Community College",
-    "url": "http://cgez.waynecc.edu:2048/login?url=",
+    "url": "http://cgez.waynecc.edu:2048/login?url=$@",
     "location": {
       "lng": -77.94535288180907,
       "lat": 35.40320329467797
@@ -12835,7 +12835,7 @@
   },
   {
     "name": "Wayne State University",
-    "url": "http://proxy.lib.wayne.edu/login?url=",
+    "url": "http://proxy.lib.wayne.edu/login?url=$@",
     "location": {
       "lng": -83.06654619999999,
       "lat": 42.3591388
@@ -12844,7 +12844,7 @@
   },
   {
     "name": "Webster University",
-    "url": "http://library3.webster.edu/login?url=",
+    "url": "http://library3.webster.edu/login?url=$@",
     "location": {
       "lng": -90.34398022210736,
       "lat": 38.589540722949536
@@ -12853,7 +12853,7 @@
   },
   {
     "name": "Weill Cornell Medicine",
-    "url": "http://ezproxy.med.cornell.edu/login?url=",
+    "url": "http://ezproxy.med.cornell.edu/login?url=$@",
     "location": {
       "lng": -73.9555127,
       "lat": 40.7664886
@@ -12862,7 +12862,7 @@
   },
   {
     "name": "Weizmann Institute of Science",
-    "url": "https://ezproxy.weizmann.ac.il/login?url=",
+    "url": "https://ezproxy.weizmann.ac.il/login?url=$@",
     "location": {
       "lng": 34.8080315,
       "lat": 31.90375409999999
@@ -12871,7 +12871,7 @@
   },
   {
     "name": "Wellesley College",
-    "url": "https://ezproxy.wellesley.edu/login?url=",
+    "url": "https://ezproxy.wellesley.edu/login?url=$@",
     "location": {
       "lng": -71.3059277,
       "lat": 42.2935733
@@ -12880,7 +12880,7 @@
   },
   {
     "name": "Wentworth Institute of Technology",
-    "url": "http://ezproxywit.flo.org/login?url=",
+    "url": "http://ezproxywit.flo.org/login?url=$@",
     "location": {
       "lng": -71.0965415,
       "lat": 42.3370447
@@ -12889,7 +12889,7 @@
   },
   {
     "name": "Wesleyan",
-    "url": "http://ezproxy.wesleyan.edu:7790/login?url=",
+    "url": "http://ezproxy.wesleyan.edu:7790/login?url=$@",
     "location": {
       "lng": -72.6568336,
       "lat": 41.5567587
@@ -12898,7 +12898,7 @@
   },
   {
     "name": "West Chester University",
-    "url": "http://proxy-wcupa.klnpa.org/login?url=",
+    "url": "http://proxy-wcupa.klnpa.org/login?url=$@",
     "location": {
       "lng": -75.5981257,
       "lat": 39.9523671
@@ -12907,7 +12907,7 @@
   },
   {
     "name": "West Texas A&M University",
-    "url": "https://login.databases.wtamu.edu/login?url=",
+    "url": "https://login.databases.wtamu.edu/login?url=$@",
     "location": {
       "lng": -101.9160329,
       "lat": 34.9816909
@@ -12916,7 +12916,7 @@
   },
   {
     "name": "West Virginia",
-    "url": "https://wvu.idm.oclc.org/login?url=",
+    "url": "https://wvu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -80.4549026,
       "lat": 38.5976262
@@ -12925,7 +12925,7 @@
   },
   {
     "name": "Western Governors",
-    "url": "http://wgu.idm.oclc.org/login?url=",
+    "url": "http://wgu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -111.8699469,
       "lat": 40.684929
@@ -12934,7 +12934,7 @@
   },
   {
     "name": "Western Illinois",
-    "url": "https://ezproxy.wiu.edu/login?url=",
+    "url": "https://ezproxy.wiu.edu/login?url=$@",
     "location": {
       "lng": -90.68435989999999,
       "lat": 40.4766148
@@ -12943,7 +12943,7 @@
   },
   {
     "name": "Western Iowa Tech",
-    "url": "http://witcc.idm.oclc.org/login?url=",
+    "url": "http://witcc.idm.oclc.org/login?url=$@",
     "location": {
       "lng": -96.34792,
       "lat": 42.483421
@@ -12952,7 +12952,7 @@
   },
   {
     "name": "Western Kentucky",
-    "url": "http://libsrv.wku.edu:2048/login?url=",
+    "url": "http://libsrv.wku.edu:2048/login?url=$@",
     "location": {
       "lng": -86.4559991,
       "lat": 36.9847153
@@ -12961,7 +12961,7 @@
   },
   {
     "name": "Western Michigan",
-    "url": "http://libproxy.library.wmich.edu/login?url=",
+    "url": "http://libproxy.library.wmich.edu/login?url=$@",
     "location": {
       "lng": -85.6102506,
       "lat": 42.2837337
@@ -12970,7 +12970,7 @@
   },
   {
     "name": "Western Montana College of The University of Montana",
-    "url": "http://proxyserver.umwestern.edu:2048/login?url=",
+    "url": "http://proxyserver.umwestern.edu:2048/login?url=$@",
     "location": {
       "lng": -112.6386268,
       "lat": 45.208792
@@ -12979,7 +12979,7 @@
   },
   {
     "name": "Western Norway University of Applied Sciences (HVL)",
-    "url": "https://galanga.hvl.no/login?url=",
+    "url": "https://galanga.hvl.no/login?url=$@",
     "location": {
       "lng": 5.350094299999999,
       "lat": 60.3689499
@@ -12988,7 +12988,7 @@
   },
   {
     "name": "Western Oregon",
-    "url": "https://ezproxy.wou.edu/login?url=",
+    "url": "https://ezproxy.wou.edu/login?url=$@",
     "location": {
       "lng": -123.2405476,
       "lat": 44.8538061
@@ -12997,7 +12997,7 @@
   },
   {
     "name": "Western Oregon University",
-    "url": "https://login.ezproxy.wou.edu/login?url=",
+    "url": "https://login.ezproxy.wou.edu/login?url=$@",
     "location": {
       "lng": -123.2405476,
       "lat": 44.8538061
@@ -13006,7 +13006,7 @@
   },
   {
     "name": "Western Sydney University",
-    "url": "http://ezproxy.uws.edu.au/login?url=",
+    "url": "http://ezproxy.uws.edu.au/login?url=$@",
     "location": {
       "lng": 151.20764898180545,
       "lat": -33.839881410614645
@@ -13015,7 +13015,7 @@
   },
   {
     "name": "Western Technical",
-    "url": "http://ezproxy.westerntc.edu:2048/login?url=",
+    "url": "http://ezproxy.westerntc.edu:2048/login?url=$@",
     "location": {
       "lng": -91.2460065,
       "lat": 43.8154127
@@ -13024,7 +13024,7 @@
   },
   {
     "name": "Western Theological Seminary",
-    "url": "https://login.proxy.westernsem.edu:4443/login?url=",
+    "url": "https://login.proxy.westernsem.edu:4443/login?url=$@",
     "location": {
       "lng": -86.1033533,
       "lat": 42.7861144
@@ -13033,7 +13033,7 @@
   },
   {
     "name": "Western University of Health Sciences",
-    "url": "https://proxy.westernu.edu/login?url=",
+    "url": "https://proxy.westernu.edu/login?url=$@",
     "location": {
       "lng": -117.7457873,
       "lat": 34.0579319
@@ -13042,7 +13042,7 @@
   },
   {
     "name": "Western Washington University",
-    "url": "http://ezproxy.library.wwu.edu/login?url=",
+    "url": "http://ezproxy.library.wwu.edu/login?url=$@",
     "location": {
       "lng": -122.4866102,
       "lat": 48.7342877
@@ -13051,7 +13051,7 @@
   },
   {
     "name": "Western Wyoming Community College",
-    "url": "http://library.westernwyoming.edu/login?url=",
+    "url": "http://library.westernwyoming.edu/login?url=$@",
     "location": {
       "lng": -109.23703,
       "lat": 41.5911812
@@ -13060,7 +13060,7 @@
   },
   {
     "name": "Westminster",
-    "url": "http://ezproxy.westminstercollege.edu/login?url=",
+    "url": "http://ezproxy.westminstercollege.edu/login?url=$@",
     "location": {
       "lng": -0.1356583,
       "lat": 51.4974948
@@ -13069,7 +13069,7 @@
   },
   {
     "name": "Westminster College, Salt Lake City",
-    "url": "https://login.ezproxy.westminstercollege.edu/login?url=",
+    "url": "https://login.ezproxy.westminstercollege.edu/login?url=$@",
     "location": {
       "lng": -111.8549815,
       "lat": 40.7322206
@@ -13078,7 +13078,7 @@
   },
   {
     "name": "Westminster Seminary California",
-    "url": "http://ezproxy.wscal.edu/login?url=",
+    "url": "http://ezproxy.wscal.edu/login?url=$@",
     "location": {
       "lng": -117.046063,
       "lat": 33.121678
@@ -13087,7 +13087,7 @@
   },
   {
     "name": "Westmont",
-    "url": "http://ezproxy.westmont.edu:2048/login?url=",
+    "url": "http://ezproxy.westmont.edu:2048/login?url=$@",
     "location": {
       "lng": -87.9756175,
       "lat": 41.7958639
@@ -13096,7 +13096,7 @@
   },
   {
     "name": "Wheaton College",
-    "url": "http://ezproxy.wheaton.edu/login?url=",
+    "url": "http://ezproxy.wheaton.edu/login?url=$@",
     "location": {
       "lng": -88.0969325,
       "lat": 41.8695424
@@ -13105,7 +13105,7 @@
   },
   {
     "name": "Whitman College",
-    "url": "http://ezproxy.whitman.edu:2048/login?url=",
+    "url": "http://ezproxy.whitman.edu:2048/login?url=$@",
     "location": {
       "lng": -117.93672801368764,
       "lat": 47.148304723917335
@@ -13114,7 +13114,7 @@
   },
   {
     "name": "Whittier",
-    "url": "http://ezproxy.whittier.edu/login?url=",
+    "url": "http://ezproxy.whittier.edu/login?url=$@",
     "location": {
       "lng": -118.032844,
       "lat": 33.9791793
@@ -13123,7 +13123,7 @@
   },
   {
     "name": "Wichita State",
-    "url": "http://proxy.wichita.edu/login?url=",
+    "url": "http://proxy.wichita.edu/login?url=$@",
     "location": {
       "lng": -97.28994209999999,
       "lat": 37.7191442
@@ -13132,7 +13132,7 @@
   },
   {
     "name": "Wilfrid Laurier University",
-    "url": "http://libproxy.wlu.ca/login?url=",
+    "url": "http://libproxy.wlu.ca/login?url=$@",
     "location": {
       "lng": -80.5274701,
       "lat": 43.4738499
@@ -13141,7 +13141,7 @@
   },
   {
     "name": "Wilkes",
-    "url": "http://ezproxy.wilkescc.edu:2048/login?url=",
+    "url": "http://ezproxy.wilkescc.edu:2048/login?url=$@",
     "location": {
       "lng": -75.8883633,
       "lat": 41.2449585
@@ -13150,7 +13150,7 @@
   },
   {
     "name": "William Jessup",
-    "url": "http://ezproxy.jessup.edu/login?url=",
+    "url": "http://ezproxy.jessup.edu/login?url=$@",
     "location": {
       "lng": -121.292457,
       "lat": 38.8203949
@@ -13159,7 +13159,7 @@
   },
   {
     "name": "William Paterson",
-    "url": "http://ezproxy.wpunj.edu:2048/login?url=",
+    "url": "http://ezproxy.wpunj.edu:2048/login?url=$@",
     "location": {
       "lng": -74.19677949999999,
       "lat": 40.9476318
@@ -13168,7 +13168,7 @@
   },
   {
     "name": "William Peace",
-    "url": "http://ezproxy.peace.edu:2048/login?url=",
+    "url": "http://ezproxy.peace.edu:2048/login?url=$@",
     "location": {
       "lng": -78.637391,
       "lat": 35.78948099999999
@@ -13177,7 +13177,7 @@
   },
   {
     "name": "William Penn University",
-    "url": "http://library.wmpenn.edu:2048/login?url=",
+    "url": "http://library.wmpenn.edu:2048/login?url=$@",
     "location": {
       "lng": -92.64718599472059,
       "lat": 41.308936447267165
@@ -13186,7 +13186,7 @@
   },
   {
     "name": "Williams College",
-    "url": "https://ezproxy2.williams.edu/login?url=",
+    "url": "https://ezproxy2.williams.edu/login?url=$@",
     "location": {
       "lng": -73.20313949999999,
       "lat": 42.7128843
@@ -13195,7 +13195,7 @@
   },
   {
     "name": "Winona State",
-    "url": "http://wsuproxy.mnpals.net/login?url=",
+    "url": "http://wsuproxy.mnpals.net/login?url=$@",
     "location": {
       "lng": -91.6432837,
       "lat": 44.0473997
@@ -13204,7 +13204,7 @@
   },
   {
     "name": "Woodbury University",
-    "url": "https://ezproxy.woodbury.edu:2443/login?url=",
+    "url": "https://ezproxy.woodbury.edu:2443/login?url=$@",
     "location": {
       "lng": -118.3412543,
       "lat": 34.2076585
@@ -13213,7 +13213,7 @@
   },
   {
     "name": "Worcester Polytechnic Institute",
-    "url": "http://ezproxy.wpi.edu/login?url=",
+    "url": "http://ezproxy.wpi.edu/login?url=$@",
     "location": {
       "lng": -71.8068416,
       "lat": 42.2746179
@@ -13222,7 +13222,7 @@
   },
   {
     "name": "World Maritime University",
-    "url": "http://proxy.wmu.se/login?url=",
+    "url": "http://proxy.wmu.se/login?url=$@",
     "location": {
       "lng": 12.9965185,
       "lat": 55.6078138
@@ -13231,7 +13231,7 @@
   },
   {
     "name": "Wright State University",
-    "url": "http://ezproxy.libraries.wright.edu:2048/login?url=",
+    "url": "http://ezproxy.libraries.wright.edu:2048/login?url=$@",
     "location": {
       "lng": -84.0587338,
       "lat": 39.7846274
@@ -13240,7 +13240,7 @@
   },
   {
     "name": "Xavier",
-    "url": "http://libproxy.xu.edu:2048/login?url=",
+    "url": "http://libproxy.xu.edu:2048/login?url=$@",
     "location": {
       "lng": -84.4740892,
       "lat": 39.1499074
@@ -13249,7 +13249,7 @@
   },
   {
     "name": "Xavier University of Louisiana",
-    "url": "https://ezproxy.xula.edu/login?url=",
+    "url": "https://ezproxy.xula.edu/login?url=$@",
     "location": {
       "lng": -90.10616259999999,
       "lat": 29.9632276
@@ -13258,7 +13258,7 @@
   },
   {
     "name": "Yeshiva University",
-    "url": "https://yulib002.mc.yu.edu:8443/login?url=",
+    "url": "https://yulib002.mc.yu.edu:8443/login?url=$@",
     "location": {
       "lng": -73.9297205,
       "lat": 40.8506041
@@ -13267,7 +13267,7 @@
   },
   {
     "name": "Yonsei",
-    "url": "https://access.yonsei.ac.kr/link.n2s?url=",
+    "url": "https://access.yonsei.ac.kr/link.n2s?url=$@",
     "location": {
       "lng": 126.938572,
       "lat": 37.565784
@@ -13276,7 +13276,7 @@
   },
   {
     "name": "York College",
-    "url": "https://login.york.ezproxy.cuny.edu/login?qurl=",
+    "url": "https://login.york.ezproxy.cuny.edu/login?qurl=$@",
     "location": {
       "lng": -73.7961103,
       "lat": 40.7010415
@@ -13285,7 +13285,7 @@
   },
   {
     "name": "York University",
-    "url": "http://ezproxy.library.yorku.ca/login?url=",
+    "url": "http://ezproxy.library.yorku.ca/login?url=$@",
     "location": {
       "lng": -79.50186839999999,
       "lat": 43.7734535
@@ -13294,7 +13294,7 @@
   },
   {
     "name": "Youngstown State",
-    "url": "http://eps.maag.ysu.edu:2048/login?url=",
+    "url": "http://eps.maag.ysu.edu:2048/login?url=$@",
     "location": {
       "lng": -80.6480952,
       "lat": 41.1066413
@@ -13303,7 +13303,7 @@
   },
   {
     "name": "Åbo Akademi University",
-    "url": "https://ezproxy.vasa.abo.fi/login?url=",
+    "url": "https://ezproxy.vasa.abo.fi/login?url=$@",
     "location": {
       "lng": 22.2776003,
       "lat": 60.45098689999999
@@ -13312,7 +13312,7 @@
   },
   {
     "name": "École des Mines d'Albi - Carmaux",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=",
+    "url": "https://gorgone.univ-toulouse.fr/login?url=$@",
     "location": {
       "lng": 2.178954,
       "lat": 43.922508
@@ -13321,7 +13321,7 @@
   },
   {
     "name": "台湾新光医院 (Taiwan Xinguang Hospital)",
-    "url": "http://rpa.skh.org.tw:81/login?url=",
+    "url": "http://rpa.skh.org.tw:81/login?url=$@",
     "location": {
       "lng": 121.5201549,
       "lat": 25.0964041
@@ -13330,7 +13330,7 @@
   },
   {
     "name": "地质大学",
-    "url": "http://yc.hnadl.cn/login?url=",
+    "url": "http://yc.hnadl.cn/login?url=$@",
     "location": {
       "lng": 116.3471009,
       "lat": 39.991253

--- a/static/proxies.json
+++ b/static/proxies.json
@@ -1,5926 +1,13322 @@
 [
   {
     "name": "A.T. Still University of Health Sciences",
-    "url": "http://p.atsu.edu/login?url=$@"
+    "url": "http://p.atsu.edu/login?url=",
+    "location": {
+      "lng": -92.58941430000002,
+      "lat": 40.19314929999999
+    },
+    "country": "United States"
   },
   {
     "name": "Aalborg Universitet",
-    "url": "http://zorac.aub.aau.dk/login?qurl=$@"
+    "url": "http://zorac.aub.aau.dk/login?qurl=",
+    "location": {
+      "lng": 9.9845553,
+      "lat": 57.0139858
+    },
+    "country": "Denmark"
   },
   {
     "name": "Aalto University",
-    "url": "http://libproxy.aalto.fi/login?url=$@"
+    "url": "http://libproxy.aalto.fi/login?url=",
+    "location": {
+      "lng": 24.827682,
+      "lat": 60.1866693
+    },
+    "country": "Finland"
   },
   {
     "name": "Abertay",
-    "url": "http://libproxy.abertay.ac.uk/login?url=$@"
+    "url": "http://libproxy.abertay.ac.uk/login?url=",
+    "location": {
+      "lng": -2.973917,
+      "lat": 56.463307
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Acadia",
-    "url": "http://ezproxy.acadiau.ca:2048/login?url=$@"
+    "url": "http://ezproxy.acadiau.ca:2048/login?url=",
+    "location": {
+      "lng": -68.2733346,
+      "lat": 44.3385559
+    },
+    "country": "United States"
   },
   {
     "name": "Adams State",
-    "url": "http://adams.idm.oclc.org/login?url=$@"
+    "url": "http://adams.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -105.8798507,
+      "lat": 37.47427709999999
+    },
+    "country": "United States"
   },
   {
     "name": "Adelphi",
-    "url": "http://libproxy.adelphi.edu:2048/login?url=$@"
+    "url": "http://libproxy.adelphi.edu:2048/login?url=",
+    "location": {
+      "lng": -73.65247109262027,
+      "lat": 40.72015882159732
+    },
+    "country": "United States"
   },
   {
     "name": "Adler University",
-    "url": "http://ezproxy.adler.edu/login?url=$@"
+    "url": "http://ezproxy.adler.edu/login?url=",
+    "location": {
+      "lng": -87.6291651,
+      "lat": 41.8824688
+    },
+    "country": "United States"
   },
   {
     "name": "AFIT D'Azzo Research Library",
-    "url": "https://login.afit.idm.oclc.org/login?url=$@"
+    "url": "https://login.afit.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -84.0823546,
+      "lat": 39.7832782
+    },
+    "country": "United States"
   },
   {
     "name": "AFRL D'Azzo Research Library",
-    "url": "http://wrs.idm.oclc.org/login?url=$@"
+    "url": "http://wrs.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -84.0823546,
+      "lat": 39.7832782
+    },
+    "country": "United States"
   },
   {
     "name": "Agency for Science Technology and Research",
-    "url": "http://ejproxy.a-star.edu.sg/login?url=$@"
+    "url": "http://ejproxy.a-star.edu.sg/login?url=",
+    "location": {
+      "lng": 103.78764128619945,
+      "lat": 1.299698103943425
+    },
+    "country": "Singapore"
   },
   {
     "name": "Aichi Shukutoku University Library",
-    "url": "https://aasa.idm.oclc.org/login?url=$@"
+    "url": "https://aasa.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 137.0314337,
+      "lat": 35.1573669
+    },
+    "country": "Japan"
   },
   {
     "name": "Air University",
-    "url": "http://aufric.idm.oclc.org/login?url=$@"
+    "url": "http://aufric.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -86.35099703480662,
+      "lat": 32.37949101145906
+    },
+    "country": "United States"
   },
   {
     "name": "Akademie ved Ceske republiky",
-    "url": "https://ezproxy.lib.cas.cz/login?url=$@"
+    "url": "https://ezproxy.lib.cas.cz/login?url=",
+    "location": {
+      "lng": 14.4142,
+      "lat": 50.0816138
+    },
+    "country": "Czechia"
   },
   {
     "name": "Alabama A M",
-    "url": "http://ezproxy.aamu.edu:2048/login?url=$@"
+    "url": "http://ezproxy.aamu.edu:2048/login?url=",
+    "location": {
+      "lng": -86.5722237,
+      "lat": 34.78384090000001
+    },
+    "country": "United States"
   },
   {
     "name": "Alameda County Library",
-    "url": "https://ezproxy.aclibrary.org/login?url=$@"
+    "url": "https://ezproxy.aclibrary.org/login?url=",
+    "location": {
+      "lng": -121.7195459,
+      "lat": 37.6016892
+    },
+    "country": "United States"
   },
   {
     "name": "Albany Medical",
-    "url": "http://elibrary.amc.edu/login?url=$@"
+    "url": "http://elibrary.amc.edu/login?url=",
+    "location": {
+      "lng": -73.7771411,
+      "lat": 42.6536483
+    },
+    "country": "United States"
   },
   {
     "name": "Albert Einstein College of Medicine",
-    "url": "http://elibrary.einstein.yu.edu/login?url=$@"
+    "url": "http://elibrary.einstein.yu.edu/login?url=",
+    "location": {
+      "lng": -73.8459022,
+      "lat": 40.8504961
+    },
+    "country": "United States"
   },
   {
     "name": "Alberta Health Services",
-    "url": "https://ahs.idm.oclc.org/login?url=$@"
+    "url": "https://ahs.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -114.13613106894597,
+      "lat": 51.044717356702854
+    },
+    "country": "Canada"
   },
   {
     "name": "Albright",
-    "url": "https://felix.albright.edu/login?url=$@"
+    "url": "https://felix.albright.edu/login?url=",
+    "location": {
+      "lng": -75.9106812,
+      "lat": 40.363518
+    },
+    "country": "United States"
   },
   {
     "name": "Alfred",
-    "url": "http://ezproxy.alfred.edu:2048/login?url=$@"
+    "url": "http://ezproxy.alfred.edu:2048/login?url=",
+    "location": {
+      "lng": -77.78610634434509,
+      "lat": 42.25587308337543
+    },
+    "country": ""
   },
   {
     "name": "Allan Hancock",
-    "url": "http://ezproxy.hancockcollege.edu:3048/login?url=$@"
+    "url": "http://ezproxy.hancockcollege.edu:3048/login?url=",
+    "location": {
+      "lng": -120.4189337,
+      "lat": 34.9446133
+    },
+    "country": "United States"
   },
   {
     "name": "Allegheny College",
-    "url": "http://ezproxy1.allegheny.edu:2048/login?url=$@"
+    "url": "http://ezproxy1.allegheny.edu:2048/login?url=",
+    "location": {
+      "lng": -80.1455328,
+      "lat": 41.6484557
+    },
+    "country": "United States"
   },
   {
     "name": "American Institutes for Research",
-    "url": "https://air.idm.oclc.org/login?url=$@"
+    "url": "https://air.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -79.01866958652967,
+      "lat": 35.94014392918445
+    },
+    "country": "United States"
   },
   {
     "name": "American Jewish University",
-    "url": "https://proxy.aju.edu/login?url=$@"
+    "url": "https://proxy.aju.edu/login?url=",
+    "location": {
+      "lng": -118.4725275,
+      "lat": 34.1263884
+    },
+    "country": "United States"
   },
   {
     "name": "American Museum of Natural History",
-    "url": "http://libraryproxy.amnh.org:9000/login?url=$@"
+    "url": "http://libraryproxy.amnh.org:9000/login?url=",
+    "location": {
+      "lng": -73.9739882,
+      "lat": 40.7813241
+    },
+    "country": "United States"
   },
   {
     "name": "American Public University System",
-    "url": "http://ezproxy.apus.edu/login?url=$@"
+    "url": "https://login.ezproxy1.apus.edu/login?url=",
+    "location": {
+      "lng": -77.86157952282755,
+      "lat": 39.291746789555674
+    },
+    "country": "United States"
   },
   {
-    "name": "American Public University System",
-    "url": "https://login.ezproxy1.apus.edu/login?url=$@"
+    "name": "American Public University System (Alternative)",
+    "url": "http://ezproxy.apus.edu/login?url=",
+    "location": {
+      "lng": -77.86157952282755,
+      "lat": 39.291746789555674
+    },
+    "country": "United States"
   },
   {
     "name": "American University",
-    "url": "https://myau.american.edu/my.policy?url=$@"
+    "url": "https://myau.american.edu/my.policy?url=",
+    "location": {
+      "lng": -77.088922,
+      "lat": 38.9380155
+    },
+    "country": "United States"
   },
   {
     "name": "American University in Cairo",
-    "url": "http://ezproxy.library.aucegypt.edu:2048/login?url=$@"
+    "url": "http://ezproxy.library.aucegypt.edu:2048/login?url=",
+    "location": {
+      "lng": 31.49908139999999,
+      "lat": 30.0201508
+    },
+    "country": "Egypt"
   },
   {
     "name": "American University of Beirut",
-    "url": "https://ezproxy.aub.edu.lb/login?url=$@"
+    "url": "https://ezproxy.aub.edu.lb/login?url=",
+    "location": {
+      "lng": 35.480744,
+      "lat": 33.9008359
+    },
+    "country": "Lebanon"
   },
   {
     "name": "American University Washington College of Law",
-    "url": "http://proxy.wcl.american.edu/login?url=$@"
+    "url": "http://proxy.wcl.american.edu/login?url=",
+    "location": {
+      "lng": -77.088922,
+      "lat": 38.9380155
+    },
+    "country": "United States"
   },
   {
     "name": "American University, Washington, D.C.",
-    "url": "http://proxyau.wrlc.org/login?url=$@"
+    "url": "http://proxyau.wrlc.org/login?url=",
+    "location": {
+      "lng": -77.08891112711191,
+      "lat": 38.938133217419576
+    },
+    "country": "United States"
   },
   {
     "name": "Amherst College",
-    "url": "https://ezproxy.amherst.edu/login?url=$@"
+    "url": "https://ezproxy.amherst.edu/login?url=",
+    "location": {
+      "lng": -72.5170028,
+      "lat": 42.3709104
+    },
+    "country": "United States"
   },
   {
     "name": "Anadolu University Library",
-    "url": "https://offcampus.anadolu.edu.tr/login?url=$@"
+    "url": "https://offcampus.anadolu.edu.tr/login?url=",
+    "location": {
+      "lng": 30.5006587,
+      "lat": 39.789626
+    },
+    "country": "Türkiye"
   },
   {
     "name": "Angelina College",
-    "url": "https://ezproxy.angelina.edu/login?url=$@"
+    "url": "https://ezproxy.angelina.edu/login?url=",
+    "location": {
+      "lng": -94.73120139999999,
+      "lat": 31.2873317
+    },
+    "country": "United States"
   },
   {
     "name": "Angelo State",
-    "url": "https://easydb.angelo.edu/login?url=$@"
+    "url": "https://easydb.angelo.edu/login?url=",
+    "location": {
+      "lng": -100.4598144,
+      "lat": 31.4386537
+    },
+    "country": "United States"
   },
   {
     "name": "Anglo-European College of Chiropractic",
-    "url": "http://aecc.idm.oclc.org/login?url=$@"
+    "url": "http://aecc.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -1.8286846,
+      "lat": 50.72728189999999
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Antioch",
-    "url": "https://antioch.idm.oclc.org/login?url=$@"
+    "url": "https://antioch.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -121.805789,
+      "lat": 38.0049214
+    },
+    "country": "United States"
   },
   {
     "name": "ANZCA",
-    "url": "http://ezproxy.anzca.edu.au/login?url=$@"
+    "url": "http://ezproxy.anzca.edu.au/login?url=",
+    "location": {
+      "lng": 153.0028309,
+      "lat": -27.4798016
+    },
+    "country": "Australia"
   },
   {
     "name": "Arcadia",
-    "url": "http://ezproxy.arcadia.edu:2048/login?url=$@"
+    "url": "http://ezproxy.arcadia.edu:2048/login?url=",
+    "location": {
+      "lng": -118.0353449,
+      "lat": 34.1397292
+    },
+    "country": "United States"
   },
   {
     "name": "Arizona State University",
-    "url": "http://login.ezproxy1.lib.asu.edu/login?url=$@"
+    "url": "http://login.ezproxy1.lib.asu.edu/login?url=",
+    "location": {
+      "lng": -111.9280527,
+      "lat": 33.4242399
+    },
+    "country": "United States"
   },
   {
     "name": "Arkansas State",
-    "url": "https://ezproxy.library.astate.edu/login?url=$@"
+    "url": "https://ezproxy.library.astate.edu/login?url=",
+    "location": {
+      "lng": -92.28634029999999,
+      "lat": 34.5573549
+    },
+    "country": "United States"
   },
   {
     "name": "Arts University Bournemouth",
-    "url": "https://go.openathens.net/redirector/aub.ac.uk?url=$@"
+    "url": "https://go.openathens.net/redirector/aub.ac.uk?url=",
+    "location": {
+      "lng": -1.8961949,
+      "lat": 50.7421804
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Asheville-Buncombe Technical",
-    "url": "http://lrc-proxy.abtech.edu:2048/login?url=$@"
+    "url": "http://lrc-proxy.abtech.edu:2048/login?url=",
+    "location": {
+      "lng": -82.5514869,
+      "lat": 35.5950581
+    },
+    "country": "United States"
   },
   {
     "name": "Ashland",
-    "url": "http://proxy.ashland.edu:2048/login?url=$@"
+    "url": "http://proxy.ashland.edu:2048/login?url=",
+    "location": {
+      "lng": -122.7094767,
+      "lat": 42.1945758
+    },
+    "country": "United States"
   },
   {
     "name": "Athabasca",
-    "url": "http://ezproxy.athabascau.ca:2048/login?url=$@"
+    "url": "http://ezproxy.athabascau.ca:2048/login?url=",
+    "location": {
+      "lng": -113.2858262,
+      "lat": 54.72126549999999
+    },
+    "country": "Canada"
   },
   {
     "name": "Auburn",
-    "url": "http://spot.lib.auburn.edu/login?url=$@"
+    "url": "http://spot.lib.auburn.edu/login?url=",
+    "location": {
+      "lng": -85.48078249999999,
+      "lat": 32.6098566
+    },
+    "country": "United States"
   },
   {
-    "name": "Auburn University",
-    "url": "https://auaccess.auburn.edu/c/portal/login?url=$@"
+    "name": "Auburn University ",
+    "url": "https://auaccess.auburn.edu/c/portal/login?url=",
+    "location": {
+      "lng": -85.4951663,
+      "lat": 32.5933574
+    },
+    "country": "United States"
   },
   {
     "name": "Auckland University of Technology",
-    "url": "http://ezproxy.aut.ac.nz/login?url=$@"
+    "url": "http://ezproxy.aut.ac.nz/login?url=",
+    "location": {
+      "lng": 174.7664805,
+      "lat": -36.8536098
+    },
+    "country": "New Zealand"
   },
   {
     "name": "Augsburg",
-    "url": "http://ezproxy.augsburg.edu/login?url=$@"
+    "url": "http://ezproxy.augsburg.edu/login?url=",
+    "location": {
+      "lng": 10.89779,
+      "lat": 48.3705449
+    },
+    "country": "Germany"
   },
   {
     "name": "Augusta University",
-    "url": "http://ezproxy.augusta.edu/login?url=$@"
+    "url": "http://ezproxy.augusta.edu/login?url=",
+    "location": {
+      "lng": -81.9898848,
+      "lat": 33.4709094
+    },
+    "country": "United States"
   },
   {
     "name": "Augustana",
-    "url": "http://fulla.augustana.edu:2048/login?url=$@"
+    "url": "http://fulla.augustana.edu:2048/login?url=",
+    "location": {
+      "lng": -96.73936359999999,
+      "lat": 43.5224294
+    },
+    "country": "United States"
   },
   {
     "name": "Auraria Library",
-    "url": "http://aurarialibrary.idm.oclc.org/login?url=$@"
+    "url": "http://aurarialibrary.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -105.002931,
+      "lat": 39.743355
+    },
+    "country": "United States"
   },
   {
     "name": "Austin College",
-    "url": "http://webster.austincollege.edu/login?url=$@"
+    "url": "http://webster.austincollege.edu/login?url=",
+    "location": {
+      "lng": -96.5981984,
+      "lat": 33.6473694
+    },
+    "country": "United States"
   },
   {
     "name": "Austin Community College",
-    "url": "https://lsproxy.austincc.edu/login?url=$@"
+    "url": "https://lsproxy.austincc.edu/login?url=",
+    "location": {
+      "lng": -97.7430608,
+      "lat": 30.267153
+    },
+    "country": "United States"
   },
   {
     "name": "Austin Health",
-    "url": "http://journals.library.austin.org.au/login?url=$@"
+    "url": "http://journals.library.austin.org.au/login?url=",
+    "location": {
+      "lng": 145.0586279,
+      "lat": -37.7562696
+    },
+    "country": "Australia"
   },
   {
     "name": "Austin Peay State",
-    "url": "http://ezproxy.lib.apsu.edu/login?url=$@"
+    "url": "http://ezproxy.lib.apsu.edu/login?url=",
+    "location": {
+      "lng": -87.3548855,
+      "lat": 36.53498
+    },
+    "country": "United States"
   },
   {
     "name": "Austin Public Library",
-    "url": "http://www.austinlibrary.com:2048/login?url=$@"
+    "url": "http://www.austinlibrary.com:2048/login?url=",
+    "location": {
+      "lng": -97.75204851901493,
+      "lat": 30.269507888732885
+    },
+    "country": "United States"
   },
   {
     "name": "Austin University of Technology",
-    "url": "http://journals.library.austin.org.au/login?url=$@"
+    "url": "http://journals.library.austin.org.au/login?url=",
+    "location": {
+      "lng": -97.7430608,
+      "lat": 30.267153
+    },
+    "country": "United States"
   },
   {
     "name": "Australian Catholic University",
-    "url": "http://ezproxy.acu.edu.au/login?url=$@"
+    "url": "http://ezproxy.acu.edu.au/login?url=",
+    "location": {
+      "lng": 153.0888676,
+      "lat": -27.3780232
+    },
+    "country": "Australia"
   },
   {
     "name": "Australian National University",
-    "url": "http://virtual.anu.edu.au/login?url=$@"
+    "url": "http://virtual.anu.edu.au/login?url=",
+    "location": {
+      "lng": 149.1183238,
+      "lat": -35.2812533
+    },
+    "country": "Australia"
   },
   {
     "name": "Averett",
-    "url": "http://ezproxy.averett.edu/login?url=$@"
+    "url": "http://ezproxy.averett.edu/login?url=",
+    "location": {
+      "lng": -79.4142589,
+      "lat": 36.5793099
+    },
+    "country": "United States"
   },
   {
     "name": "Baden State Library",
-    "url": "https://login.ezproxy.blb-karlsruhe.de/login?url=$@"
+    "url": "https://login.ezproxy.blb-karlsruhe.de/login?url=",
+    "location": {
+      "lng": 8.3988313,
+      "lat": 49.0079994
+    },
+    "country": "Germany"
   },
   {
     "name": "Bakersfield",
-    "url": "https://ezproxy.bakersfieldcollege.edu/login?url=$@"
+    "url": "https://ezproxy.bakersfieldcollege.edu/login?url=",
+    "location": {
+      "lng": -119.0187125,
+      "lat": 35.3732921
+    },
+    "country": "United States"
   },
   {
     "name": "Ball State",
-    "url": "http://proxy.bsu.edu/login?url=$@"
+    "url": "http://proxy.bsu.edu/login?url=",
+    "location": {
+      "lng": -85.4134775,
+      "lat": 40.2079938
+    },
+    "country": "United States"
   },
   {
     "name": "Bank Street College of Education",
-    "url": "http://libproxy.bankstreet.edu/login?url=$@"
+    "url": "http://libproxy.bankstreet.edu/login?url=",
+    "location": {
+      "lng": -73.96648539011375,
+      "lat": 40.80587775364672
+    },
+    "country": "United States"
   },
   {
     "name": "Baptist School of Health Professions",
-    "url": "http://ezproxy.bshp.edu:2048/login?url=$@"
+    "url": "http://ezproxy.bshp.edu:2048/login?url=",
+    "location": {
+      "lng": -98.56752,
+      "lat": 29.5169589
+    },
+    "country": "United States"
   },
   {
     "name": "Bar-Ilan University (and other OpenAthens/MyAthens users)",
-    "url": "http://proxy1.athensams.net/login?url=$@"
+    "url": "http://proxy1.athensams.net/login?url=",
+    "location": {
+      "lng": 34.84325926136056,
+      "lat": 32.06998078248142
+    },
+    "country": "Israel"
   },
   {
     "name": "Bard College",
-    "url": "http://ezprox.bard.edu:2048/login?url=$@"
+    "url": "http://ezprox.bard.edu:2048/login?url=",
+    "location": {
+      "lng": -73.909314,
+      "lat": 42.0230728
+    },
+    "country": "United States"
   },
   {
     "name": "Bard College at Simons Rock",
-    "url": "http://ezproxy.simons-rock.edu/login?url=$@"
+    "url": "http://ezproxy.simons-rock.edu/login?url=",
+    "location": {
+      "lng": -73.3804375,
+      "lat": 42.2087695
+    },
+    "country": "United States"
   },
   {
     "name": "Barwon Health Library",
-    "url": "http://bh.idm.oclc.org/login?url=$@"
+    "url": "http://bh.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 144.3640160955289,
+      "lat": -38.151645901131126
+    },
+    "country": "Australia"
   },
   {
     "name": "Bath Spa",
-    "url": "http://ezproxy.bathspa.ac.uk:2048/login?url=$@"
+    "url": "http://ezproxy.bathspa.ac.uk:2048/login?url=",
+    "location": {
+      "lng": -2.3615092,
+      "lat": 51.3803643
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Bath Spa University",
-    "url": "https://bathspa.idm.oclc.org/login?url=$@"
+    "url": "https://bathspa.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -2.4393324,
+      "lat": 51.3748563
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Baylor Health Sciences Library",
-    "url": "http://bcd.tamhsc.libguides.com/proxy_login?url=$@"
+    "url": "http://bcd.tamhsc.libguides.com/proxy_login?url=",
+    "location": {
+      "lng": -96.7812168,
+      "lat": 32.789823
+    },
+    "country": "United States"
   },
   {
-    "name": "Baylor University",
-    "url": "http://ezproxy.baylor.edu/login?url=$@"
+    "name": "Baylor University ",
+    "url": "http://ezproxy.baylor.edu/login?url=",
+    "location": {
+      "lng": -97.11354,
+      "lat": 31.5500848
+    },
+    "country": "United States"
   },
   {
     "name": "Beaumont Health System",
-    "url": "http://login.beaumont.idm.oclc.org/login?url=$@"
+    "url": "http://login.beaumont.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -83.19237110373544,
+      "lat": 42.51456776349747
+    },
+    "country": "United States"
   },
   {
     "name": "Beaumont Health System - LibLynx",
-    "url": "https://liblynxgateway.com/beaumont?url=$@"
+    "url": "https://liblynxgateway.com/beaumont?url=",
+    "location": {
+      "lng": -83.19237110373544,
+      "lat": 42.51456776349747
+    },
+    "country": "United States"
   },
   {
     "name": "Beilinson Rabin Medical Center",
-    "url": "https://login.beilinson-ez.medlcp.tau.ac.il/login?url=$@"
+    "url": "https://login.beilinson-ez.medlcp.tau.ac.il/login?url=",
+    "location": {
+      "lng": 34.8670288,
+      "lat": 32.0904591
+    },
+    "country": "Israel"
   },
   {
     "name": "Bellevue University",
-    "url": "http://ezproxy.bellevue.edu/login?url=$@"
+    "url": "http://ezproxy.bellevue.edu/login?url=",
+    "location": {
+      "lng": -95.91815799999999,
+      "lat": 41.150572
+    },
+    "country": "United States"
   },
   {
     "name": "Beloit",
-    "url": "https://ezproxy.beloit.edu/login?url=$@"
+    "url": "https://ezproxy.beloit.edu/login?url=",
+    "location": {
+      "lng": -89.03177649999999,
+      "lat": 42.5083482
+    },
+    "country": "United States"
   },
   {
     "name": "Ben Gurion University",
-    "url": "https://ezproxy.bgu.ac.il/login?url=$@"
+    "url": "https://ezproxy.bgu.ac.il/login?url=",
+    "location": {
+      "lng": 34.7995546,
+      "lat": 31.261426
+    },
+    "country": "Israel"
   },
   {
     "name": "Berkeley Public Library",
-    "url": "https://login.ezproxy.berkeleypubliclibrary.org/login?url=$@"
+    "url": "https://login.ezproxy.berkeleypubliclibrary.org/login?url=",
+    "location": {
+      "lng": -122.26848638481121,
+      "lat": 37.86821893293512
+    },
+    "country": "United States"
   },
   {
     "name": "Berklee College of Music",
-    "url": "http://catalog.berklee.edu:2048/login?url=$@"
+    "url": "http://catalog.berklee.edu:2048/login?url=",
+    "location": {
+      "lng": -71.0895292,
+      "lat": 42.3465952
+    },
+    "country": "United States"
   },
   {
     "name": "Bethel",
-    "url": "http://ezproxy.bethel.edu/login?url=$@"
+    "url": "http://ezproxy.bethel.edu/login?url=",
+    "location": {
+      "lng": -122.3584268,
+      "lat": 40.6098473
+    },
+    "country": "United States"
   },
   {
     "name": "BI Norwegian Business School",
-    "url": "http://ezproxy.library.bi.no/login?url=$@"
+    "url": "http://ezproxy.library.bi.no/login?url=",
+    "location": {
+      "lng": 10.7685565,
+      "lat": 59.9484015
+    },
+    "country": "Norway"
   },
   {
     "name": "BiblioPl@nets - CNRS INIST",
-    "url": "http://biblioplanets.gate.inist.fr/login?url=$@"
+    "url": "http://biblioplanets.gate.inist.fr/login?url=",
+    "location": {
+      "lng": 6.1499824,
+      "lat": 48.65528200000001
+    },
+    "country": "France"
   },
   {
     "name": "Bibliothèque nationale de Luxembourg",
-    "url": "http://proxy.bnl.lu/login?url=$@"
+    "url": "http://proxy.bnl.lu/login?url=",
+    "location": {
+      "lng": 6.1657734,
+      "lat": 49.6295817
+    },
+    "country": "Luxembourg"
   },
   {
     "name": "Bindura University of Science Education",
-    "url": "http://liboasis.buse.ac.zw:2048/login?url=$@"
+    "url": "http://liboasis.buse.ac.zw:2048/login?url=",
+    "location": {
+      "lng": 31.3326816,
+      "lat": -17.3246383
+    },
+    "country": "Zimbabwe"
   },
   {
     "name": "Binghamton University",
-    "url": "https://login.proxy.binghamton.edu/login?url=$@"
+    "url": "https://login.proxy.binghamton.edu/login?url=",
+    "location": {
+      "lng": -75.9694885,
+      "lat": 42.0894288
+    },
+    "country": "United States"
   },
   {
     "name": "Biola",
-    "url": "https://login.ezproxy.biola.edu/login?url=$@"
+    "url": "https://login.ezproxy.biola.edu/login?url=",
+    "location": {
+      "lng": -118.0155533,
+      "lat": 33.9062611
+    },
+    "country": "United States"
   },
   {
     "name": "Birkbeck University of London",
-    "url": "http://ezproxy.lib.bbk.ac.uk/login?url=$@"
+    "url": "http://ezproxy.lib.bbk.ac.uk/login?url=",
+    "location": {
+      "lng": -0.1303146,
+      "lat": 51.5218563
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Birkbeck, University of London",
-    "url": "http://login.ezproxy.lib.bbk.ac.uk/login?url=$@"
+    "url": "http://login.ezproxy.lib.bbk.ac.uk/login?url=",
+    "location": {
+      "lng": -0.1303146,
+      "lat": 51.5218563
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Birmingham-Southern",
-    "url": "https://ezproxy.bsc.edu/login?url=$@"
+    "url": "https://ezproxy.bsc.edu/login?url=",
+    "location": {
+      "lng": -86.8510103,
+      "lat": 33.5159411
+    },
+    "country": "United States"
   },
   {
     "name": "Blekinge Tekniska Hogskola",
-    "url": "http://miman.bib.bth.se/login?url=$@"
+    "url": "http://miman.bib.bth.se/login?url=",
+    "location": {
+      "lng": 15.5906982,
+      "lat": 56.1806556
+    },
+    "country": "Sweden"
   },
   {
     "name": "Bloomsburg University",
-    "url": "http://proxy-bloomu.klnpa.org/login?url=$@"
+    "url": "http://proxy-bloomu.klnpa.org/login?url=",
+    "location": {
+      "lng": -76.4472749,
+      "lat": 41.0081119
+    },
+    "country": "United States"
   },
   {
     "name": "Blue Mountain",
-    "url": "http://proxy.bluecc.edu:2048/login?url=$@"
+    "url": "http://proxy.bluecc.edu:2048/login?url=",
+    "location": {
+      "lng": -75.520864,
+      "lat": 40.81073
+    },
+    "country": "United States"
   },
   {
     "name": "Bob Jones",
-    "url": "http://ezproxy.bju.net/login?url=$@"
+    "url": "http://ezproxy.bju.net/login?url=",
+    "location": {
+      "lng": -82.3624705,
+      "lat": 34.8725832
+    },
+    "country": "United States"
   },
   {
     "name": "Boise State",
-    "url": "https://libproxy.boisestate.edu/login?url=$@"
+    "url": "https://libproxy.boisestate.edu/login?url=",
+    "location": {
+      "lng": -116.1998719,
+      "lat": 43.60287599999999
+    },
+    "country": "United States"
   },
   {
     "name": "Bond University",
-    "url": "http://ezproxy.bond.edu.au/login?url=$@"
+    "url": "http://ezproxy.bond.edu.au/login?url=",
+    "location": {
+      "lng": 153.4166377,
+      "lat": -28.0730934
+    },
+    "country": "Australia"
   },
   {
     "name": "Boston Architectural",
-    "url": "http://proxy.the-bac.edu/login?url=$@"
+    "url": "http://proxy.the-bac.edu/login?url=",
+    "location": {
+      "lng": -71.0859315,
+      "lat": 42.3479568
+    },
+    "country": "United States"
   },
   {
     "name": "Boston College",
-    "url": "https://login.proxy.bc.edu/login?url=$@"
+    "url": "https://login.proxy.bc.edu/login?url=",
+    "location": {
+      "lng": -71.16849450000001,
+      "lat": 42.3355488
+    },
+    "country": "United States"
   },
   {
     "name": "Boston Public Library",
-    "url": "http://ezproxy.bpl.org/login?url=$@"
+    "url": "http://ezproxy.bpl.org/login?url=",
+    "location": {
+      "lng": -71.0588801,
+      "lat": 42.3600825
+    },
+    "country": "United States"
   },
   {
     "name": "Boston University",
-    "url": "https://ezproxy.bu.edu/login?url=$@"
+    "url": "https://ezproxy.bu.edu/login?url=",
+    "location": {
+      "lng": -71.1053991,
+      "lat": 42.3504997
+    },
+    "country": "United States"
   },
   {
     "name": "Bournemouth University",
-    "url": "http://libezproxy.bournemouth.ac.uk/login?url=$@"
+    "url": "http://libezproxy.bournemouth.ac.uk/login?url=",
+    "location": {
+      "lng": -1.8983382,
+      "lat": 50.7435102
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Bowdoin",
-    "url": "http://ezproxy.bowdoin.edu/login?url=$@"
+    "url": "http://ezproxy.bowdoin.edu/login?url=",
+    "location": {
+      "lng": -69.9639971,
+      "lat": 43.9076929
+    },
+    "country": "United States"
   },
   {
     "name": "Bowling Green State",
-    "url": "http://ezproxy.bgsu.edu:8080/login?url=$@"
+    "url": "http://ezproxy.bgsu.edu:8080/login?url=",
+    "location": {
+      "lng": -83.6300596,
+      "lat": 41.3793592
+    },
+    "country": "United States"
   },
   {
     "name": "Bradford College",
-    "url": "http://shibboleth.bradfordcollege.ac.uk:2048/login?url=$@"
+    "url": "http://shibboleth.bradfordcollege.ac.uk:2048/login?url=",
+    "location": {
+      "lng": -121.2900205,
+      "lat": 37.9524339
+    },
+    "country": "United States"
   },
   {
     "name": "Bradley",
-    "url": "https://login.ezproxy.bradley.edu/login?url=$@"
+    "url": "https://login.ezproxy.bradley.edu/login?url=",
+    "location": {
+      "lng": -89.6153484,
+      "lat": 40.6977743
+    },
+    "country": "United States"
   },
   {
     "name": "Brandeis University",
-    "url": "https://go.openathens.net/redirector/brandeis.edu?url=$@"
+    "url": "https://go.openathens.net/redirector/brandeis.edu?url=",
+    "location": {
+      "lng": -71.2586441,
+      "lat": 42.36535689999999
+    },
+    "country": "United States"
   },
   {
     "name": "Brazosport",
-    "url": "http://plainview.brazosport.edu:2048/login?url=$@"
+    "url": "http://plainview.brazosport.edu:2048/login?url=",
+    "location": {
+      "lng": -95.4091723,
+      "lat": 29.0483827
+    },
+    "country": "United States"
   },
   {
     "name": "Brenau",
-    "url": "http://ezproxy.brenau.edu:2048/login?url=$@"
+    "url": "http://ezproxy.brenau.edu:2048/login?url=",
+    "location": {
+      "lng": -83.8197347,
+      "lat": 34.3041267
+    },
+    "country": "United States"
   },
   {
     "name": "Brescia",
-    "url": "https://ezproxy.brescia.edu/login?url=$@"
+    "url": "https://ezproxy.brescia.edu/login?url=",
+    "location": {
+      "lng": 10.2118019,
+      "lat": 45.5415526
+    },
+    "country": "Italy"
   },
   {
     "name": "Briercrest College and Seminary",
-    "url": "http://ezproxy.briercrest.lib.sk.ca/login?url=$@"
+    "url": "http://ezproxy.briercrest.lib.sk.ca/login?url=",
+    "location": {
+      "lng": -105.81491,
+      "lat": 50.4573732
+    },
+    "country": "Canada"
   },
   {
     "name": "Brigham Young University",
-    "url": "https://www.lib.byu.edu/cgi-bin/remoteauth.pl?url=$@"
+    "url": "https://www.lib.byu.edu/cgi-bin/remoteauth.pl?url=",
+    "location": {
+      "lng": -111.6493156,
+      "lat": 40.2518435
+    },
+    "country": "United States"
   },
   {
     "name": "British Medical Association",
-    "url": "http://ezproxy.bma.org.uk/login?url=$@"
+    "url": "http://ezproxy.bma.org.uk/login?url=",
+    "location": {
+      "lng": -0.12820981759989078,
+      "lat": 51.52875768815621
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Brno University of Technology",
-    "url": "https://ezproxy.lib.vutbr.cz/login?qurl=$@"
+    "url": "https://ezproxy.lib.vutbr.cz/login?qurl=",
+    "location": {
+      "lng": 16.603619,
+      "lat": 49.2015407
+    },
+    "country": "Czechia"
   },
   {
     "name": "Brock University",
-    "url": "https://login.proxy.library.brocku.ca/login?qurl=$@"
+    "url": "https://login.proxy.library.brocku.ca/login?qurl=",
+    "location": {
+      "lng": -79.24762812668484,
+      "lat": 43.1178080458223
+    },
+    "country": "Canada"
   },
   {
     "name": "Brooklyn College",
-    "url": "https://login.ez-proxy.brooklyn.cuny.edu/login?url=$@"
+    "url": "https://login.ez-proxy.brooklyn.cuny.edu/login?url=",
+    "location": {
+      "lng": -73.9523802,
+      "lat": 40.6311257
+    },
+    "country": "United States"
   },
   {
     "name": "Brown University",
-    "url": "https://revproxy.brown.edu/login?url=$@"
+    "url": "https://revproxy.brown.edu/login?url=",
+    "location": {
+      "lng": -71.4025482,
+      "lat": 41.8267718
+    },
+    "country": "United States"
   },
   {
     "name": "Brunel University",
-    "url": "https://login.ezproxy.brunel.ac.uk/login?url=$@"
+    "url": "https://login.ezproxy.brunel.ac.uk/login?url=",
+    "location": {
+      "lng": -0.4727493,
+      "lat": 51.5321389
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Bryn Mawr",
-    "url": "https://proxy.brynmawr.edu/login?url=$@"
+    "url": "https://proxy.brynmawr.edu/login?url=",
+    "location": {
+      "lng": -75.3151772,
+      "lat": 40.0230237
+    },
+    "country": "United States"
   },
   {
     "name": "Bucknell University",
-    "url": "http://ezproxy.bucknell.edu/login?url=$@"
+    "url": "http://ezproxy.bucknell.edu/login?url=",
+    "location": {
+      "lng": -76.88507589999999,
+      "lat": 40.9547722
+    },
+    "country": "United States"
   },
   {
     "name": "Butler",
-    "url": "https://ezproxy.butler.edu:8443/login?url=$@"
+    "url": "https://ezproxy.butler.edu:8443/login?url=",
+    "location": {
+      "lng": -86.1708927,
+      "lat": 39.8405491
+    },
+    "country": "United States"
   },
   {
     "name": "CAFe Comunidade Acadêmica Federada",
-    "url": "http://ez119.periodicos.capes.gov.br/login?url=$@"
+    "url": "http://ez119.periodicos.capes.gov.br/login?url=",
+    "location": {
+      "lng": -47.9858173931249,
+      "lat": -15.699815561813493
+    },
+    "country": "Brasil"
   },
   {
     "name": "Cal Poly Pomona",
-    "url": "https://login.proxy.library.cpp.edu/login?url=$@"
+    "url": "https://login.proxy.library.cpp.edu/login?url=",
+    "location": {
+      "lng": -117.819263,
+      "lat": 34.0555994
+    },
+    "country": "United States"
   },
   {
     "name": "Cal State Monterey Bay",
-    "url": "http://library2.csumb.edu:2048/login?url=$@"
+    "url": "http://library2.csumb.edu:2048/login?url=",
+    "location": {
+      "lng": -121.7977985,
+      "lat": 36.6516548
+    },
+    "country": "United States"
   },
   {
     "name": "Caldwell",
-    "url": "http://ezproxy.caldwell.edu:2048/login?url=$@"
+    "url": "http://ezproxy.caldwell.edu:2048/login?url=",
+    "location": {
+      "lng": -74.2765366,
+      "lat": 40.8398218
+    },
+    "country": "United States"
   },
   {
     "name": "California Baptist",
-    "url": "http://libproxy.calbaptist.edu/login?url=$@"
+    "url": "http://libproxy.calbaptist.edu/login?url=",
+    "location": {
+      "lng": -117.4259155,
+      "lat": 33.9288906
+    },
+    "country": "United States"
   },
   {
     "name": "California Health Sciences University",
-    "url": "http://chsu.idm.oclc.org/login?url=$@"
+    "url": "http://chsu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -119.7019191,
+      "lat": 36.8325594
+    },
+    "country": "United States"
   },
   {
     "name": "California Institute of Integral Studies",
-    "url": "https://ciis.idm.oclc.org/login?url=$@"
+    "url": "https://ciis.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.4164229,
+      "lat": 37.7746792
+    },
+    "country": "United States"
   },
   {
     "name": "California Polytechnic State University",
-    "url": "https://calpoly.idm.oclc.org/login?url=$@"
-  },
-  {
-    "name": "California State University Long Beach",
-    "url": "https://csulb.idm.oclc.org/login?url=$@"
+    "url": "http://ezproxy.lib.calpoly.edu/login?url=",
+    "location": {
+      "lng": -120.6624942,
+      "lat": 35.3050053
+    },
+    "country": "United States"
   },
   {
     "name": "California State University San Marcos",
-    "url": "https://ezproxy.csusm.edu/login?url=$@"
+    "url": "https://ezproxy.csusm.edu/login?url=",
+    "location": {
+      "lng": -117.1586856,
+      "lat": 33.1298249
+    },
+    "country": "United States"
   },
   {
     "name": "California State University Stanislaus",
-    "url": "http://libproxy.csustan.edu/login?url=$@"
+    "url": "http://libproxy.csustan.edu/login?url=",
+    "location": {
+      "lng": -120.8554591,
+      "lat": 37.525398
+    },
+    "country": "United States"
   },
   {
     "name": "California State University, Fullerton",
-    "url": "http://lib-proxy.fullerton.edu/login?url=$@"
+    "url": "http://lib-proxy.fullerton.edu/login?url=",
+    "location": {
+      "lng": -117.8851033,
+      "lat": 33.8823476
+    },
+    "country": "United States"
   },
   {
     "name": "California State University, Los Angeles",
-    "url": "http://mimas.calstatela.edu/login?url=$@"
+    "url": "http://mimas.calstatela.edu/login?url=",
+    "location": {
+      "lng": -118.1684782,
+      "lat": 34.0663797
+    },
+    "country": "United States"
   },
   {
     "name": "California State University, Northridge",
-    "url": "http://libproxy.csun.edu/login?url=$@"
+    "url": "http://libproxy.csun.edu/login?url=",
+    "location": {
+      "lng": -118.5300196,
+      "lat": 34.2406756
+    },
+    "country": "United States"
   },
   {
     "name": "California University of PA",
-    "url": "http://proxy-calu.klnpa.org/login?url=$@"
+    "url": "http://proxy-calu.klnpa.org/login?url=",
+    "location": {
+      "lng": -79.8844522,
+      "lat": 40.06439659999999
+    },
+    "country": "United States"
   },
   {
     "name": "California Western School of Law",
-    "url": "http://lib-proxy.cwsl.edu:2048/login?url=$@"
+    "url": "http://lib-proxy.cwsl.edu:2048/login?url=",
+    "location": {
+      "lng": -117.1624897,
+      "lat": 32.721719
+    },
+    "country": "United States"
   },
   {
     "name": "Caltech",
-    "url": "http://clsproxy.library.caltech.edu/login?url=$@"
+    "url": "http://clsproxy.library.caltech.edu/login?url=",
+    "location": {
+      "lng": -118.125269,
+      "lat": 34.1376576
+    },
+    "country": "United States"
   },
   {
     "name": "Calumet College of St Joseph",
-    "url": "http://ezproxy.ccsj.edu:2048/login?url=$@"
+    "url": "http://ezproxy.ccsj.edu:2048/login?url=",
+    "location": {
+      "lng": -87.49445899999999,
+      "lat": 41.67086
+    },
+    "country": "United States"
   },
   {
     "name": "Calvin",
-    "url": "https://lib-proxy.calvin.edu/login?url=$@"
+    "url": "https://lib-proxy.calvin.edu/login?url=",
+    "location": {
+      "lng": -85.58897189999999,
+      "lat": 42.9269528
+    },
+    "country": "United States"
   },
   {
     "name": "Cameron",
-    "url": "http://ezproxy.cameron.edu/login?url=$@"
+    "url": "http://ezproxy.cameron.edu/login?url=",
+    "location": {
+      "lng": -98.436244,
+      "lat": 34.6049663
+    },
+    "country": "United States"
   },
   {
     "name": "Canadian Memorial Chiropractic",
-    "url": "http://ezproxy.cmcc.ca/login?url=$@"
+    "url": "http://ezproxy.cmcc.ca/login?url=",
+    "location": {
+      "lng": 2.7737521,
+      "lat": 50.3795055
+    },
+    "country": "France"
   },
   {
     "name": "Cancer Research UK",
-    "url": "http://libraryproxy.cancerresearchuk.org/login?url=$@"
+    "url": "http://libraryproxy.cancerresearchuk.org/login?url=",
+    "location": {
+      "lng": -1.2078627797469357,
+      "lat": 51.731666502450146
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Canisius",
-    "url": "https://ezproxy.canisius.edu/login?url=$@"
+    "url": "https://ezproxy.canisius.edu/login?url=",
+    "location": {
+      "lng": -78.8550954,
+      "lat": 42.9237929
+    },
+    "country": "United States"
   },
   {
     "name": "Cape Breton University",
-    "url": "https://cbu.idm.oclc.org/login?url=$@"
+    "url": "https://cbu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -60.08976879999999,
+      "lat": 46.1672583
+    },
+    "country": "Canada"
   },
   {
     "name": "Cape Peninsula University of Technology",
-    "url": "http://ezproxy.cput.ac.za/login?url=$@"
+    "url": "http://ezproxy.cput.ac.za/login?url=",
+    "location": {
+      "lng": 18.639063,
+      "lat": -33.9305085
+    },
+    "country": "South Africa"
   },
   {
     "name": "Capella",
-    "url": "http://ezproxy.library.capella.edu/login?url=$@"
+    "url": "http://ezproxy.library.capella.edu/login?url=",
+    "location": {
+      "lng": -93.26858089999999,
+      "lat": 44.976168
+    },
+    "country": "United States"
   },
   {
     "name": "Capilano",
-    "url": "https://ezproxy.capilanou.ca/login?url=$@"
+    "url": "https://ezproxy.capilanou.ca/login?url=",
+    "location": {
+      "lng": -123.1260877188983,
+      "lat": 49.33730254215083
+    },
+    "country": "Canada"
   },
   {
     "name": "Cardiff",
-    "url": "http://abc.cardiff.ac.uk/login?url=$@"
+    "url": "http://abc.cardiff.ac.uk/login?url=",
+    "location": {
+      "lng": -3.1680962,
+      "lat": 51.483707
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Cardiff Metropolitan University",
-    "url": "https://ezproxy.cardiffmet.ac.uk/login?url=$@"
+    "url": "https://ezproxy.cardiffmet.ac.uk/login?url=",
+    "location": {
+      "lng": -3.2120517,
+      "lat": 51.4959559
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Caribbean",
-    "url": "http://securelib.caribbean.edu:2048/login?url=$@"
+    "url": "http://securelib.caribbean.edu:2048/login?url=",
+    "location": {
+      "lng": -78.6568942,
+      "lat": 21.4691137
+    },
+    "country": ""
   },
   {
     "name": "Carleton",
-    "url": "http://ezproxy.carleton.edu/login?url=$@"
+    "url": "http://ezproxy.carleton.edu/login?url=",
+    "location": {
+      "lng": -75.69602019999999,
+      "lat": 45.3875812
+    },
+    "country": "Canada"
   },
   {
     "name": "Carleton University",
-    "url": "https://login.proxy.library.carleton.ca/login?url=$@"
+    "url": "https://login.proxy.library.carleton.ca/login?url=",
+    "location": {
+      "lng": -75.69602019999999,
+      "lat": 45.3875812
+    },
+    "country": "Canada"
   },
   {
     "name": "Carlow",
-    "url": "http://carlow.idm.oclc.org/login?url=$@"
+    "url": "http://carlow.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -6.932474399999999,
+      "lat": 52.835854
+    },
+    "country": "Ireland"
   },
   {
     "name": "Carnegie Mellon University (CMU)",
-    "url": "https://cmu.idm.oclc.org/login?url=$@"
+    "url": "https://cmu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -79.9428499,
+      "lat": 40.4432027
+    },
+    "country": "United States"
   },
   {
     "name": "Catholic University of America",
-    "url": "http://proxycu.wrlc.org/login?url=$@"
+    "url": "http://proxycu.wrlc.org/login?url=",
+    "location": {
+      "lng": -76.99869199999999,
+      "lat": 38.9368811
+    },
+    "country": "United States"
   },
   {
     "name": "Cayuga",
-    "url": "http://ezproxy.cayuga-cc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.cayuga-cc.edu:2048/login?url=",
+    "location": {
+      "lng": -76.5488232,
+      "lat": 42.7655231
+    },
+    "country": "United States"
   },
   {
     "name": "Cedars-Sinai Medical Center",
-    "url": "http://mlprox.csmc.edu/login?url=$@"
+    "url": "http://mlprox.csmc.edu/login?url=",
+    "location": {
+      "lng": -118.380967,
+      "lat": 34.074922
+    },
+    "country": "United States"
   },
   {
     "name": "Centenary College of Louisiana",
-    "url": "https://centenary.idm.oclc.org/login?url=$@"
+    "url": "https://centenary.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -93.73215560000001,
+      "lat": 32.4847432
+    },
+    "country": "United States"
   },
   {
     "name": "Central Baptist Theological Seminary",
-    "url": "http://library.cbts.edu:2048/login?url=$@"
+    "url": "http://library.cbts.edu:2048/login?url=",
+    "location": {
+      "lng": -94.8382488,
+      "lat": 39.0093678
+    },
+    "country": "United States"
   },
   {
     "name": "Central Michigan",
-    "url": "http://cmich.idm.oclc.org/login?url=$@"
+    "url": "http://cmich.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -84.7755904,
+      "lat": 43.5906616
+    },
+    "country": "United States"
   },
   {
     "name": "Central Oregon",
-    "url": "http://library.cocc.edu:2048/login?url=$@"
+    "url": "http://library.cocc.edu:2048/login?url=",
+    "location": {
+      "lng": -120.5542012,
+      "lat": 43.8041334
+    },
+    "country": "United States"
   },
   {
     "name": "Central Washington",
-    "url": "https://login.ezp.lib.cwu.edu/login?url=$@"
+    "url": "https://login.ezp.lib.cwu.edu/login?url=",
+    "location": {
+      "lng": -120.5362805,
+      "lat": 47.0073154
+    },
+    "country": "United States"
   },
   {
     "name": "Central Wyoming",
-    "url": "http://proxy.cwc.edu:2048/login?url=$@"
+    "url": "http://proxy.cwc.edu:2048/login?url=",
+    "location": {
+      "lng": -108.426918,
+      "lat": 43.0304794
+    },
+    "country": "United States"
   },
   {
     "name": "Centre College",
-    "url": "https://ezproxy.centre.edu/login?url=$@"
+    "url": "https://ezproxy.centre.edu/login?url=",
+    "location": {
+      "lng": -84.77906100344322,
+      "lat": 37.645860888911464
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "CeRA - Indian Agricultural Research Institute",
-    "url": "http://14.139.56.75/login?url=$@"
+    "url": "http://14.139.56.75/login?url=",
+    "location": {
+      "lng": 77.15249589999999,
+      "lat": 28.6331469
+    },
+    "country": "India"
   },
   {
     "name": "CERN",
-    "url": "https://ezproxy.cern.ch/login?url=$@"
+    "url": "https://ezproxy.cern.ch/login?url=",
+    "location": {
+      "lng": 6.0556771,
+      "lat": 46.2330492
+    },
+    "country": "Switzerland"
   },
   {
     "name": "Cerro Coso",
-    "url": "http://ezproxy.cerrocoso.edu:2048/login?url=$@"
+    "url": "http://ezproxy.cerrocoso.edu:2048/login?url=",
+    "location": {
+      "lng": -117.667777,
+      "lat": 35.5674569
+    },
+    "country": "United States"
   },
   {
     "name": "CETYS University",
-    "url": "https://ebiblio.cetys.mx/login?url=$@"
+    "url": "https://ebiblio.cetys.mx/login?url=",
+    "location": {
+      "lng": -115.4084339,
+      "lat": 32.6547625
+    },
+    "country": "Mexico"
   },
   {
     "name": "Chadli Bendjedid University",
-    "url": "http://ezproxy.univ-eltarf.dz/login?url=$@"
+    "url": "http://ezproxy.univ-eltarf.dz/login?url=",
+    "location": {
+      "lng": 8.3211257,
+      "lat": 36.7619589
+    },
+    "country": "Algeria"
   },
   {
     "name": "Chalmers tekniska hogskola AB",
-    "url": "http://proxy.lib.chalmers.se/login?url=$@"
+    "url": "http://proxy.lib.chalmers.se/login?url=",
+    "location": {
+      "lng": 11.93666,
+      "lat": 57.70661589999999
+    },
+    "country": "Sweden"
   },
   {
     "name": "Chalmers University of Technology",
-    "url": "https://login.proxy.lib.chalmers.se/login?url=$@"
+    "url": "https://login.proxy.lib.chalmers.se/login?url=",
+    "location": {
+      "lng": 11.9741616,
+      "lat": 57.6898004
+    },
+    "country": "Sweden"
   },
   {
     "name": "Champlain College Online",
-    "url": "https://cobalt.champlain.edu/login?url=$@"
+    "url": "https://cobalt.champlain.edu/login?url=",
+    "location": {
+      "lng": -73.2159534,
+      "lat": 44.4610113
+    },
+    "country": "United States"
   },
   {
     "name": "Chandler-Gilbert",
-    "url": "http://ez1.maricopa.edu:2048/login?url=$@"
+    "url": "http://ez1.maricopa.edu:2048/login?url=",
+    "location": {
+      "lng": -111.7956814,
+      "lat": 33.2951034
+    },
+    "country": "United States"
   },
   {
     "name": "Chang Gung",
-    "url": "http://proxy.lib.cgu.edu.tw:81/login?url=$@"
+    "url": "http://proxy.lib.cgu.edu.tw:81/login?url=",
+    "location": {
+      "lng": 121.3877767,
+      "lat": 25.0349186
+    },
+    "country": "Taiwan"
   },
   {
     "name": "Chapman University",
-    "url": "http://libproxy.chapman.edu/login?url=$@"
+    "url": "http://libproxy.chapman.edu/login?url=",
+    "location": {
+      "lng": -117.8520736,
+      "lat": 33.7933203
+    },
+    "country": "United States"
   },
   {
     "name": "Charles Darwin University",
-    "url": "http://ezproxy.cdu.edu.au/login?url=$@"
+    "url": "http://ezproxy.cdu.edu.au/login?url=",
+    "location": {
+      "lng": 130.8688636,
+      "lat": -12.3719948
+    },
+    "country": "Australia"
   },
   {
     "name": "Charles Sturt University",
-    "url": "http://ezproxy.csu.edu.au/login?url=$@"
+    "url": "http://ezproxy.csu.edu.au/login?url=",
+    "location": {
+      "lng": 147.3871248690005,
+      "lat": -34.87645965380469
+    },
+    "country": "Australia"
   },
   {
     "name": "Charleston Southern University",
-    "url": "http://mendel.csuniv.edu/login?url=$@"
+    "url": "http://mendel.csuniv.edu/login?url=",
+    "location": {
+      "lng": -80.07065539999999,
+      "lat": 32.9821829
+    },
+    "country": "United States"
   },
   {
     "name": "Cheyney University",
-    "url": "http://proxy-cheyney.klnpa.org/login?url=$@"
+    "url": "http://proxy-cheyney.klnpa.org/login?url=",
+    "location": {
+      "lng": -75.52950849999999,
+      "lat": 39.9332726
+    },
+    "country": "United States"
   },
   {
     "name": "Chicago Theological Seminary",
-    "url": "https://cts.idm.oclc.org/login?url=$@"
+    "url": "https://cts.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -87.590926,
+      "lat": 41.7854913
+    },
+    "country": "United States"
   },
   {
     "name": "Chinese University of Hong Kong",
-    "url": "https://easylogin1.lib.cuhk.edu.hk/login?url=$@"
+    "url": "https://easylogin1.lib.cuhk.edu.hk/login?url=",
+    "location": {
+      "lng": 114.2067606,
+      "lat": 22.419625
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "CIAP, NSW Health",
-    "url": "http://acs.hcn.com.au/?acc=36422&url=$@"
+    "url": "http://acs.hcn.com.au/?acc=36422&url=",
+    "location": {
+      "lng": 146.921099,
+      "lat": -31.2532183
+    },
+    "country": "Australia"
   },
   {
     "name": "Cincinnati State Technical and",
-    "url": "http://ezproxy1.cincinnatistate.edu:2048/login?url=$@"
+    "url": "http://ezproxy1.cincinnatistate.edu:2048/login?url=",
+    "location": {
+      "lng": -84.53711609999999,
+      "lat": 39.1506136
+    },
+    "country": "United States"
   },
   {
     "name": "City College Brighton and Hove",
-    "url": "http://ezproxy.ccb.ac.uk:2048/login?url=$@"
+    "url": "http://ezproxy.ccb.ac.uk:2048/login?url=",
+    "location": {
+      "lng": -0.136965,
+      "lat": 50.8291136
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "City College of San Francisco",
-    "url": "http://ezproxy.ccsf.edu/login?url=$@"
+    "url": "http://ezproxy.ccsf.edu/login?url=",
+    "location": {
+      "lng": -122.4510797,
+      "lat": 37.72569
+    },
+    "country": "United States"
   },
   {
     "name": "City University of Hong Kong",
-    "url": "https://lbapp01.lib.cityu.edu.hk/ezlogin/index.aspx?url=$@"
+    "url": "https://lbapp01.lib.cityu.edu.hk/ezlogin/index.aspx?url=",
+    "location": {
+      "lng": 114.17272,
+      "lat": 22.3370342
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "City University of New York",
-    "url": "https://ezproxy.gc.cuny.edu/login?url=$@"
+    "url": "https://ezproxy.gc.cuny.edu/login?url=",
+    "location": {
+      "lng": -73.9735038,
+      "lat": 40.7509381
+    },
+    "country": "United States"
   },
   {
     "name": "City University of Seattle",
-    "url": "https://proxy.cityu.edu/login?url=$@"
+    "url": "https://proxy.cityu.edu/login?url=",
+    "location": {
+      "lng": -122.3444142,
+      "lat": 47.6175471
+    },
+    "country": "United States"
   },
   {
     "name": "Claremont Colleges",
-    "url": "https://ccl.idm.oclc.org/login?url=$@"
+    "url": "https://ccl.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -117.7119768,
+      "lat": 34.1035316
+    },
+    "country": "United States"
   },
   {
     "name": "Clarion University",
-    "url": "http://proxy-clarion.klnpa.org/login?url=$@"
+    "url": "http://proxy-clarion.klnpa.org/login?url=",
+    "location": {
+      "lng": -79.37856310000001,
+      "lat": 41.2089367
+    },
+    "country": "United States"
   },
   {
     "name": "Clark University",
-    "url": "https://goddard40.clarku.edu/login?qurl=$@"
+    "url": "https://goddard40.clarku.edu/login?qurl=",
+    "location": {
+      "lng": -71.82455005320072,
+      "lat": 42.25220425261454
+    },
+    "country": "United States"
   },
   {
     "name": "Clarkson University",
-    "url": "https://ezproxy.clarkson.edu/login?url=$@"
+    "url": "https://ezproxy.clarkson.edu/login?url=",
+    "location": {
+      "lng": -74.9932733,
+      "lat": 44.6647724
+    },
+    "country": "United States"
   },
   {
     "name": "Clemson",
-    "url": "http://proxy.lib.clemson.edu/login?url=$@"
+    "url": "http://proxy.lib.clemson.edu/login?url=",
+    "location": {
+      "lng": -82.8367119,
+      "lat": 34.673407
+    },
+    "country": "United States"
   },
   {
     "name": "Clemson University",
-    "url": "http://libproxy.clemson.edu/login?url=$@"
+    "url": "http://libproxy.clemson.edu/login?url=",
+    "location": {
+      "lng": -82.8367119,
+      "lat": 34.673407
+    },
+    "country": "United States"
   },
   {
     "name": "Clermont Universite",
-    "url": "http://sicd.clermont-universite.fr/login?url=$@"
+    "url": "http://sicd.clermont-universite.fr/login?url=",
+    "location": {
+      "lng": 3.087025,
+      "lat": 45.77722199999999
+    },
+    "country": "France"
   },
   {
     "name": "Cleveland State",
-    "url": "http://proxy.ulib.csuohio.edu:2050/login?url=$@"
+    "url": "http://proxy.ulib.csuohio.edu:2050/login?url=",
+    "location": {
+      "lng": -81.67442299999999,
+      "lat": 41.5027643
+    },
+    "country": "United States"
   },
   {
     "name": "Cleveland University-Kansas City",
-    "url": "http://ezproxy.cleveland.edu:2048/login?url=$@"
+    "url": "http://ezproxy.cleveland.edu:2048/login?url=",
+    "location": {
+      "lng": -94.6791964,
+      "lat": 38.9320301
+    },
+    "country": "United States"
   },
   {
     "name": "Clinton Community College",
-    "url": "http://ezproxy.clinton.edu:2048/login?url=$@"
+    "url": "http://ezproxy.clinton.edu:2048/login?url=",
+    "location": {
+      "lng": -73.44005102061675,
+      "lat": 44.64832548820429
+    },
+    "country": "United States"
   },
   {
     "name": "CNRS INEE",
-    "url": "http://inee.bib.cnrs.fr/login?url=$@"
+    "url": "http://inee.bib.cnrs.fr/login?url=",
+    "location": {
+      "lng": 2.2639934,
+      "lat": 48.8476037
+    },
+    "country": "France"
   },
   {
     "name": "CNRS INSB",
-    "url": "http://insb.bib.cnrs.fr/login?url=$@"
+    "url": "http://insb.bib.cnrs.fr/login?url=",
+    "location": {
+      "lng": 2.2639934,
+      "lat": 48.8476037
+    },
+    "country": "France"
   },
   {
     "name": "Coastal Carolina",
-    "url": "http://login.library.coastal.edu:2048/login?url=$@"
+    "url": "http://login.library.coastal.edu:2048/login?url=",
+    "location": {
+      "lng": -79.0136958,
+      "lat": 33.79611939999999
+    },
+    "country": "United States"
   },
   {
     "name": "Colby",
-    "url": "https://colby.idm.oclc.org/login?url=$@"
+    "url": "https://colby.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -69.6626362,
+      "lat": 44.5638691
+    },
+    "country": "United States"
   },
   {
     "name": "Cold Spring Harbor Laboratory",
-    "url": "http://journals.cshl.edu:2048/login?url=$@"
+    "url": "http://journals.cshl.edu:2048/login?url=",
+    "location": {
+      "lng": -73.4669315,
+      "lat": 40.8580545
+    },
+    "country": "United States"
   },
   {
     "name": "College of Charleston",
-    "url": "http://nuncio.cofc.edu/login?url=$@"
+    "url": "http://nuncio.cofc.edu/login?url=",
+    "location": {
+      "lng": -79.93700179999999,
+      "lat": 32.7834441
+    },
+    "country": "United States"
   },
   {
     "name": "College of DuPage",
-    "url": "https://cod.idm.oclc.org/login?url=$@"
+    "url": "https://cod.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -88.07334010000001,
+      "lat": 41.8411058
+    },
+    "country": "United States"
   },
   {
     "name": "College of New Jersey",
-    "url": "http://ezproxy.tcnj.edu:2048/login?url=$@"
+    "url": "http://ezproxy.tcnj.edu:2048/login?url=",
+    "location": {
+      "lng": -74.77763329999999,
+      "lat": 40.268479
+    },
+    "country": "United States"
   },
   {
     "name": "College of Southern Nevada",
-    "url": "http://ezproxy.library.csn.edu/login?url=$@"
+    "url": "http://ezproxy.library.csn.edu/login?url=",
+    "location": {
+      "lng": -114.9653903,
+      "lat": 36.0081705
+    },
+    "country": "United States"
   },
   {
     "name": "College of the Canyons",
-    "url": "http://ezproxy.canyons.edu:2048/login?url=$@"
+    "url": "http://ezproxy.canyons.edu:2048/login?url=",
+    "location": {
+      "lng": -118.5696313,
+      "lat": 34.4042187
+    },
+    "country": "United States"
   },
   {
     "name": "College of the Holy Cross",
-    "url": "https://holycross.idm.oclc.org/login?auth=cas&url=$@"
+    "url": "https://holycross.idm.oclc.org/login?auth=cas&url=",
+    "location": {
+      "lng": -71.8079608,
+      "lat": 42.2392391
+    },
+    "country": "United States"
   },
   {
     "name": "College of the Mainland",
-    "url": "https://ezproxy.com.edu/login?url=$@"
+    "url": "https://ezproxy.com.edu/login?url=",
+    "location": {
+      "lng": -94.9998366,
+      "lat": 29.3955473
+    },
+    "country": "United States"
   },
   {
     "name": "College of the Sequoias",
-    "url": "http://cos.idm.oclc.org/login?url=$@"
+    "url": "http://cos.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -119.3149754,
+      "lat": 36.325102
+    },
+    "country": "United States"
   },
   {
     "name": "College of William and Mary",
-    "url": "https://proxy.wm.edu/login?url=$@"
+    "url": "https://proxy.wm.edu/login?url=",
+    "location": {
+      "lng": -76.71624659999999,
+      "lat": 37.2709753
+    },
+    "country": "United States"
   },
   {
     "name": "Colorado Mountain",
-    "url": "http://cmclibraries.coloradomtn.edu/login?url=$@"
+    "url": "http://cmclibraries.coloradomtn.edu/login?url=",
+    "location": {
+      "lng": -107.3245249,
+      "lat": 39.5464607
+    },
+    "country": "United States"
   },
   {
     "name": "Colorado School of Mines",
-    "url": "https://mines.idm.oclc.org/login?url=$@"
+    "url": "https://mines.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -105.2225708,
+      "lat": 39.7510475
+    },
+    "country": "United States"
   },
   {
     "name": "Colorado State University",
-    "url": "http://ezproxy2.library.colostate.edu/login?url=$@"
+    "url": "http://ezproxy2.library.colostate.edu/login?url=",
+    "location": {
+      "lng": -105.0865487,
+      "lat": 40.57341479999999
+    },
+    "country": "United States"
   },
   {
     "name": "Colorado State University-Global Campus",
-    "url": "https://csuglobal.idm.oclc.org/login?url=$@"
+    "url": "https://csuglobal.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -104.786609,
+      "lat": 39.7251537
+    },
+    "country": "United States"
   },
   {
     "name": "Colorado Technical",
-    "url": "https://login.ctu.idm.oclc.org/login?qurl=$@"
+    "url": "https://login.ctu.idm.oclc.org/login?qurl=",
+    "location": {
+      "lng": -104.8561593,
+      "lat": 38.8946973
+    },
+    "country": "United States"
   },
   {
     "name": "Columbia College",
-    "url": "https://proxy.ccis.edu/login?url=$@"
+    "url": "https://proxy.ccis.edu/login?url=",
+    "location": {
+      "lng": -92.3261593220258,
+      "lat": 38.95833850911415
+    },
+    "country": "United States"
   },
   {
     "name": "Columbia College Sonora",
-    "url": "http://libdbcc.yosemite.edu/login?url=$@"
+    "url": "http://libdbcc.yosemite.edu/login?url=",
+    "location": {
+      "lng": -120.3885135,
+      "lat": 38.0317977
+    },
+    "country": "United States"
   },
   {
     "name": "Columbia College Vancouver",
-    "url": "http://ezproxy.columbiacollege.bc.ca/login?url=$@"
+    "url": "http://ezproxy.columbiacollege.bc.ca/login?url=",
+    "location": {
+      "lng": -123.0947321,
+      "lat": 49.27163239999999
+    },
+    "country": "Canada"
   },
   {
     "name": "Columbia Gorge",
-    "url": "http://cgcc-access.sage.eou.edu/login?url=$@"
+    "url": "http://cgcc-access.sage.eou.edu/login?url=",
+    "location": {
+      "lng": -121.7524723,
+      "lat": 45.7087498
+    },
+    "country": "United States"
   },
   {
     "name": "Columbia University",
-    "url": "http://ezproxy.cul.columbia.edu/login?url=$@"
+    "url": "http://ezproxy.cul.columbia.edu/login?url=",
+    "location": {
+      "lng": -73.9625727,
+      "lat": 40.8075355
+    },
+    "country": "United States"
   },
   {
     "name": "Concordia College-New York",
-    "url": "http://ezproxy.concordia-ny.edu:2048/login?url=$@"
+    "url": "http://ezproxy.concordia-ny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.82214239999999,
+      "lat": 40.94264
+    },
+    "country": "United States"
   },
   {
     "name": "Concordia University",
-    "url": "https://ezproxy.cui.edu/login?qurl=$@"
+    "url": "https://ezproxy.cui.edu/login?qurl=",
+    "location": {
+      "lng": -73.5779128,
+      "lat": 45.4948363
+    },
+    "country": "Canada"
   },
   {
     "name": "Concordia University (Montreal, Canada)",
-    "url": "https://lib-ezproxy.concordia.ca/login?url=$@"
+    "url": "https://lib-ezproxy.concordia.ca/login?url=",
+    "location": {
+      "lng": -73.5779128,
+      "lat": 45.4948363
+    },
+    "country": "Canada"
   },
   {
     "name": "Concordia University Irvine",
-    "url": "http://ezproxy.cui.edu/login?url=$@"
+    "url": "http://ezproxy.cui.edu/login?url=",
+    "location": {
+      "lng": -117.8105295,
+      "lat": 33.6539343
+    },
+    "country": "United States"
   },
   {
     "name": "Concordia University Portland",
-    "url": "https://cupdx.idm.oclc.org/login?url=$@"
+    "url": "https://cupdx.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.6363765,
+      "lat": 45.5690187
+    },
+    "country": "United States"
   },
   {
     "name": "Concordia University St Paul",
-    "url": "https://ezproxy.csp.edu/login?url=$@"
+    "url": "https://ezproxy.csp.edu/login?url=",
+    "location": {
+      "lng": -93.156483,
+      "lat": 44.9490802
+    },
+    "country": "United States"
   },
   {
     "name": "Consiglio Nazionale delle Ricerche",
-    "url": "https://biblioproxy.cnr.it/login?url=$@"
+    "url": "https://biblioproxy.cnr.it/login?url=",
+    "location": {
+      "lng": 12.533432038742754,
+      "lat": 41.94858996338506
+    },
+    "country": "Italy"
   },
   {
     "name": "Contra Costa County Library",
-    "url": "https://login.ez.ccclib.org/login?url=$@"
+    "url": "https://login.ez.ccclib.org/login?url=",
+    "location": {
+      "lng": -121.9017954,
+      "lat": 37.8534093
+    },
+    "country": "United States"
   },
   {
     "name": "Copenhagen Business School",
-    "url": "http://esc-web.lib.cbs.dk/login?url=$@"
+    "url": "http://esc-web.lib.cbs.dk/login?url=",
+    "location": {
+      "lng": 12.5296944,
+      "lat": 55.68156519999999
+    },
+    "country": "Denmark"
   },
   {
     "name": "Copenhagen University - The Royal Library",
-    "url": "http://ep.fjernadgang.kb.dk/login?url=$@"
+    "url": "http://ep.fjernadgang.kb.dk/login?url=",
+    "location": {
+      "lng": 12.5826588,
+      "lat": 55.6733994
+    },
+    "country": "Denmark"
   },
   {
     "name": "Corban",
-    "url": "http://ezproxy.corban.edu/login?url=$@"
+    "url": "http://ezproxy.corban.edu/login?url=",
+    "location": {
+      "lng": -122.9580948,
+      "lat": 44.88383779999999
+    },
+    "country": "United States"
   },
   {
     "name": "Cornell",
-    "url": "https://proxy.library.cornell.edu/login?url=$@"
+    "url": "https://proxy.library.cornell.edu/login?url=",
+    "location": {
+      "lng": -76.4735027,
+      "lat": 42.4534492
+    },
+    "country": "United States"
   },
   {
     "name": "Cornell University",
-    "url": "http://encompass.library.cornell.edu/cgi-bin/checkIP.cgi?access=gateway_standard&url=$@"
+    "url": "http://encompass.library.cornell.edu/cgi-bin/checkIP.cgi?access=gateway_standard&url=",
+    "location": {
+      "lng": -76.4735027,
+      "lat": 42.4534492
+    },
+    "country": "United States"
   },
   {
     "name": "County College of Morris",
-    "url": "http://skynet.ccm.edu:2048/login?url=$@"
+    "url": "http://skynet.ccm.edu:2048/login?url=",
+    "location": {
+      "lng": -74.5814491,
+      "lat": 40.85817369999999
+    },
+    "country": "United States"
   },
   {
     "name": "Covenant Theological Seminary",
-    "url": "https://search.covenantseminary.edu/login?url=$@"
+    "url": "https://search.covenantseminary.edu/login?url=",
+    "location": {
+      "lng": -90.4521276,
+      "lat": 38.6437191
+    },
+    "country": "United States"
   },
   {
     "name": "CQUniversity Australia",
-    "url": "https://ezproxy.cqu.edu.au/login?url=$@"
+    "url": "https://ezproxy.cqu.edu.au/login?url=",
+    "location": {
+      "lng": 150.5189408,
+      "lat": -23.3264685
+    },
+    "country": "Australia"
   },
   {
     "name": "Creighton University",
-    "url": "https://login.cuhsl.creighton.edu/login?url=$@"
+    "url": "https://login.cuhsl.creighton.edu/login?url=",
+    "location": {
+      "lng": -95.94638619999999,
+      "lat": 41.2655521
+    },
+    "country": "United States"
   },
   {
     "name": "CSU Chico",
-    "url": "http://mantis.csuchico.edu/login?url=$@"
+    "url": "http://mantis.csuchico.edu/login?url=",
+    "location": {
+      "lng": -121.8478871,
+      "lat": 39.7296653
+    },
+    "country": "United States"
   },
   {
     "name": "CSU East Bay",
-    "url": "http://proxylib.csueastbay.edu/login?url=$@"
+    "url": "http://proxylib.csueastbay.edu/login?url=",
+    "location": {
+      "lng": -122.0558839,
+      "lat": 37.6568259
+    },
+    "country": "United States"
   },
   {
     "name": "CSU Fresno",
-    "url": "http://hmlproxy.lib.csufresno.edu/login?url=$@"
+    "url": "http://hmlproxy.lib.csufresno.edu/login?url=",
+    "location": {
+      "lng": -119.7461767,
+      "lat": 36.8136777
+    },
+    "country": "United States"
   },
   {
     "name": "CSU Sacramento",
-    "url": "http://proxy.lib.csus.edu/login?url=$@"
+    "url": "http://proxy.lib.csus.edu/login?url=",
+    "location": {
+      "lng": -121.4276493,
+      "lat": 38.564761
+    },
+    "country": "United States"
   },
   {
     "name": "CSU San Bernardino",
-    "url": "http://libproxy.lib.csusb.edu/login?url=$@"
+    "url": "http://libproxy.lib.csusb.edu/login?url=",
+    "location": {
+      "lng": -117.3231875,
+      "lat": 34.1813584
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY Baruch",
-    "url": "http://remote.baruch.cuny.edu/login?url=$@"
+    "url": "http://remote.baruch.cuny.edu/login?url=",
+    "location": {
+      "lng": -73.9835124,
+      "lat": 40.7402384
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY Central Office",
-    "url": "http://central.ezproxy.cuny.edu:2048/login?url=$@"
+    "url": "http://central.ezproxy.cuny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9735038,
+      "lat": 40.7509381
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY City College of New York",
-    "url": "http://ccny-proxy1.libr.ccny.cuny.edu/login?url=$@"
+    "url": "http://ccny-proxy1.libr.ccny.cuny.edu/login?url=",
+    "location": {
+      "lng": -73.9492724,
+      "lat": 40.8200471
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY College of Staten Island",
-    "url": "http://proxy.library.csi.cuny.edu/login?url=$@"
+    "url": "http://proxy.library.csi.cuny.edu/login?url=",
+    "location": {
+      "lng": -74.15038109999999,
+      "lat": 40.6021807
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY Graduate School of Journalism",
-    "url": "http://journalism.ezproxy.cuny.edu:2048/login?url=$@"
+    "url": "http://journalism.ezproxy.cuny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9889219,
+      "lat": 40.7554192
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY Hostos",
-    "url": "http://hostos.ezproxy.cuny.edu:2048/login?url=$@"
+    "url": "http://hostos.ezproxy.cuny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9735038,
+      "lat": 40.7509381
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY Hunter",
-    "url": "http://proxy.wexler.hunter.cuny.edu/login?url=$@"
+    "url": "http://proxy.wexler.hunter.cuny.edu/login?url=",
+    "location": {
+      "lng": -73.9645291,
+      "lat": 40.7678398
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY John Jay College of Criminal Justice",
-    "url": "http://ez.lib.jjay.cuny.edu/login?url=$@"
+    "url": "http://ez.lib.jjay.cuny.edu/login?url=",
+    "location": {
+      "lng": -73.9735038,
+      "lat": 40.7509381
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY Kingsborough",
-    "url": "http://kbcc.ezproxy.cuny.edu:2048/login?url=$@"
+    "url": "http://kbcc.ezproxy.cuny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9351016,
+      "lat": 40.5786707
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY Law School",
-    "url": "http://law.ezproxy.cuny.edu:2048/login?url=$@"
+    "url": "http://law.ezproxy.cuny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.94398269999999,
+      "lat": 40.747929
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY Medgar Evers",
-    "url": "http://mec.ezproxy.cuny.edu:2048/login?url=$@"
+    "url": "http://mec.ezproxy.cuny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9574025,
+      "lat": 40.6670398
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY New York City College of Technology",
-    "url": "http://citytech.ezproxy.cuny.edu:2048/login?url=$@"
+    "url": "http://citytech.ezproxy.cuny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9735038,
+      "lat": 40.7509381
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY Queens",
-    "url": "http://queens.ezproxy.cuny.edu:2048/login?url=$@"
+    "url": "http://queens.ezproxy.cuny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9735038,
+      "lat": 40.7509381
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY Queensborough",
-    "url": "http://qbcc.ezproxy.cuny.edu:2048/login?url=$@"
+    "url": "http://qbcc.ezproxy.cuny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9735038,
+      "lat": 40.7509381
+    },
+    "country": "United States"
   },
   {
     "name": "CUNY York",
-    "url": "http://york.ezproxy.cuny.edu:2048/login?url=$@"
+    "url": "http://york.ezproxy.cuny.edu:2048/login?url=",
+    "location": {
+      "lng": -73.7961103,
+      "lat": 40.7010415
+    },
+    "country": "United States"
   },
   {
     "name": "Curry College",
-    "url": "http://odin.curry.edu/login?url=$@"
+    "url": "http://odin.curry.edu/login?url=",
+    "location": {
+      "lng": -71.11348937838551,
+      "lat": 42.23474401938337
+    },
+    "country": "United States"
   },
   {
     "name": "Curtin",
-    "url": "http://dbgw.lis.curtin.edu.au/login?url=$@"
+    "url": "http://dbgw.lis.curtin.edu.au/login?url=",
+    "location": {
+      "lng": 115.8919818,
+      "lat": -32.0054649
+    },
+    "country": "Australia"
   },
   {
     "name": "Curtin University",
-    "url": "https://link.library.curtin.edu.au/gw?url=$@"
+    "url": "https://link.library.curtin.edu.au/gw?url=",
+    "location": {
+      "lng": 115.8919818,
+      "lat": -32.0054649
+    },
+    "country": "Australia"
   },
   {
     "name": "Dakota Wesleyan",
-    "url": "https://ezproxy.dwu.edu:2048/login?url=$@"
+    "url": "https://ezproxy.dwu.edu:2048/login?url=",
+    "location": {
+      "lng": -98.03122,
+      "lat": 43.697665
+    },
+    "country": "United States"
   },
   {
     "name": "Dalhousie University",
-    "url": "https://login.ezproxy.library.dal.ca/login?url=$@"
+    "url": "https://login.ezproxy.library.dal.ca/login?url=",
+    "location": {
+      "lng": -63.59165549999999,
+      "lat": 44.63658119999999
+    },
+    "country": "Canada"
   },
   {
     "name": "Dallas Baptist",
-    "url": "http://library.dbu.edu:2048/login?url=$@"
+    "url": "http://library.dbu.edu:2048/login?url=",
+    "location": {
+      "lng": -96.9466776,
+      "lat": 32.7095466
+    },
+    "country": "United States"
   },
   {
     "name": "Dalton State",
-    "url": "https://login.dsc.idm.oclc.org/login?qurl=$@"
+    "url": "https://login.dsc.idm.oclc.org/login?qurl=",
+    "location": {
+      "lng": -85.00294029999999,
+      "lat": 34.7749867
+    },
+    "country": "United States"
   },
   {
     "name": "Danske museers e-tidsskriftadgang",
-    "url": "http://ep.museum-fjernadgang.kb.dk/login?url=$@"
+    "url": "http://ep.museum-fjernadgang.kb.dk/login?url=",
+    "location": {
+      "lng": 9.501785,
+      "lat": 56.26392
+    },
+    "country": "Denmark"
   },
   {
     "name": "Dartmouth",
-    "url": "http://dartmouth.idm.oclc.org/login?url=$@"
+    "url": "http://dartmouth.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -72.2886934,
+      "lat": 43.7044406
+    },
+    "country": "United States"
   },
   {
     "name": "Davidson College",
-    "url": "https://login.proxy048.nclive.org/login?url=$@"
+    "url": "http://ezproxy.lib.davidson.edu/login?url=",
+    "location": {
+      "lng": -80.8423248,
+      "lat": 35.5015528
+    },
+    "country": "United States"
   },
   {
-    "name": "Davidson College",
-    "url": "http://ezproxy.lib.davidson.edu/login?url=$@"
+    "name": "Davidson College (Alternative)",
+    "url": "https://login.proxy048.nclive.org/login?url=",
+    "location": {
+      "lng": -80.8423248,
+      "lat": 35.5015528
+    },
+    "country": "United States"
   },
   {
     "name": "Daviess County Public Library",
-    "url": "https://ezproxy.dcplibrary.org/login?url=$@"
+    "url": "https://ezproxy.dcplibrary.org/login?url=",
+    "location": {
+      "lng": -87.1121167,
+      "lat": 37.7559529
+    },
+    "country": "United States"
   },
   {
     "name": "De Haagse Hogeschool",
-    "url": "http://ezproxy.hhs.nl:2048/login?url=$@"
+    "url": "http://ezproxy.hhs.nl:2048/login?url=",
+    "location": {
+      "lng": 4.323974,
+      "lat": 52.0670747
+    },
+    "country": "Netherlands"
   },
   {
     "name": "De Montfort University",
-    "url": "http://proxy.library.dmu.ac.uk/login?url=$@"
+    "url": "http://proxy.library.dmu.ac.uk/login?url=",
+    "location": {
+      "lng": -1.1398564,
+      "lat": 52.6298398
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Deakin University",
-    "url": "http://ezproxy.deakin.edu.au/login?url=$@"
+    "url": "http://ezproxy.deakin.edu.au/login?url=",
+    "location": {
+      "lng": 145.11220195239576,
+      "lat": -37.84431193559967
+    },
+    "country": "Australia"
   },
   {
     "name": "Deerfield Academy",
-    "url": "http://proxy.library.deerfield.edu:2048/login?url=$@"
+    "url": "http://proxy.library.deerfield.edu:2048/login?url=",
+    "location": {
+      "lng": -72.6076286,
+      "lat": 42.546129
+    },
+    "country": "United States"
   },
   {
     "name": "Del Mar",
-    "url": "http://library.delmar.edu:2048/login?url=$@"
+    "url": "http://library.delmar.edu:2048/login?url=",
+    "location": {
+      "lng": -117.2653146,
+      "lat": 32.9594891
+    },
+    "country": "United States"
   },
   {
     "name": "Delta College",
-    "url": "http://ezproxy.delta.edu:2048/login?url=$@"
+    "url": "http://ezproxy.delta.edu:2048/login?url=",
+    "location": {
+      "lng": -83.98590972010047,
+      "lat": 43.55929097881718
+    },
+    "country": "United States"
   },
   {
     "name": "DeVry",
-    "url": "http://proxy.devry.edu/login?url=$@"
+    "url": "http://proxy.devry.edu/login?url=",
+    "location": {
+      "lng": -88.1262831,
+      "lat": 41.800125
+    },
+    "country": "United States"
   },
   {
     "name": "Dickinson College",
-    "url": "http://envoy.dickinson.edu:2048/login?url=$@"
+    "url": "http://envoy.dickinson.edu:2048/login?url=",
+    "location": {
+      "lng": -77.200919234303,
+      "lat": 40.202869085904254
+    },
+    "country": "United States"
   },
   {
     "name": "Dixon Center",
-    "url": "http://proxy-dixon.klnpa.org/login?url=$@"
+    "url": "http://proxy-dixon.klnpa.org/login?url=",
+    "location": {
+      "lng": -123.2786381,
+      "lat": 44.5631448
+    },
+    "country": "United States"
   },
   {
-    "name": "Drake",
-    "url": "https://login.cowles-proxy.drake.edu/login?qurl=$@"
+    "name": "Drake University",
+    "url": "https://login.cowles-proxy.drake.edu/login?qurl=",
+    "location": {
+      "lng": -93.65464811887604,
+      "lat": 41.603179634141526
+    },
+    "country": "United States"
   },
   {
     "name": "Drew University",
-    "url": "http://ezproxy.drew.edu/login?url=$@"
+    "url": "http://ezproxy.drew.edu/login?url=",
+    "location": {
+      "lng": -74.42661744592519,
+      "lat": 40.760385948806665
+    },
+    "country": "United States"
   },
   {
     "name": "Drexel University",
-    "url": "https://ezproxy2.library.drexel.edu/login?url=$@"
+    "url": "https://ezproxy2.library.drexel.edu/login?url=",
+    "location": {
+      "lng": -75.18994409999999,
+      "lat": 39.9566127
+    },
+    "country": "United States"
   },
   {
     "name": "Dublin City University",
-    "url": "http://dcu.idm.oclc.org/login?url=$@"
+    "url": "http://dcu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -6.2588403,
+      "lat": 53.38533169999999
+    },
+    "country": "Ireland"
   },
   {
     "name": "Duke",
-    "url": "http://proxy.lib.duke.edu/login?url=$@"
+    "url": "http://proxy.lib.duke.edu/login?url=",
+    "location": {
+      "lng": -78.9382286,
+      "lat": 36.0014258
+    },
+    "country": "United States"
   },
   {
     "name": "Duke University",
-    "url": "http://proxy.lib.duke.edu:2048/login?url=$@"
+    "url": "http://proxy.lib.duke.edu:2048/login?url=",
+    "location": {
+      "lng": -78.9382286,
+      "lat": 36.0014258
+    },
+    "country": "United States"
   },
   {
     "name": "Duquesne",
-    "url": "https://authenticate.library.duq.edu/login?url=$@"
+    "url": "https://authenticate.library.duq.edu/login?url=",
+    "location": {
+      "lng": -79.99025759999999,
+      "lat": 40.4369485
+    },
+    "country": "United States"
   },
   {
     "name": "Durban University of Technology",
-    "url": "http://dutlib.dut.ac.za:2048/login?url=$@"
+    "url": "http://dutlib.dut.ac.za:2048/login?url=",
+    "location": {
+      "lng": 31.0061131,
+      "lat": -29.8536128
+    },
+    "country": "South Africa"
   },
   {
     "name": "Durham University",
-    "url": "http://ezphost.dur.ac.uk/login?url=$@"
+    "url": "http://ezphost.dur.ac.uk/login?url=",
+    "location": {
+      "lng": -1.5782029,
+      "lat": 54.7649859
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Dyersburg State",
-    "url": "http://ezproxy.dscc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.dscc.edu:2048/login?url=",
+    "location": {
+      "lng": -89.39095449999999,
+      "lat": 36.0480637
+    },
+    "country": "United States"
   },
   {
     "name": "DYouville",
-    "url": "https://dyc.idm.oclc.org/login?url=$@"
+    "url": "https://dyc.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -78.8905599,
+      "lat": 42.9033183
+    },
+    "country": "United States"
   },
   {
     "name": "Earlham College",
-    "url": "http://proxy.earlham.edu:2048/login?url=$@"
+    "url": "http://proxy.earlham.edu:2048/login?url=",
+    "location": {
+      "lng": -84.913241,
+      "lat": 39.823941
+    },
+    "country": "United States"
   },
   {
     "name": "East Carolina",
-    "url": "http://jproxy.lib.ecu.edu/login?url=$@"
+    "url": "http://jproxy.lib.ecu.edu/login?url=",
+    "location": {
+      "lng": -77.3665364,
+      "lat": 35.6068806
+    },
+    "country": "United States"
   },
   {
     "name": "East Central",
-    "url": "http://ezproxy.eastcentral.edu:2048/login?url=$@"
+    "url": "http://ezproxy.eastcentral.edu:2048/login?url=",
+    "location": {
+      "lng": -98.265058,
+      "lat": 29.3934197
+    },
+    "country": "United States"
   },
   {
     "name": "East Stroudsburg University",
-    "url": "http://navigator-esu.passhe.edu/login?url=$@"
+    "url": "http://navigator-esu.passhe.edu/login?url=",
+    "location": {
+      "lng": -75.1727074,
+      "lat": 40.9974693
+    },
+    "country": "United States"
   },
   {
     "name": "East Texas Baptist University",
-    "url": "http://media.etbu.edu:2048/login?url=$@"
+    "url": "http://media.etbu.edu:2048/login?url=",
+    "location": {
+      "lng": -94.3734369,
+      "lat": 32.5558104
+    },
+    "country": "United States"
   },
   {
     "name": "Eastern Illinois",
-    "url": "http://proxy.library.eiu.edu:2048/login?url=$@"
+    "url": "http://proxy.library.eiu.edu:2048/login?url=",
+    "location": {
+      "lng": -88.17521839999999,
+      "lat": 39.4835612
+    },
+    "country": "United States"
   },
   {
     "name": "Eastern Illinois University",
-    "url": "http://proxy1.library.eiu.edu/login?url=$@"
+    "url": "http://proxy1.library.eiu.edu/login?url=",
+    "location": {
+      "lng": -88.17521839999999,
+      "lat": 39.4835612
+    },
+    "country": "United States"
   },
   {
     "name": "Eastern Institute of Technology",
-    "url": "http://library.eit.ac.nz:2048/login?url=$@"
+    "url": "http://library.eit.ac.nz:2048/login?url=",
+    "location": {
+      "lng": 176.8385542,
+      "lat": -39.5469143
+    },
+    "country": "New Zealand"
   },
   {
     "name": "Eastern Kentucky University",
-    "url": "http://libproxy.eku.edu/login?url=$@"
+    "url": "http://libproxy.eku.edu/login?url=",
+    "location": {
+      "lng": -84.2987483,
+      "lat": 37.7359731
+    },
+    "country": "United States"
   },
   {
     "name": "Eastern Michigan",
-    "url": "http://ezproxy.emich.edu/login?url=$@"
+    "url": "http://ezproxy.emich.edu/login?url=",
+    "location": {
+      "lng": -83.624089,
+      "lat": 42.2506803
+    },
+    "country": "United States"
   },
   {
     "name": "Eastern Nazarene",
-    "url": "http://ezproxy.library.enc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.library.enc.edu:2048/login?url=",
+    "location": {
+      "lng": -71.0104487,
+      "lat": 42.2712766
+    },
+    "country": "United States"
   },
   {
     "name": "Eastern Oregon",
-    "url": "http://access.library.eou.edu/login?url=$@"
+    "url": "http://access.library.eou.edu/login?url=",
+    "location": {
+      "lng": -118.8917537,
+      "lat": 44.4383953
+    },
+    "country": "United States"
   },
   {
     "name": "Eastern Virginia Medical School",
-    "url": "https://evms.idm.oclc.org/login?url=$@"
+    "url": "https://evms.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -76.3035708,
+      "lat": 36.8604506
+    },
+    "country": "United States"
   },
   {
     "name": "Eastern Washington",
-    "url": "http://ezproxy.library.ewu.edu:2048/login?url=$@"
+    "url": "http://ezproxy.library.ewu.edu:2048/login?url=",
+    "location": {
+      "lng": -117.5847877,
+      "lat": 47.4906616
+    },
+    "country": "United States"
   },
   {
     "name": "Eckerd",
-    "url": "http://proxy.eckerd.edu:5000/login?url=$@"
+    "url": "http://proxy.eckerd.edu:5000/login?url=",
+    "location": {
+      "lng": -82.6864739,
+      "lat": 27.7147317
+    },
+    "country": "United States"
   },
   {
     "name": "Ecole Nationale Superieure dArts et Metiers",
-    "url": "http://rp1.ensam.eu/login?url=$@"
+    "url": "http://rp1.ensam.eu/login?url=",
+    "location": {
+      "lng": 2.3582236,
+      "lat": 48.8330427
+    },
+    "country": "France"
   },
   {
     "name": "Ecole normale superieure",
-    "url": "http://proxy.rubens.ens.fr/login?url=$@"
+    "url": "http://proxy.rubens.ens.fr/login?url=",
+    "location": {
+      "lng": 2.1653030679638117,
+      "lat": 48.712692318826825
+    },
+    "country": "France"
   },
   {
     "name": "Edge Hill",
-    "url": "https://edgehill.idm.oclc.org/login?url=$@"
+    "url": "https://edgehill.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -2.8703472,
+      "lat": 53.5588278
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Edinboro University",
-    "url": "http://proxy-edinboro.klnpa.org/login?url=$@"
+    "url": "http://proxy-edinboro.klnpa.org/login?url=",
+    "location": {
+      "lng": -80.12080279999999,
+      "lat": 41.871572
+    },
+    "country": "United States"
   },
   {
     "name": "Edinburgh Napier",
-    "url": "http://ezproxy.napier.ac.uk/login?url=$@"
+    "url": "http://ezproxy.napier.ac.uk/login?url=",
+    "location": {
+      "lng": -3.188267,
+      "lat": 55.953252
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Edith Cowan University",
-    "url": "http://ezproxy.ecu.edu.au/login?url=$@"
+    "url": "http://ezproxy.ecu.edu.au/login?url=",
+    "location": {
+      "lng": 115.7727799,
+      "lat": -31.7524902
+    },
+    "country": "Australia"
   },
   {
     "name": "Eindhoven University of Technology",
-    "url": "https://janus.libr.tue.nl/login?url=$@"
+    "url": "https://janus.libr.tue.nl/login?url=",
+    "location": {
+      "lng": 5.4907148,
+      "lat": 51.44860980000001
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Elizabethtown College",
-    "url": "http://ezproxy.etown.edu/login?url=$@"
+    "url": "http://ezproxy.etown.edu/login?url=",
+    "location": {
+      "lng": -76.58965393031816,
+      "lat": 40.14947367887843
+    },
+    "country": "United States"
   },
   {
     "name": "Elmira",
-    "url": "http://ezproxy.elmira.edu:2048/login?url=$@"
+    "url": "http://ezproxy.elmira.edu:2048/login?url=",
+    "location": {
+      "lng": -76.8077338,
+      "lat": 42.0897965
+    },
+    "country": "United States"
   },
   {
     "name": "Elms",
-    "url": "http://elms.idm.oclc.org/login?url=$@"
+    "url": "http://elms.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -87.6279965,
+      "lat": 41.9033774
+    },
+    "country": "United States"
   },
   {
     "name": "Embry-Riddle Aeronautical University - Hunt Library",
-    "url": "http://ezproxy.libproxy.db.erau.edu/login?url=$@"
+    "url": "http://ezproxy.libproxy.db.erau.edu/login?url=",
+    "location": {
+      "lng": -81.0492933,
+      "lat": 29.1878901
+    },
+    "country": "United States"
   },
   {
     "name": "Emerson College",
-    "url": "http://proxy.emerson.edu/login?url=$@"
+    "url": "http://proxy.emerson.edu/login?url=",
+    "location": {
+      "lng": -71.06582403235687,
+      "lat": 42.352401004337835
+    },
+    "country": "United States"
   },
   {
     "name": "Emily Carr",
-    "url": "http://ezproxy.eciad.ca:2048/login?url=$@"
+    "url": "http://ezproxy.eciad.ca:2048/login?url=",
+    "location": {
+      "lng": -123.09266683437563,
+      "lat": 49.26822477301482
+    },
+    "country": "Canada"
   },
   {
     "name": "Emmanuel College",
-    "url": "http://library.emmanuel.edu:2048/login?url=$@"
+    "url": "http://library.emmanuel.edu:2048/login?url=",
+    "location": {
+      "lng": -71.10272270352222,
+      "lat": 42.34124915409021
+    },
+    "country": "United States"
   },
   {
     "name": "Emory Henry",
-    "url": "http://ezproxy.ehc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.ehc.edu:2048/login?url=",
+    "location": {
+      "lng": -81.82925,
+      "lat": 36.77252
+    },
+    "country": "United States"
   },
   {
     "name": "Emory University",
-    "url": "https://proxy.library.emory.edu/login?url=$@"
+    "url": "https://proxy.library.emory.edu/login?url=",
+    "location": {
+      "lng": -84.32224,
+      "lat": 33.7971368
+    },
+    "country": "United States"
   },
   {
     "name": "ENCG Settat",
-    "url": "https://www.ezproxy.uh1.ac.ma/login?url=$@"
+    "url": "https://www.ezproxy.uh1.ac.ma/login?url=",
+    "location": {
+      "lng": -7.616952899999999,
+      "lat": 33.0329202
+    },
+    "country": "Morocco"
   },
   {
     "name": "Erasmus University Rotterdam",
-    "url": "https://eur.idm.oclc.org/login?url=$@"
+    "url": "https://eur.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 4.5263027,
+      "lat": 51.9172477
+    },
+    "country": "Netherlands"
   },
   {
     "name": "ERDC",
-    "url": "http://erdclibrary.idm.oclc.org/login?url=$@"
+    "url": "http://erdclibrary.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -90.8714067,
+      "lat": 32.3012717
+    },
+    "country": "United States"
   },
   {
     "name": "Erie",
-    "url": "https://ezproxy.ecc.edu:2443/login?url=$@"
+    "url": "https://ezproxy.ecc.edu:2443/login?url=",
+    "location": {
+      "lng": -80.085059,
+      "lat": 42.12922409999999
+    },
+    "country": "United States"
   },
   {
     "name": "ESSEC Business School",
-    "url": "https://login.ezp.essec.fr/login?url=$@"
+    "url": "https://login.ezp.essec.fr/login?url=",
+    "location": {
+      "lng": 2.078274,
+      "lat": 49.0333771
+    },
+    "country": "France"
   },
   {
     "name": "ETH Zurich",
-    "url": "https://proxy.ethz.ch/cgi-bin/login.pl?url=$@"
+    "url": "https://proxy.ethz.ch/cgi-bin/login.pl?url=",
+    "location": {
+      "lng": 8.547628,
+      "lat": 47.37638889999999
+    },
+    "country": "Switzerland"
   },
   {
     "name": "European University Institute",
-    "url": "http://ezproxy.eui.eu/login?url=$@"
+    "url": "http://ezproxy.eui.eu/login?url=",
+    "location": {
+      "lng": 11.282959,
+      "lat": 43.803079
+    },
+    "country": "Italy"
   },
   {
     "name": "Evangelische Hochschule Nürnberg",
-    "url": "https://evhn.idm.oclc.org/login?url=$@"
+    "url": "https://evhn.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 11.060193,
+      "lat": 49.4510101
+    },
+    "country": "Germany"
   },
   {
     "name": "Everett",
-    "url": "http://ezproxy.everettcc.edu/login?url=$@"
+    "url": "http://ezproxy.everettcc.edu/login?url=",
+    "location": {
+      "lng": -122.2020794,
+      "lat": 47.9789848
+    },
+    "country": "United States"
   },
   {
     "name": "Fachhochschule Munster",
-    "url": "https://www.hb.fh-muenster.de:2443/login?url=$@"
+    "url": "https://www.hb.fh-muenster.de:2443/login?url=",
+    "location": {
+      "lng": 7.6261347,
+      "lat": 51.9606649
+    },
+    "country": "Germany"
   },
   {
     "name": "Fachhochschule Salzburg",
-    "url": "http://ezproxy.fh-salzburg.ac.at/login?url=$@"
+    "url": "http://ezproxy.fh-salzburg.ac.at/login?url=",
+    "location": {
+      "lng": 13.0871253,
+      "lat": 47.7233835
+    },
+    "country": "Austria"
   },
   {
     "name": "Fairfield University",
-    "url": "http://libdb.fairfield.edu/login?url=$@"
+    "url": "http://libdb.fairfield.edu/login?url=",
+    "location": {
+      "lng": -73.25758271537647,
+      "lat": 41.160089562662264
+    },
+    "country": "United States"
   },
   {
     "name": "Fashion Institute of Technology",
-    "url": "https://libproxy.fitsuny.edu/login?url=$@"
+    "url": "https://libproxy.fitsuny.edu/login?url=",
+    "location": {
+      "lng": -73.99502919999999,
+      "lat": 40.7472624
+    },
+    "country": "United States"
   },
   {
-    "name": "Faulkner",
-    "url": "http://library.faulkner.edu:2048/login?url=$@"
+    "name": "Faulkner University",
+    "url": "http://library.faulkner.edu:2048/login?url=",
+    "location": {
+      "lng": -86.24262099952868,
+      "lat": 32.559822310993205
+    },
+    "country": "United States"
   },
   {
     "name": "Fielding Graduate",
-    "url": "https://fgul.idm.oclc.org/login?url=$@"
+    "url": "https://fgul.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -119.7174748,
+      "lat": 34.42927590000001
+    },
+    "country": "United States"
   },
   {
     "name": "Finger Lakes",
-    "url": "https://ezproxy.flcc.edu/login?url=$@"
+    "url": "https://ezproxy.flcc.edu/login?url=",
+    "location": {
+      "lng": -76.9297247,
+      "lat": 42.7238165
+    },
+    "country": "United States"
   },
   {
     "name": "Finlandia",
-    "url": "http://20p4y.finlandia.edu:2048/login?url=$@"
+    "url": "http://20p4y.finlandia.edu:2048/login?url=",
+    "location": {
+      "lng": 25.748151,
+      "lat": 61.92410999999999
+    },
+    "country": "Finland"
   },
   {
     "name": "Flinders University",
-    "url": "http://ezproxy.flinders.edu.au/login?url=$@"
+    "url": "http://ezproxy.flinders.edu.au/login?url=",
+    "location": {
+      "lng": 138.5688883101934,
+      "lat": -35.02296968878218
+    },
+    "country": "Australia"
   },
   {
     "name": "Florida Atlantic University",
-    "url": "https://login.ezproxy.fau.edu/login?url=$@"
+    "url": "https://login.ezproxy.fau.edu/login?url=",
+    "location": {
+      "lng": -80.1289321,
+      "lat": 26.3683064
+    },
+    "country": "United States"
   },
   {
     "name": "Florida Gulf Coast",
-    "url": "http://ezproxy.fgcu.edu/login?url=$@"
+    "url": "http://ezproxy.fgcu.edu/login?url=",
+    "location": {
+      "lng": -81.7800748,
+      "lat": 26.4626967
+    },
+    "country": "United States"
   },
   {
     "name": "Florida International",
-    "url": "http://ezproxy.fiu.edu/login?url=$@"
+    "url": "http://ezproxy.fiu.edu/login?url=",
+    "location": {
+      "lng": -80.3755401,
+      "lat": 25.7562465
+    },
+    "country": "United States"
   },
   {
     "name": "Florida International University",
-    "url": "https://login.ezproxy.fiu.edu/login?url=$@"
+    "url": "https://login.ezproxy.fiu.edu/login?url=",
+    "location": {
+      "lng": -80.3755401,
+      "lat": 25.7562465
+    },
+    "country": "United States"
   },
   {
     "name": "Florida Southern",
-    "url": "http://ezproxy.flsouthern.edu:2048/login?url=$@"
+    "url": "http://ezproxy.flsouthern.edu:2048/login?url=",
+    "location": {
+      "lng": -81.9450401,
+      "lat": 28.0314545
+    },
+    "country": "United States"
   },
   {
     "name": "Florida State",
-    "url": "https://login.proxy.lib.fsu.edu/login?url=$@"
+    "url": "https://login.proxy.lib.fsu.edu/login?url=",
+    "location": {
+      "lng": -81.5157535,
+      "lat": 27.6648274
+    },
+    "country": "United States"
   },
   {
     "name": "Fordham University",
-    "url": "https://avoserv.library.fordham.edu/login?url=$@"
+    "url": "https://avoserv.library.fordham.edu/login?url=",
+    "location": {
+      "lng": -73.8852771,
+      "lat": 40.8614567
+    },
+    "country": "United States"
   },
   {
     "name": "Fort Hays State",
-    "url": "http://ezproxy.fhsu.edu:2048/login?url=$@"
+    "url": "http://ezproxy.fhsu.edu:2048/login?url=",
+    "location": {
+      "lng": -99.3444887,
+      "lat": 38.8714463
+    },
+    "country": "United States"
   },
   {
     "name": "Fort Lewis",
-    "url": "https://fortlewis.idm.oclc.org/login?url=$@"
+    "url": "https://fortlewis.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -107.8711817,
+      "lat": 37.27368999999999
+    },
+    "country": "United States"
   },
   {
     "name": "Francis Marion",
-    "url": "http://fmarion.idm.oclc.org/login?url=$@"
+    "url": "http://fmarion.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -79.6519849,
+      "lat": 34.1904251
+    },
+    "country": "United States"
   },
   {
-    "name": "Franklin",
-    "url": "https://ezproxy.franklincollege.edu/login?url=$@"
+    "name": "Franklin College",
+    "url": "https://ezproxy.franklincollege.edu/login?url=",
+    "location": {
+      "lng": -86.04544828787014,
+      "lat": 39.478843608085185
+    },
+    "country": "United States"
   },
   {
     "name": "Franklin Marshall",
-    "url": "http://auth.illiad.oclc.org:2048/login?url=$@"
+    "url": "http://auth.illiad.oclc.org:2048/login?url=",
+    "location": {
+      "lng": -76.3199261,
+      "lat": 40.04874
+    },
+    "country": "United States"
   },
   {
     "name": "Fred Hutchinson Cancer Research Center",
-    "url": "https://login.fhcrc.idm.oclc.org/login?url=$@"
+    "url": "https://login.fhcrc.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.3314858,
+      "lat": 47.6272634
+    },
+    "country": "United States"
   },
   {
     "name": "Free University Bozen Bolzano",
-    "url": "http://libproxy.unibz.it/login?url=$@"
+    "url": "http://libproxy.unibz.it/login?url=",
+    "location": {
+      "lng": 11.3507102,
+      "lat": 46.4984534
+    },
+    "country": "Italy"
   },
   {
     "name": "Fuller Theological Seminary",
-    "url": "http://proxy.fuller.edu:2048/login?url=$@"
+    "url": "http://proxy.fuller.edu:2048/login?url=",
+    "location": {
+      "lng": -118.1404425,
+      "lat": 34.1482032
+    },
+    "country": "United States"
   },
   {
     "name": "Furman",
-    "url": "https://login.libproxy.furman.edu/login?url=$@"
+    "url": "https://login.libproxy.furman.edu/login?url=",
+    "location": {
+      "lng": -82.4400679,
+      "lat": 34.9274741
+    },
+    "country": "United States"
   },
   {
     "name": "Gadjah Mada University",
-    "url": "http://ezproxy.ugm.ac.id/login?url=$@"
+    "url": "http://ezproxy.ugm.ac.id/login?url=",
+    "location": {
+      "lng": 110.3774998,
+      "lat": -7.7713847
+    },
+    "country": "Indonesia"
   },
   {
     "name": "Gavilan College",
-    "url": "http://ezproxy.gavilan.edu/login?url=$@"
+    "url": "http://ezproxy.gavilan.edu/login?url=",
+    "location": {
+      "lng": -121.5685598,
+      "lat": 36.9732557
+    },
+    "country": "United States"
   },
   {
     "name": "Geneva University",
-    "url": "http://proxy-geneva.klnpa.org/login?url=$@"
+    "url": "http://proxy-geneva.klnpa.org/login?url=",
+    "location": {
+      "lng": 6.1451157,
+      "lat": 46.199444
+    },
+    "country": "Switzerland"
   },
   {
     "name": "George Fox",
-    "url": "https://georgefox.idm.oclc.org/login?url=$@"
+    "url": "https://georgefox.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.9667381,
+      "lat": 45.3033817
+    },
+    "country": "United States"
   },
   {
     "name": "George Mason University",
-    "url": "http://mutex.gmu.edu/login?url=$@"
+    "url": "http://mutex.gmu.edu/login?url=",
+    "location": {
+      "lng": -77.31174709999999,
+      "lat": 38.8314578
+    },
+    "country": "United States"
   },
   {
     "name": "George Washington University Law School",
-    "url": "https://gwlaw.idm.oclc.org/login?url=$@"
+    "url": "https://gwlaw.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -77.0457907,
+      "lat": 38.8985596
+    },
+    "country": "United States"
   },
   {
     "name": "Georgetown",
-    "url": "http://ezproxy.georgetowncollege.edu:2048/login?url=$@"
+    "url": "http://ezproxy.georgetowncollege.edu:2048/login?url=",
+    "location": {
+      "lng": -77.06535650000001,
+      "lat": 38.9097057
+    },
+    "country": "United States"
   },
   {
     "name": "Georgetown University",
-    "url": "http://proxy.library.georgetown.edu/login?url=$@"
+    "url": "http://proxy.library.georgetown.edu/login?url=",
+    "location": {
+      "lng": -77.07225849999999,
+      "lat": 38.9076089
+    },
+    "country": "United States"
   },
   {
     "name": "Georgia Institute of Technology",
-    "url": "http://prx.library.gatech.edu/login?url=$@"
+    "url": "http://prx.library.gatech.edu/login?url=",
+    "location": {
+      "lng": -84.39628499999999,
+      "lat": 33.7756178
+    },
+    "country": "United States"
   },
   {
     "name": "Georgia Southern",
-    "url": "http://libez.lib.georgiasouthern.edu:2048/login?url=$@"
+    "url": "http://libez.lib.georgiasouthern.edu:2048/login?url=",
+    "location": {
+      "lng": -81.7842919,
+      "lat": 32.4196512
+    },
+    "country": "United States"
   },
   {
     "name": "Georgia Tech",
-    "url": "http://www.library.gatech.edu:2048/login?url=$@"
+    "url": "http://www.library.gatech.edu:2048/login?url=",
+    "location": {
+      "lng": -84.39628499999999,
+      "lat": 33.7756178
+    },
+    "country": "United States"
   },
   {
     "name": "Glasgow Caledonian",
-    "url": "https://gcu.idm.oclc.org/login?url=$@"
+    "url": "https://gcu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -4.249960199999999,
+      "lat": 55.8668183
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Glendale",
-    "url": "http://libproxy.gc.maricopa.edu/login?url=$@"
+    "url": "http://libproxy.gc.maricopa.edu/login?url=",
+    "location": {
+      "lng": -118.255075,
+      "lat": 34.1425078
+    },
+    "country": "United States"
   },
   {
     "name": "God's Bible School and College",
-    "url": "http://www.ezproxy.gbs.edu:2048/login?url=$@"
+    "url": "http://www.ezproxy.gbs.edu:2048/login?url=",
+    "location": {
+      "lng": -84.5055938,
+      "lat": 39.1157219
+    },
+    "country": "United States"
   },
   {
     "name": "Goethe-Uni Frankfurt am Main",
-    "url": "http://proxy.ub.uni-frankfurt.de/login?url=$@"
+    "url": "http://proxy.ub.uni-frankfurt.de/login?url=",
+    "location": {
+      "lng": 8.6677635,
+      "lat": 50.1270675
+    },
+    "country": "Germany"
   },
   {
     "name": "Gordon-Conwell Theological Seminary",
-    "url": "http://proxy.gordonconwell.edu/login?url=$@"
+    "url": "http://proxy.gordonconwell.edu/login?url=",
+    "location": {
+      "lng": -70.8450204,
+      "lat": 42.6124501
+    },
+    "country": "United States"
   },
   {
     "name": "Goshen",
-    "url": "https://ezproxy.goshen.edu/login?url=$@"
+    "url": "https://ezproxy.goshen.edu/login?url=",
+    "location": {
+      "lng": -85.83456389999999,
+      "lat": 41.5891606
+    },
+    "country": "United States"
   },
   {
     "name": "Grand Canyon",
-    "url": "https://lopes.idm.oclc.org/login?url=$@"
+    "url": "https://lopes.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -112.3535253,
+      "lat": 36.2678855
+    },
+    "country": "United States"
   },
   {
     "name": "Grand Valley State",
-    "url": "http://ezproxy.gvsu.edu/login?url=$@"
+    "url": "http://ezproxy.gvsu.edu/login?url=",
+    "location": {
+      "lng": -85.8890404,
+      "lat": 42.9641221
+    },
+    "country": "United States"
   },
   {
     "name": "Grand Valley State University",
-    "url": "https://login.ezproxy.gvsu.edu/login?url=$@"
+    "url": "https://login.ezproxy.gvsu.edu/login?url=",
+    "location": {
+      "lng": -85.8890404,
+      "lat": 42.9641221
+    },
+    "country": "United States"
   },
   {
     "name": "Grays Harbor",
-    "url": "http://ezproxy.ghc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.ghc.edu:2048/login?url=",
+    "location": {
+      "lng": -123.7012468,
+      "lat": 46.9953526
+    },
+    "country": "United States"
   },
   {
     "name": "Great Basin College",
-    "url": "http://library.gbcnv.edu:2048/login?url=$@"
+    "url": "http://library.gbcnv.edu:2048/login?url=",
+    "location": {
+      "lng": -115.7671347,
+      "lat": 40.8425713
+    },
+    "country": "United States"
   },
   {
     "name": "Griffith Univsity",
-    "url": "http://libraryproxy.griffith.edu.au/login?url=$@"
+    "url": "http://libraryproxy.griffith.edu.au/login?url=",
+    "location": {
+      "lng": 136.06403838387402,
+      "lat": -30.904027644443286
+    },
+    "country": "Australia"
   },
   {
     "name": "Grinnell",
-    "url": "https://grinnell.idm.oclc.org/login?url=$@"
+    "url": "https://grinnell.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -92.7232456,
+      "lat": 41.74340919999999
+    },
+    "country": "United States"
   },
   {
     "name": "Guilford Technical",
-    "url": "http://ezproxy.gtcc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.gtcc.edu:2048/login?url=",
+    "location": {
+      "lng": -79.9191627,
+      "lat": 35.9981517
+    },
+    "country": "United States"
   },
   {
     "name": "Halmstad University",
-    "url": "https://ezproxy.bib.hh.se/login?url=$@"
+    "url": "https://ezproxy.bib.hh.se/login?url=",
+    "location": {
+      "lng": 12.8780003,
+      "lat": 56.66467400000001
+    },
+    "country": "Sweden"
   },
   {
     "name": "Hamilton",
-    "url": "http://ez.hamilton.edu:2048/login?url=$@"
+    "url": "http://ez.hamilton.edu:2048/login?url=",
+    "location": {
+      "lng": -75.40602017163035,
+      "lat": 43.052927735089526
+    },
+    "country": "United States"
   },
   {
     "name": "Hamline",
-    "url": "http://ezproxy.hamline.edu:2048/login?url=$@"
+    "url": "http://ezproxy.hamline.edu:2048/login?url=",
+    "location": {
+      "lng": -93.1644153,
+      "lat": 44.9650421
+    },
+    "country": "United States"
   },
   {
     "name": "Hardin-Simmons",
-    "url": "http://ezproxy.hsutx.edu:2048/login?url=$@"
+    "url": "http://ezproxy.hsutx.edu:2048/login?url=",
+    "location": {
+      "lng": -99.7340564,
+      "lat": 32.4768502
+    },
+    "country": "United States"
   },
   {
     "name": "Harding School of Theology",
-    "url": "http://ezproxy-hst.harding.edu:2048/login?url=$@"
+    "url": "http://ezproxy-hst.harding.edu:2048/login?url=",
+    "location": {
+      "lng": -89.9135055,
+      "lat": 35.1044006
+    },
+    "country": "United States"
   },
   {
     "name": "Harrisburg University",
-    "url": "http://proxy-harrisburg.klnpa.org/login?url=$@"
+    "url": "http://proxy-harrisburg.klnpa.org/login?url=",
+    "location": {
+      "lng": -76.8802144,
+      "lat": 40.2621191
+    },
+    "country": "United States"
   },
   {
     "name": "Hartford Seminiary",
-    "url": "http://ezproxy.hartsem.edu/login?url=$@"
+    "url": "http://ezproxy.hartsem.edu/login?url=",
+    "location": {
+      "lng": -72.7077092,
+      "lat": 41.7698571
+    },
+    "country": "United States"
   },
   {
     "name": "Hartwick",
-    "url": "http://ezproxy.hartwick.edu:2048/login?url=$@"
+    "url": "http://ezproxy.hartwick.edu:2048/login?url=",
+    "location": {
+      "lng": -75.0718461,
+      "lat": 42.4586674
+    },
+    "country": "United States"
   },
   {
     "name": "Harvard University",
-    "url": "http://ezp-prod1.hul.harvard.edu/login?url=$@"
+    "url": "http://ezp-prod1.hul.harvard.edu/login?url=",
+    "location": {
+      "lng": -71.116936,
+      "lat": 42.3768943
+    },
+    "country": "United States"
   },
   {
     "name": "Haverford",
-    "url": "https://ezproxy.haverford.edu/login?url=$@"
+    "url": "https://ezproxy.haverford.edu/login?url=",
+    "location": {
+      "lng": -75.3208107,
+      "lat": 40.0022406
+    },
+    "country": "United States"
   },
   {
     "name": "Haverford College",
-    "url": "https://www.ezproxy.haverford.edu/login?url=$@"
+    "url": "https://www.ezproxy.haverford.edu/login?url=",
+    "location": {
+      "lng": -75.3051299,
+      "lat": 40.00744230000001
+    },
+    "country": "United States"
   },
   {
     "name": "HEC Montreal",
-    "url": "http://proxy2.hec.ca/login?url=$@"
+    "url": "http://proxy2.hec.ca/login?url=",
+    "location": {
+      "lng": -73.6211174,
+      "lat": 45.5035488
+    },
+    "country": "Canada"
   },
   {
     "name": "HEC Paris",
-    "url": "http://ezproxy.hec.fr/login?url=$@"
+    "url": "http://ezproxy.hec.fr/login?url=",
+    "location": {
+      "lng": 2.1687971,
+      "lat": 48.7570776
+    },
+    "country": "France"
   },
   {
     "name": "HEIG-VD",
-    "url": "https://biblioproxy.heig-vd.ch/login?url=$@"
+    "url": "https://biblioproxy.heig-vd.ch/login?url=",
+    "location": {
+      "lng": 6.6473097,
+      "lat": 46.7812274
+    },
+    "country": "Switzerland"
   },
   {
     "name": "Hellenic Open University (EAP)",
-    "url": "http://proxy.eap.gr/login?url=$@"
+    "url": "http://proxy.eap.gr/login?url=",
+    "location": {
+      "lng": 21.767111,
+      "lat": 38.206531
+    },
+    "country": "Greece"
   },
   {
     "name": "HELP University",
-    "url": "https://ezproxy.help.edu.my/login?url=$@"
+    "url": "https://ezproxy.help.edu.my/login?url=",
+    "location": {
+      "lng": 101.670172,
+      "lat": 3.1515226
+    },
+    "country": "Malaysia"
   },
   {
     "name": "Helsingin yliopisto",
-    "url": "http://libproxy.helsinki.fi/login?url=$@"
+    "url": "http://libproxy.helsinki.fi/login?url=",
+    "location": {
+      "lng": 24.9510419,
+      "lat": 60.1726348
+    },
+    "country": "Finland"
   },
   {
     "name": "Henderson State",
-    "url": "http://library.hsu.edu:2048/login?url=$@"
+    "url": "http://library.hsu.edu:2048/login?url=",
+    "location": {
+      "lng": -93.06025729999999,
+      "lat": 34.1299174
+    },
+    "country": "United States"
   },
   {
     "name": "Heriot-Watt University",
-    "url": "https://ezproxy1.hw.ac.uk/login?url=$@"
+    "url": "https://ezproxy1.hw.ac.uk/login?url=",
+    "location": {
+      "lng": -3.3216711,
+      "lat": 55.9111604
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Heriot-Watt University Edinburgh",
-    "url": "http://ezproxy1.hw.ac.uk:2048/login?url=$@"
+    "url": "http://ezproxy1.hw.ac.uk:2048/login?url=",
+    "location": {
+      "lng": -3.3216711,
+      "lat": 55.9111604
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Highline",
-    "url": "http://moe.ic.highline.edu:2048/login?url=$@"
+    "url": "http://moe.ic.highline.edu:2048/login?url=",
+    "location": {
+      "lng": -74.0047649,
+      "lat": 40.7479925
+    },
+    "country": "United States"
   },
   {
     "name": "Hiram",
-    "url": "http://ezproxy.hiram.edu/login?url=$@"
+    "url": "http://ezproxy.hiram.edu/login?url=",
+    "location": {
+      "lng": -81.1437098,
+      "lat": 41.3125552
+    },
+    "country": "United States"
   },
   {
     "name": "Hofstra University",
-    "url": "http://ezproxy.hofstra.edu/login?url=$@"
+    "url": "http://ezproxy.hofstra.edu/login?url=",
+    "location": {
+      "lng": -73.5993965,
+      "lat": 40.7166872
+    },
+    "country": "United States"
   },
   {
     "name": "Hogeschool Rotterdam",
-    "url": "http://ezproxy.hro.nl/login?url=$@"
+    "url": "http://ezproxy.hro.nl/login?url=",
+    "location": {
+      "lng": 4.4636372,
+      "lat": 51.9100039
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Hokkaido University",
-    "url": "https://login.ezoris.lib.hokudai.ac.jp/login?url=$@"
+    "url": "https://login.ezoris.lib.hokudai.ac.jp/login?url=",
+    "location": {
+      "lng": 141.340013,
+      "lat": 43.0779575
+    },
+    "country": "Japan"
   },
   {
     "name": "Holland",
-    "url": "https://rpa.hollandcollege.com:2048/login?url=$@"
+    "url": "https://rpa.hollandcollege.com:2048/login?url=",
+    "location": {
+      "lng": 5.291265999999999,
+      "lat": 52.132633
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Holy Family",
-    "url": "http://holyfamily.idm.oclc.org/login?url=$@"
+    "url": "http://holyfamily.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -75.00162943433621,
+      "lat": 40.126963450134426
+    },
+    "country": "United States"
   },
   {
     "name": "Hong Kong Baptist University",
-    "url": "https://lib-ezproxy.hkbu.edu.hk/login?url=$@"
+    "url": "https://lib-ezproxy.hkbu.edu.hk/login?url=",
+    "location": {
+      "lng": 114.1798757,
+      "lat": 22.3408088
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "Hong Kong Institute of Vocational Education",
-    "url": "http://eproxy.vtclib9.vtc.edu.hk:2048/login?url=$@"
+    "url": "http://eproxy.vtclib9.vtc.edu.hk:2048/login?url=",
+    "location": {
+      "lng": 114.177926,
+      "lat": 22.276239
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "Hong Kong Metropolitan University",
-    "url": "https://ezproxy.lib.hkmu.edu.hk/login?url=$@"
+    "url": "https://ezproxy.lib.hkmu.edu.hk/login?url=",
+    "location": {
+      "lng": 114.1801817,
+      "lat": 22.3163552
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "Hong Kong Public Libraries",
-    "url": "https://ezproxy.hkpl.gov.hk/login?url=$@"
+    "url": "https://ezproxy.hkpl.gov.hk/login?url=",
+    "location": {
+      "lng": 114.1693611,
+      "lat": 22.3193039
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "Hong Kong University of Science and Technology",
-    "url": "https://lib.ezproxy.ust.hk/login?url=$@"
+    "url": "https://lib.ezproxy.ust.hk/login?url=",
+    "location": {
+      "lng": 114.2654655,
+      "lat": 22.3363998
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "Hood College",
-    "url": "http://taurus.hood.edu:2048/login?url=$@"
+    "url": "http://taurus.hood.edu:2048/login?url=",
+    "location": {
+      "lng": -77.41890870325902,
+      "lat": 39.422899735458714
+    },
+    "country": ""
   },
   {
     "name": "Hope College",
-    "url": "https://login.ezproxy.hope.edu/login?url=$@"
+    "url": "https://login.ezproxy.hope.edu/login?url=",
+    "location": {
+      "lng": -86.1026663,
+      "lat": 42.7875308
+    },
+    "country": "United States"
   },
   {
     "name": "Houston Academy of Medicine - Texas Medical Center",
-    "url": "http://ezproxyhost.library.tmc.edu/login?url=$@"
+    "url": "http://ezproxyhost.library.tmc.edu/login?url=",
+    "location": {
+      "lng": -95.3967443,
+      "lat": 29.7118682
+    },
+    "country": "United States"
   },
   {
     "name": "Howard University",
-    "url": "https://proxyhu.wrlc.org/login?url=$@"
+    "url": "https://proxyhu.wrlc.org/login?url=",
+    "location": {
+      "lng": -77.0194377,
+      "lat": 38.9226843
+    },
+    "country": "United States"
   },
   {
     "name": "Huddersfield University",
-    "url": "http://librouter.hud.ac.uk/login?url=$@"
+    "url": "http://librouter.hud.ac.uk/login?url=",
+    "location": {
+      "lng": -1.7780981,
+      "lat": 53.64282850000001
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Hudson Valley",
-    "url": "http://proxy.hvcc.edu:2048/login?url=$@"
+    "url": "http://proxy.hvcc.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9612887,
+      "lat": 41.9209018
+    },
+    "country": "United States"
   },
   {
     "name": "Humboldt State University",
-    "url": "http://ezproxy.humboldt.edu/login?url=$@"
+    "url": "http://ezproxy.humboldt.edu/login?url=",
+    "location": {
+      "lng": -124.0789268,
+      "lat": 40.8747332
+    },
+    "country": "United States"
   },
   {
     "name": "Høgskolen i Innlandet",
-    "url": "http://ezproxy.inn.no/login?url=$@"
+    "url": "http://ezproxy.inn.no/login?url=",
+    "location": {
+      "lng": 11.074194,
+      "lat": 60.7963798
+    },
+    "country": "Norway"
   },
   {
     "name": "Høgskulen på Vestlandet",
-    "url": "https://login.galanga.hvl.no/login?url=$@"
+    "url": "https://login.galanga.hvl.no/login?url=",
+    "location": {
+      "lng": 5.350094299999999,
+      "lat": 60.3689499
+    },
+    "country": "Norway"
   },
   {
     "name": "Ibn Haldun University Library",
-    "url": "https://offcampus.ihu.edu.tr/login?url=$@"
+    "url": "https://offcampus.ihu.edu.tr/login?url=",
+    "location": {
+      "lng": 28.7968759,
+      "lat": 41.1385303
+    },
+    "country": "Türkiye"
   },
   {
     "name": "Idaho College of Osteopathic Medicine",
-    "url": "https://icom.idm.oclc.org/login?url=$@"
+    "url": "https://icom.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -116.3766313,
+      "lat": 43.5948543
+    },
+    "country": "United States"
   },
   {
     "name": "Idaho State",
-    "url": "http://libpublic3.library.isu.edu/login?url=$@"
+    "url": "http://libpublic3.library.isu.edu/login?url=",
+    "location": {
+      "lng": -114.7420408,
+      "lat": 44.0682019
+    },
+    "country": "United States"
   },
   {
     "name": "IIT Chicago-Kent College of Law",
-    "url": "http://libproxy.kentlaw.edu/login?url=$@"
+    "url": "http://libproxy.kentlaw.edu/login?url=",
+    "location": {
+      "lng": -87.6423118,
+      "lat": 41.8788582
+    },
+    "country": "United States"
   },
   {
     "name": "IIT Italian Institute of Technology",
-    "url": "https://login.biblio.iit.it/login?url=$@"
+    "url": "https://login.biblio.iit.it/login?url=",
+    "location": {
+      "lng": 12.56738,
+      "lat": 41.87194
+    },
+    "country": "Italy"
   },
   {
     "name": "Illinois Institute of Technology",
-    "url": "https://ezproxy.gl.iit.edu/login?url=$@"
+    "url": "https://ezproxy.gl.iit.edu/login?url=",
+    "location": {
+      "lng": -87.6270059,
+      "lat": 41.8348731
+    },
+    "country": "United States"
   },
   {
     "name": "Illinois State University",
-    "url": "http://sfx.carli.illinois.edu/login?url=$@"
+    "url": "http://sfx.carli.illinois.edu/login?url=",
+    "location": {
+      "lng": -88.99476299999999,
+      "lat": 40.5121009
+    },
+    "country": "United States"
   },
   {
     "name": "Illinois Valley",
-    "url": "http://ezproxy.ivcc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.ivcc.edu:2048/login?url=",
+    "location": {
+      "lng": -89.3985283,
+      "lat": 40.6331249
+    },
+    "country": "United States"
   },
   {
     "name": "Imperial College London",
-    "url": "https://login.iclibezp1.cc.ic.ac.uk/login?url=$@"
+    "url": "https://login.iclibezp1.cc.ic.ac.uk/login?url=",
+    "location": {
+      "lng": -0.1748735,
+      "lat": 51.49882220000001
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Indiana State",
-    "url": "http://ezproxy.indstate.edu:2048/login?url=$@"
+    "url": "http://ezproxy.indstate.edu:2048/login?url=",
+    "location": {
+      "lng": -86.1349019,
+      "lat": 40.2671941
+    },
+    "country": "United States"
   },
   {
     "name": "Indiana University",
-    "url": "http://proxyiub.uits.iu.edu/login?url=$@"
+    "url": "http://proxyiub.uits.iu.edu/login?url=",
+    "location": {
+      "lng": -86.52300729999999,
+      "lat": 39.1682449
+    },
+    "country": "United States"
   },
   {
     "name": "Indiana University of Pennsylvania",
-    "url": "http://proxy-iup.klnpa.org/login?url=$@"
+    "url": "http://proxy-iup.klnpa.org/login?url=",
+    "location": {
+      "lng": -79.1610224,
+      "lat": 40.6143979
+    },
+    "country": "United States"
   },
   {
     "name": "Indiana University Purdue University Indianapolis",
-    "url": "http://proxy.ulib.iupui.edu/login?url=$@"
+    "url": "http://proxy.ulib.iupui.edu/login?url=",
+    "location": {
+      "lng": -86.1772798,
+      "lat": 39.7749927
+    },
+    "country": "United States"
   },
   {
     "name": "Indiana University School of Medicine",
-    "url": "https://proxy.medlib.iupui.edu/login?url=$@"
+    "url": "https://proxy.medlib.iupui.edu/login?url=",
+    "location": {
+      "lng": -86.16517139999999,
+      "lat": 39.7815613
+    },
+    "country": "United States"
   },
   {
     "name": "INFLIBNET Centre (Information and Library Network Centre)",
-    "url": "http://nlist.inflibnet.ac.in:2048/login?url=$@"
+    "url": "http://nlist.inflibnet.ac.in:2048/login?url=",
+    "location": {
+      "lng": 72.63325296349466,
+      "lat": 23.18932292611307
+    },
+    "country": ""
   },
   {
     "name": "INSA de Rennes",
-    "url": "http://rproxy.insa-rennes.fr/login?url=$@"
+    "url": "http://rproxy.insa-rennes.fr/login?url=",
+    "location": {
+      "lng": -1.635663,
+      "lat": 48.12085219999999
+    },
+    "country": "France"
   },
   {
     "name": "Institut de l'Information Scientifique et Technique (INSERM)",
-    "url": "https://proxy.insermbiblio.inist.fr/login?url=$@"
+    "url": "https://proxy.insermbiblio.inist.fr/login?url=",
+    "location": {
+      "lng": 6.149990421500785,
+      "lat": 48.65538067074214
+    },
+    "country": "France"
   },
   {
     "name": "Institut national de la recherche scientifique",
-    "url": "http://erable.inrs.ca:2048/login?url=$@"
+    "url": "http://erable.inrs.ca:2048/login?url=",
+    "location": {
+      "lng": -71.21573520705446,
+      "lat": 46.86790358778025
+    },
+    "country": "Canada"
   },
   {
     "name": "Institut National des Sciences Appliquées  - Toulouse",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
+    "url": "https://gorgone.univ-toulouse.fr/login?url=",
+    "location": {
+      "lng": 1.4680904,
+      "lat": 43.5703326
+    },
+    "country": "France"
   },
   {
     "name": "Institut National Polytechnique - Toulouse",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
+    "url": "https://gorgone.univ-toulouse.fr/login?url=",
+    "location": {
+      "lng": 1.5039621,
+      "lat": 43.5554249
+    },
+    "country": "France"
   },
   {
     "name": "Institut national universitaire Jean-François - Champollion",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
+    "url": "https://gorgone.univ-toulouse.fr/login?url=",
+    "location": {
+      "lng": 2.138535,
+      "lat": 43.91945279999999
+    },
+    "country": "France"
   },
   {
     "name": "Institute of American Indian Arts",
-    "url": "http://pro.iaia.edu:2048/login?url=$@"
+    "url": "http://pro.iaia.edu:2048/login?url=",
+    "location": {
+      "lng": -106.0100577,
+      "lat": 35.5870573
+    },
+    "country": "United States"
   },
   {
     "name": "Institute of Cancer Research",
-    "url": "https://ezproxy.icr.ac.uk/login?url=$@"
+    "url": "https://ezproxy.icr.ac.uk/login?url=",
+    "location": {
+      "lng": -0.1892491,
+      "lat": 51.3440949
+    },
+    "country": "United Kingdom"
+  },
+  {
+    "name": "Institute of Technology (Unitec)",
+    "url": "http://libproxy.unitec.ac.nz/login?url=",
+    "location": {
+      "lng": 174.7090215575075,
+      "lat": -36.88129537066539
+    },
+    "country": "New Zealand"
   },
   {
     "name": "Institute of Technology Sligo",
-    "url": "http://ezproxy.library.itsligo.ie:2048/login?url=$@"
+    "url": "http://ezproxy.library.itsligo.ie:2048/login?url=",
+    "location": {
+      "lng": -8.461323,
+      "lat": 54.2791632
+    },
+    "country": "Ireland"
   },
   {
-    "name": "Institute of Technology（Unitec）",
-    "url": "http://libproxy.unitec.ac.nz/login?url=$@"
-  },
-  {
-    "name": "Instituto Tecnológico y de Estudios Superiores de Occidente（ITESO）",
-    "url": "http://ezproxy.iteso.mx/login?url=$@"
+    "name": "Instituto Tecnológico y de Estudios Superiores de Occidente (ITESO)",
+    "url": "http://ezproxy.iteso.mx/login?url=",
+    "location": {
+      "lng": -103.4146601,
+      "lat": 20.6083796
+    },
+    "country": "Mexico"
   },
   {
     "name": "International Medical University Malaysia",
-    "url": "http://ezp.imu.edu.my/login?url=$@"
+    "url": "http://ezp.imu.edu.my/login?url=",
+    "location": {
+      "lng": 101.68720503060177,
+      "lat": 3.060037457138748
+    },
+    "country": "Malaysia"
   },
   {
     "name": "Iowa State University",
-    "url": "http://proxy.lib.iastate.edu:2048/login?url=$@"
+    "url": "http://proxy.lib.iastate.edu:2048/login?url=",
+    "location": {
+      "lng": -93.64645159999999,
+      "lat": 42.0266573
+    },
+    "country": "United States"
   },
   {
     "name": "Isik University",
-    "url": "http://ezp.isikun.edu.tr/login?url=$@"
+    "url": "http://ezp.isikun.edu.tr/login?url=",
+    "location": {
+      "lng": 29.5639972,
+      "lat": 41.16889949999999
+    },
+    "country": "Türkiye"
   },
   {
     "name": "IT University of Copenhagen",
-    "url": "https://ep.ituproxy.kb.dk/login?url=$@"
+    "url": "https://ep.ituproxy.kb.dk/login?url=",
+    "location": {
+      "lng": 12.590958,
+      "lat": 55.65963499999999
+    },
+    "country": "Denmark"
   },
   {
     "name": "Ita-Suomen yliopisto",
-    "url": "http://ezproxy.uef.fi:2048/login?url=$@"
+    "url": "http://ezproxy.uef.fi:2048/login?url=",
+    "location": {
+      "lng": 27.6327062,
+      "lat": 62.89027650000001
+    },
+    "country": "Finland"
   },
   {
     "name": "Ithaca",
-    "url": "https://login.ezproxy.ithaca.edu/login?qurl=$@"
+    "url": "https://login.ezproxy.ithaca.edu/login?qurl=",
+    "location": {
+      "lng": -76.5018807,
+      "lat": 42.4439614
+    },
+    "country": "United States"
   },
   {
     "name": "IUCAA",
-    "url": "http://ezproxy.iucaa.ernet.in:2048/login?url=$@"
+    "url": "http://ezproxy.iucaa.ernet.in:2048/login?url=",
+    "location": {
+      "lng": 73.8253115,
+      "lat": 18.5592415
+    },
+    "country": "India"
   },
   {
     "name": "Ivy Tech",
-    "url": "http://allstate.libproxy.ivytech.edu/login?url=$@"
+    "url": "http://allstate.libproxy.ivytech.edu/login?url=",
+    "location": {
+      "lng": -84.8466298,
+      "lat": 39.0924828
+    },
+    "country": "United States"
   },
   {
     "name": "Iwate Medical",
-    "url": "http://ej.iwate-med.ac.jp:2048/login?url=$@"
+    "url": "http://ej.iwate-med.ac.jp:2048/login?url=",
+    "location": {
+      "lng": 141.1623651,
+      "lat": 39.6109273
+    },
+    "country": "Japan"
   },
   {
     "name": "İzmir Institute of Technology",
-    "url": "http://libezproxy.iyte.edu.tr:81/login?url=$@"
+    "url": "http://libezproxy.iyte.edu.tr:81/login?url=",
+    "location": {
+      "lng": 26.6432058,
+      "lat": 38.3190947
+    },
+    "country": "Türkiye"
   },
   {
     "name": "Jackson State",
-    "url": "http://ezproxy.jscc.edu/login?url=$@"
+    "url": "http://ezproxy.jscc.edu/login?url=",
+    "location": {
+      "lng": -90.2063989,
+      "lat": 32.2968882
+    },
+    "country": "United States"
   },
   {
     "name": "James Cook University",
-    "url": "http://elibrary.jcu.edu.au/login?url=$@"
+    "url": "http://elibrary.jcu.edu.au/login?url=",
+    "location": {
+      "lng": 146.7566603,
+      "lat": -19.3258585
+    },
+    "country": "Australia"
   },
   {
-    "name": "Jawaharlal Nehru Technological University",
-    "url": "http://ezproxy.jntu.edu/login?irl=$@"
+    "name": "Jawaharlal Nehru Technological University ",
+    "url": "http://ezproxy.jntu.edu/login?irl=",
+    "location": {
+      "lng": 78.3913929,
+      "lat": 17.4932682
+    },
+    "country": "India"
   },
   {
     "name": "Jawaharlal Nehru University",
-    "url": "http://ezproxy.jnu.ac.in/login?url=$@"
+    "url": "http://ezproxy.jnu.ac.in/login?url=",
+    "location": {
+      "lng": 77.1664047,
+      "lat": 28.5398035
+    },
+    "country": "India"
   },
   {
     "name": "Jefferson College",
-    "url": "http://lib-proxy.jeffco.edu:2048/login?url=$@"
+    "url": "http://lib-proxy.jeffco.edu:2048/login?url=",
+    "location": {
+      "lng": -90.55972803191268,
+      "lat": 38.259432789864434
+    },
+    "country": "United States"
   },
   {
     "name": "John Jay College of Criminal Justice",
-    "url": "https://login.ez.lib.jjay.cuny.edu/login?url=$@"
+    "url": "https://login.ez.lib.jjay.cuny.edu/login?url=",
+    "location": {
+      "lng": -73.9892342,
+      "lat": 40.7707237
+    },
+    "country": "United States"
   },
   {
     "name": "John Marshall Law School",
-    "url": "http://ezproxy.jmls.edu:2048/login?url=$@"
+    "url": "http://ezproxy.jmls.edu:2048/login?url=",
+    "location": {
+      "lng": -87.628064,
+      "lat": 41.877932
+    },
+    "country": "United States"
   },
   {
     "name": "Johns Hopkins",
-    "url": "http://proxy.library.jhu.edu/login?url=$@"
+    "url": "http://proxy.library.jhu.edu/login?url=",
+    "location": {
+      "lng": -76.6205177,
+      "lat": 39.3299013
+    },
+    "country": "United States"
   },
   {
     "name": "Johns Hopkins University School of Medicine",
-    "url": "https://ezproxy.welch.jhmi.edu/login?url=$@"
+    "url": "https://ezproxy.welch.jhmi.edu/login?url=",
+    "location": {
+      "lng": -76.5933799,
+      "lat": 39.2992161
+    },
+    "country": "United States"
   },
   {
     "name": "Johnson C Smith",
-    "url": "http://library.jcsu.edu:2048/login?url=$@"
+    "url": "http://library.jcsu.edu:2048/login?url=",
+    "location": {
+      "lng": -80.85579349999999,
+      "lat": 35.2433851
+    },
+    "country": "United States"
   },
   {
     "name": "Jonkoping",
-    "url": "https://login.bibl.proxy.hj.se/login?url=$@"
+    "url": "https://login.bibl.proxy.hj.se/login?url=",
+    "location": {
+      "lng": 14.1617876,
+      "lat": 57.78261370000001
+    },
+    "country": "Sweden"
   },
   {
     "name": "Julius-Maximilians-Uni Wurzburg",
-    "url": "http://ezproxy.bibliothek.uni-wuerzburg.de/login?url=$@"
+    "url": "http://ezproxy.bibliothek.uni-wuerzburg.de/login?url=",
+    "location": {
+      "lng": 9.93526,
+      "lat": 49.7881814
+    },
+    "country": "Germany"
   },
   {
     "name": "Jyvaskylan yliopisto",
-    "url": "http://ezproxy.jyu.fi/login?url=$@"
+    "url": "http://ezproxy.jyu.fi/login?url=",
+    "location": {
+      "lng": 25.7316335,
+      "lat": 62.23653170000001
+    },
+    "country": "Finland"
   },
   {
     "name": "Kadir Has University Library",
-    "url": "https://icproxy.khas.edu.tr/login?url=$@"
+    "url": "https://icproxy.khas.edu.tr/login?url=",
+    "location": {
+      "lng": 28.9589739,
+      "lat": 41.0249511
+    },
+    "country": "Türkiye"
   },
   {
     "name": "Kansas City University of Medicine and Biosciences",
-    "url": "http://proxy.kcumb.edu/login?url=$@"
+    "url": "http://proxy.kcumb.edu/login?url=",
+    "location": {
+      "lng": -94.5609759,
+      "lat": 39.1072822
+    },
+    "country": "United States"
   },
   {
     "name": "Kansas State",
-    "url": "http://er.lib.k-state.edu/login?url=$@"
+    "url": "http://er.lib.k-state.edu/login?url=",
+    "location": {
+      "lng": -96.5847249,
+      "lat": 39.1974437
+    },
+    "country": "United States"
   },
   {
     "name": "Kansas State University",
-    "url": "http://er.lib.ksu.edu/login?url=$@"
+    "url": "http://er.lib.ksu.edu/login?url=",
+    "location": {
+      "lng": -96.5847249,
+      "lat": 39.1974437
+    },
+    "country": "United States"
   },
   {
     "name": "Kaohsiung Medical University Hospital",
-    "url": "http://ezp.kmu.edu.tw/login?url=$@"
+    "url": "http://ezp.kmu.edu.tw/login?url=",
+    "location": {
+      "lng": 120.3095722,
+      "lat": 22.6460433
+    },
+    "country": "Taiwan"
   },
   {
     "name": "Karolinska Institutet University Library",
-    "url": "http://proxy.kib.ki.se/login?url=$@"
+    "url": "http://proxy.kib.ki.se/login?url=",
+    "location": {
+      "lng": 18.0236578,
+      "lat": 59.34814839999999
+    },
+    "country": "Sweden"
   },
   {
     "name": "Kean",
-    "url": "http://library.kean.edu:2048/login?url=$@"
+    "url": "http://library.kean.edu:2048/login?url=",
+    "location": {
+      "lng": -74.23311,
+      "lat": 40.6801659
+    },
+    "country": "United States"
   },
   {
     "name": "Keele University",
-    "url": "https://ezproxy.keele.ac.uk/login?url=$@"
+    "url": "https://ezproxy.keele.ac.uk/login?url=",
+    "location": {
+      "lng": -2.2721329,
+      "lat": 53.0029512
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Keiser University",
-    "url": "http://ezproxy.keiser.edu/login?url=$@"
+    "url": "http://ezproxy.keiser.edu/login?url=",
+    "location": {
+      "lng": -80.1640417,
+      "lat": 26.1859293
+    },
+    "country": "United States"
   },
   {
     "name": "Kennesaw State",
-    "url": "http://proxy.kennesaw.edu/login?url=$@"
+    "url": "http://proxy.kennesaw.edu/login?url=",
+    "location": {
+      "lng": -84.6154897,
+      "lat": 34.0234337
+    },
+    "country": "United States"
   },
   {
     "name": "Kent State University",
-    "url": "https://proxy.library.kent.edu/login?url=$@"
+    "url": "https://proxy.library.kent.edu/login?url=",
+    "location": {
+      "lng": -81.34331590000001,
+      "lat": 41.1497945
+    },
+    "country": "United States"
   },
   {
     "name": "Kettering College",
-    "url": "https://proxy.kc.edu/login?url=$@"
+    "url": "https://proxy.kc.edu/login?url=",
+    "location": {
+      "lng": -84.19249769999999,
+      "lat": 39.6949236
+    },
+    "country": "United States"
   },
   {
     "name": "Khalifa University",
-    "url": "https://login.libconnect.ku.ac.ae/login?url=$@"
+    "url": "https://login.libconnect.ku.ac.ae/login?url=",
+    "location": {
+      "lng": 54.3949088,
+      "lat": 24.4473556
+    },
+    "country": "United Arab Emirates"
   },
   {
     "name": "Khalifa University of Science, Technology, and Research",
-    "url": "http://ezproxy.kustar.ac.ae:2048/login?url=$@"
+    "url": "http://ezproxy.kustar.ac.ae:2048/login?url=",
+    "location": {
+      "lng": 55.3990626,
+      "lat": 25.3542829
+    },
+    "country": "United Arab Emirates"
   },
   {
     "name": "Khon Kaen University",
-    "url": "http://ezproxy.kku.ac.th/login?url=$@"
+    "url": "http://ezproxy.kku.ac.th/login?url=",
+    "location": {
+      "lng": 102.8219888,
+      "lat": 16.4739913
+    },
+    "country": "Thailand"
   },
   {
     "name": "Kilgore College",
-    "url": "http://ezproxy.wildcatter.kilgore.edu:2048/login?url=$@"
+    "url": "http://ezproxy.wildcatter.kilgore.edu:2048/login?url=",
+    "location": {
+      "lng": -94.8722513,
+      "lat": 32.37776760000001
+    },
+    "country": "United States"
   },
   {
     "name": "King Fahd University of Petroleum & Minerals (KFUPM)",
-    "url": "https://login.kfupm.idm.oclc.org/login?url=$@"
+    "url": "https://login.kfupm.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 50.1458938,
+      "lat": 26.3070624
+    },
+    "country": "Saudi Arabia"
   },
   {
     "name": "Kings College London",
-    "url": "http://libproxy.kcl.ac.uk/login?url=$@"
+    "url": "http://libproxy.kcl.ac.uk/login?url=",
+    "location": {
+      "lng": -0.115997,
+      "lat": 51.5114864
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Kings University",
-    "url": "http://ezproxy.aekc.talonline.ca/login?url=$@"
+    "url": "http://ezproxy.aekc.talonline.ca/login?url=",
+    "location": {
+      "lng": -97.1213015,
+      "lat": 32.9396261
+    },
+    "country": "United States"
   },
   {
     "name": "Knowledge Network (NHS Education for Scotland)",
-    "url": "https://knowledge.idm.oclc.org/login?url=$@"
+    "url": "https://knowledge.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -4.1913914,
+      "lat": 57.47676860000001
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Knox College",
-    "url": "http://ezproxy.knox.edu:2048/login?url=$@"
+    "url": "http://ezproxy.knox.edu:2048/login?url=",
+    "location": {
+      "lng": -90.37376334944817,
+      "lat": 40.953008245946066
+    },
+    "country": "United States"
   },
   {
     "name": "Koc School Libraries",
-    "url": "https://offcampus.koc.k12.tr/login?url=$@"
+    "url": "https://offcampus.koc.k12.tr/login?url=",
+    "location": {
+      "lng": 29.3581415,
+      "lat": 40.9185899
+    },
+    "country": "Türkiye"
   },
   {
     "name": "Korea",
-    "url": "http://library.korea.ac.kr/login?url=$@"
+    "url": "http://library.korea.ac.kr/login?url=",
+    "location": {
+      "lng": 127.766922,
+      "lat": 35.907757
+    },
+    "country": "South Korea"
   },
   {
     "name": "Korea University",
-    "url": "https://oca.korea.ac.kr/link.n2s?url=$@"
+    "url": "https://oca.korea.ac.kr/link.n2s?url=",
+    "location": {
+      "lng": 127.0277773,
+      "lat": 37.590799
+    },
+    "country": "South Korea"
   },
   {
     "name": "Kristiania University College",
-    "url": "http://egms.idm.oclc.org/login?url=$@"
+    "url": "http://egms.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 10.7460873,
+      "lat": 59.910952
+    },
+    "country": "Norway"
   },
   {
     "name": "KULeuven",
-    "url": "https://kuleuven.e-bronnen.be/login?url=$@"
+    "url": "https://kuleuven.e-bronnen.be/login?url=",
+    "location": {
+      "lng": 4.699705300000001,
+      "lat": 50.87809710000001
+    },
+    "country": "Belgium"
   },
   {
     "name": "Kungliga Tekniska Hogskolan",
-    "url": "http://focus.lib.kth.se/login?url=$@"
+    "url": "http://focus.lib.kth.se/login?url=",
+    "location": {
+      "lng": 18.0702566,
+      "lat": 59.3498706
+    },
+    "country": "Sweden"
   },
   {
     "name": "Kutztown University",
-    "url": "http://proxy-kutztown.klnpa.org/login?url=$@"
+    "url": "http://proxy-kutztown.klnpa.org/login?url=",
+    "location": {
+      "lng": -75.78336800000001,
+      "lat": 40.5100628
+    },
+    "country": "United States"
   },
   {
-    "name": "Kuyper College",
-    "url": "https://kuyper.idm.oclc.org/login?url=$@"
+    "name": "Kuyper College ",
+    "url": "https://kuyper.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -85.5920676,
+      "lat": 43.0221755
+    },
+    "country": "United States"
   },
   {
     "name": "Kuyper College Zondervan Library",
-    "url": "http://resources.kuyper.edu:2048/login?url=$@"
+    "url": "http://resources.kuyper.edu:2048/login?url=",
+    "location": {
+      "lng": -85.592714,
+      "lat": 43.022184
+    },
+    "country": "United States"
   },
   {
     "name": "Kyorin University",
-    "url": "https://ezproxy.kyorin-u.ac.jp/login?url=$@"
+    "url": "https://ezproxy.kyorin-u.ac.jp/login?url=",
+    "location": {
+      "lng": 139.5658488826429,
+      "lat": 35.67741634251354
+    },
+    "country": "Japan"
   },
   {
     "name": "Kyungpook National University",
-    "url": "http://libproxy.knu.ac.kr/_Lib_Proxy_Url/$@"
+    "url": "http://libproxy.knu.ac.kr/_Lib_Proxy_Url/",
+    "location": {
+      "lng": 128.6102997,
+      "lat": 35.888836
+    },
+    "country": "South Korea"
   },
   {
     "name": "LA BioMed",
-    "url": "http://journals.labiomed.org/login?url=$@"
+    "url": "http://journals.labiomed.org/login?url=",
+    "location": {
+      "lng": -118.2436849,
+      "lat": 34.0522342
+    },
+    "country": "United States"
   },
   {
     "name": "La Salle",
-    "url": "http://dbproxy.lasalle.edu:2048/login?url=$@"
+    "url": "http://dbproxy.lasalle.edu:2048/login?url=",
+    "location": {
+      "lng": -73.6348608,
+      "lat": 45.4306303
+    },
+    "country": "Canada"
   },
   {
     "name": "La Sierra",
-    "url": "http://ezproxy.lasierra.edu:2048/login?url=$@"
+    "url": "http://ezproxy.lasierra.edu:2048/login?url=",
+    "location": {
+      "lng": -75.2262559,
+      "lat": 38.4575916
+    },
+    "country": "United States"
   },
   {
     "name": "La Trobe University",
-    "url": "http://ez.library.latrobe.edu.au/login?url=$@"
+    "url": "http://ez.library.latrobe.edu.au/login?url=",
+    "location": {
+      "lng": 145.047159,
+      "lat": -37.7207472
+    },
+    "country": "Australia"
   },
   {
     "name": "Laguardia",
-    "url": "https://rpa.laguardia.edu/login?url=$@"
+    "url": "https://rpa.laguardia.edu/login?url=",
+    "location": {
+      "lng": -73.8739659,
+      "lat": 40.7769271
+    },
+    "country": "United States"
   },
   {
     "name": "Lakehead University",
-    "url": "http://ezproxy.lakeheadu.ca/login?url=$@"
+    "url": "http://ezproxy.lakeheadu.ca/login?url=",
+    "location": {
+      "lng": -89.2606994,
+      "lat": 48.42111080000001
+    },
+    "country": "Canada"
   },
   {
     "name": "Lakeview College of Nursing",
-    "url": "http://ezproxy.lakeviewcol.edu:2048/login?url=$@"
+    "url": "http://ezproxy.lakeviewcol.edu:2048/login?url=",
+    "location": {
+      "lng": -87.6443161,
+      "lat": 40.1385934
+    },
+    "country": "United States"
   },
   {
     "name": "Lamar State College at Orange",
-    "url": "http://ezproxy.lsco.edu:2048/login?url=$@"
+    "url": "http://ezproxy.lsco.edu:2048/login?url=",
+    "location": {
+      "lng": -117.8531007,
+      "lat": 33.7879139
+    },
+    "country": "United States"
   },
   {
     "name": "Lamar University",
-    "url": "https://libproxy.lamar.edu/login?url=$@"
+    "url": "https://libproxy.lamar.edu/login?url=",
+    "location": {
+      "lng": -94.0747071,
+      "lat": 30.0392256
+    },
+    "country": "United States"
   },
   {
     "name": "Lancaster",
-    "url": "http://ezproxy.lancs.ac.uk/login?url=$@"
+    "url": "http://ezproxy.lancs.ac.uk/login?url=",
+    "location": {
+      "lng": -76.3055144,
+      "lat": 40.0378755
+    },
+    "country": "United States"
   },
   {
     "name": "Lane Community College",
-    "url": "http://lanecc.idm.oclc.org/login?url=$@"
+    "url": "http://lanecc.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -123.03486875630506,
+      "lat": 44.009129093147926
+    },
+    "country": "United States"
   },
   {
     "name": "Lansing",
-    "url": "https://lcc.idm.oclc.org/login?url=$@"
+    "url": "https://lcc.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -84.5555347,
+      "lat": 42.732535
+    },
+    "country": "United States"
   },
   {
     "name": "Las Positas College",
-    "url": "https://lpclibrary.idm.oclc.org/login?url=$@"
+    "url": "https://lpclibrary.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -121.80020242479456,
+      "lat": 37.71065710946536
+    },
+    "country": "United States"
   },
   {
     "name": "Laurentian",
-    "url": "http://librweb.laurentian.ca/login?url=$@"
+    "url": "http://librweb.laurentian.ca/login?url=",
+    "location": {
+      "lng": -80.9757296,
+      "lat": 46.4672485
+    },
+    "country": "Canada"
   },
   {
     "name": "Laurentian University",
-    "url": "https://login.librweb.laurentian.ca/login?url=$@"
+    "url": "https://login.librweb.laurentian.ca/login?url=",
+    "location": {
+      "lng": -80.9757296,
+      "lat": 46.4672485
+    },
+    "country": "Canada"
   },
   {
     "name": "Lawrence Technological",
-    "url": "http://ezproxy.ltu.edu:8080/login?url=$@"
+    "url": "http://ezproxy.ltu.edu:8080/login?url=",
+    "location": {
+      "lng": -83.2507416,
+      "lat": 42.4751235
+    },
+    "country": "United States"
   },
   {
     "name": "Lawrence University",
-    "url": "http://proxy.lawrence.edu:2048/login?url=$@"
+    "url": "http://proxy.lawrence.edu:2048/login?url=",
+    "location": {
+      "lng": -88.39935302776678,
+      "lat": 44.26181495876797
+    },
+    "country": "United States"
   },
   {
     "name": "Lebanese University",
-    "url": "http://ezproxy.ul.edu.lb:82/login?url=$@"
+    "url": "http://ezproxy.ul.edu.lb:82/login?url=",
+    "location": {
+      "lng": 35.5217731,
+      "lat": 33.8278696
+    },
+    "country": "Lebanon"
   },
   {
     "name": "Lebanon Valley",
-    "url": "http://ezproxy.lvc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.lvc.edu:2048/login?url=",
+    "location": {
+      "lng": -73.48697659999999,
+      "lat": 42.4905395
+    },
+    "country": "United States"
   },
   {
     "name": "Lee College",
-    "url": "http://leonardo.lee.edu/login?url=$@"
+    "url": "http://leonardo.lee.edu/login?url=",
+    "location": {
+      "lng": -94.9764522,
+      "lat": 29.7345406
+    },
+    "country": "United States"
   },
   {
     "name": "Leeds Beckett",
-    "url": "http://ezproxy.leedsbeckett.ac.uk/login?url=$@"
+    "url": "http://ezproxy.leedsbeckett.ac.uk/login?url=",
+    "location": {
+      "lng": -1.5480355,
+      "lat": 53.8035274
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Leeds Metropolitan University",
-    "url": "https://login.ezproxy.leedsmet.ac.uk/login?url=$@"
+    "url": "https://login.ezproxy.leedsmet.ac.uk/login?url=",
+    "location": {
+      "lng": -1.5480355,
+      "lat": 53.8035274
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Legacy Health",
-    "url": "https://lhs.idm.oclc.org/login?url=$@"
+    "url": "https://lhs.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.65682250648926,
+      "lat": 45.525221254361185
+    },
+    "country": "United States"
   },
   {
     "name": "Lehigh",
-    "url": "https://ezproxy.lib.lehigh.edu/login?url=$@"
+    "url": "https://ezproxy.lib.lehigh.edu/login?url=",
+    "location": {
+      "lng": -75.3775187,
+      "lat": 40.6048687
+    },
+    "country": "United States"
   },
   {
     "name": "Lehigh University",
-    "url": "https://login.ezproxy.lib.lehigh.edu/login?url=$@"
+    "url": "https://login.ezproxy.lib.lehigh.edu/login?url=",
+    "location": {
+      "lng": -75.3775187,
+      "lat": 40.6048687
+    },
+    "country": "United States"
   },
   {
     "name": "Leiden University",
-    "url": "https://ezproxy.leidenuniv.nl:2443/login?url=$@"
+    "url": "https://ezproxy.leidenuniv.nl:2443/login?url=",
+    "location": {
+      "lng": 4.4863129,
+      "lat": 52.1565752
+    },
+    "country": "Netherlands"
   },
   {
     "name": "LeTourneau University",
-    "url": "http://research-db.letu.edu/login?url=$@"
+    "url": "http://research-db.letu.edu/login?url=",
+    "location": {
+      "lng": -94.7276606,
+      "lat": 32.4669557
+    },
+    "country": "United States"
   },
   {
     "name": "Lewis & Clark College",
-    "url": "https://library.lcproxy.org/login?url=$@"
+    "url": "https://library.lcproxy.org/login?url=",
+    "location": {
+      "lng": -122.67004954776453,
+      "lat": 45.45037271087549
+    },
+    "country": "United States"
   },
   {
     "name": "Liberty",
-    "url": "http://ezproxy.liberty.edu:2048/login?url=$@"
+    "url": "http://ezproxy.liberty.edu:2048/login?url=",
+    "location": {
+      "lng": -79.17841229999999,
+      "lat": 37.3492244
+    },
+    "country": "United States"
   },
   {
     "name": "Liberty University",
-    "url": "http://ezproxy.liberty.edu/login?url=$@"
+    "url": "http://ezproxy.liberty.edu/login?url=",
+    "location": {
+      "lng": -79.17841229999999,
+      "lat": 37.3492244
+    },
+    "country": "United States"
   },
   {
     "name": "Lietuvos sveikatos mokslų universitetas",
-    "url": "http://ezproxy.dbazes.lsmuni.lt:2048/login?url=$@"
+    "url": "http://ezproxy.dbazes.lsmuni.lt:2048/login?url=",
+    "location": {
+      "lng": 23.9167513,
+      "lat": 54.8942492
+    },
+    "country": "Lithuania"
   },
   {
     "name": "Lillehammer University College",
-    "url": "http://login.ezproxy.hil.no/login?url=$@"
+    "url": "http://login.ezproxy.hil.no/login?url=",
+    "location": {
+      "lng": 10.4225301,
+      "lat": 61.1497953
+    },
+    "country": "Norway"
   },
   {
     "name": "Lincoln University",
-    "url": "http://proxy-lincoln.klnpa.org/login?url=$@"
+    "url": "http://proxy-lincoln.klnpa.org/login?url=",
+    "location": {
+      "lng": -75.928474,
+      "lat": 39.8071788
+    },
+    "country": "United States"
   },
   {
     "name": "Linfield",
-    "url": "https://ezproxy.linfield.edu/login?url=$@"
+    "url": "https://ezproxy.linfield.edu/login?url=",
+    "location": {
+      "lng": -123.1993365,
+      "lat": 45.2006802
+    },
+    "country": "United States"
   },
   {
     "name": "Linköping University",
-    "url": "https://login.e.bibl.liu.se/login?url=$@"
+    "url": "https://login.e.bibl.liu.se/login?url=",
+    "location": {
+      "lng": 15.5760072,
+      "lat": 58.3978364
+    },
+    "country": "Sweden"
   },
   {
     "name": "Linn-Benton",
-    "url": "http://ezproxy.libweb.linnbenton.edu:2048/login?url=$@"
+    "url": "http://ezproxy.libweb.linnbenton.edu:2048/login?url=",
+    "location": {
+      "lng": -123.1147938,
+      "lat": 44.5870879
+    },
+    "country": "United States"
   },
   {
     "name": "Linnaeus University",
-    "url": "http://proxy.lnu.se/login?url=$@"
+    "url": "http://proxy.lnu.se/login?url=",
+    "location": {
+      "lng": 14.8303775,
+      "lat": 56.8546039
+    },
+    "country": "Sweden"
   },
   {
     "name": "Lock Haven University",
-    "url": "http://proxy-lhup.klnpa.org/login?url=$@"
+    "url": "http://proxy-lhup.klnpa.org/login?url=",
+    "location": {
+      "lng": -77.46062429999999,
+      "lat": 41.1427108
+    },
+    "country": "United States"
   },
   {
     "name": "Lone Star",
-    "url": "http://ezproxy.lonestar.edu/login?url=$@"
+    "url": "http://ezproxy.lonestar.edu/login?url=",
+    "location": {
+      "lng": -95.4665258,
+      "lat": 29.868389
+    },
+    "country": "United States"
   },
   {
     "name": "Lone Star College",
-    "url": "http://lscsproxy.lonestar.edu/login?url=$@"
+    "url": "http://lscsproxy.lonestar.edu/login?url=",
+    "location": {
+      "lng": -95.4665258,
+      "lat": 29.868389
+    },
+    "country": "United States"
   },
   {
     "name": "Longwood",
-    "url": "https://login.proxy.longwood.edu/login?url=$@"
+    "url": "https://login.proxy.longwood.edu/login?url=",
+    "location": {
+      "lng": -81.3384011,
+      "lat": 28.7030519
+    },
+    "country": "United States"
   },
   {
     "name": "Los Angeles Harbor",
-    "url": "http://ezproxy.lahc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.lahc.edu:2048/login?url=",
+    "location": {
+      "lng": -118.2599686241527,
+      "lat": 33.73954589643058
+    },
+    "country": "United States"
   },
   {
     "name": "Louisiana State University",
-    "url": "http://libezp.lib.lsu.edu/login?url=$@"
+    "url": "http://libezp.lib.lsu.edu/login?url=",
+    "location": {
+      "lng": -91.1800023,
+      "lat": 30.4132579
+    },
+    "country": "United States"
   },
   {
     "name": "Louisiana State University Paul M Hebert Law Center",
-    "url": "http://ezproxy.law.lsu.edu/login?url=$@"
+    "url": "http://ezproxy.law.lsu.edu/login?url=",
+    "location": {
+      "lng": -91.1749433,
+      "lat": 30.414219
+    },
+    "country": "United States"
   },
   {
     "name": "Louisiana Tech University",
-    "url": "http://ezproxy.latech.edu:2048/login?url=$@"
+    "url": "http://ezproxy.latech.edu:2048/login?url=",
+    "location": {
+      "lng": -92.6522174,
+      "lat": 32.5299582
+    },
+    "country": "United States"
   },
   {
     "name": "Loyola Marymount",
-    "url": "http://electra.lmu.edu:2048/login?url=$@"
+    "url": "http://electra.lmu.edu:2048/login?url=",
+    "location": {
+      "lng": -118.4170134,
+      "lat": 33.9709541
+    },
+    "country": "United States"
   },
   {
     "name": "Loyola Marymount University | LA",
-    "url": "https://electra.lmu.edu/login?url=$@"
+    "url": "https://electra.lmu.edu/login?url=",
+    "location": {
+      "lng": -118.4170134,
+      "lat": 33.9709541
+    },
+    "country": "United States"
   },
   {
     "name": "Loyola University Chicago",
-    "url": "http://flagship.luc.edu/login?url=$@"
+    "url": "http://flagship.luc.edu/login?url=",
+    "location": {
+      "lng": -87.65825919999999,
+      "lat": 41.9989483
+    },
+    "country": "United States"
   },
   {
     "name": "Loyola University New Orleans",
-    "url": "http://ezproxy.loyno.edu/login?url=$@"
+    "url": "http://ezproxy.loyno.edu/login?url=",
+    "location": {
+      "lng": -90.1209925,
+      "lat": 29.9346582
+    },
+    "country": "United States"
   },
   {
     "name": "LSU Health Sciences Center New Orleans",
-    "url": "https://ezproxy.lsuhsc.edu/login?url=$@"
+    "url": "https://ezproxy.lsuhsc.edu/login?url=",
+    "location": {
+      "lng": -90.0832621,
+      "lat": 29.9572962
+    },
+    "country": "United States"
   },
   {
     "name": "Ludwig-Maximilians-Universität München",
-    "url": "http://emedien.ub.uni-muenchen.de/login?url=$@"
+    "url": "http://emedien.ub.uni-muenchen.de/login?url=",
+    "location": {
+      "lng": 11.5805262,
+      "lat": 48.1507496
+    },
+    "country": "Germany"
   },
   {
     "name": "Lulea Tekniska Universitet",
-    "url": "http://proxy.lib.ltu.se/login?url=$@"
+    "url": "http://proxy.lib.ltu.se/login?url=",
+    "location": {
+      "lng": 22.1401794,
+      "lat": 65.6179964
+    },
+    "country": "Sweden"
   },
   {
     "name": "Lund University",
-    "url": "http://ludwig.lub.lu.se/login?url=$@"
+    "url": "http://ludwig.lub.lu.se/login?url=",
+    "location": {
+      "lng": 13.203493,
+      "lat": 55.7119483
+    },
+    "country": "Sweden"
   },
   {
     "name": "Luther College",
-    "url": "http://proxy.luther.edu/login?url=$@"
+    "url": "http://proxy.luther.edu/login?url=",
+    "location": {
+      "lng": -90.80301436456544,
+      "lat": 44.27698912983501
+    },
+    "country": "United States"
   },
   {
     "name": "Luther Seminary",
-    "url": "https://luthersem.idm.oclc.org/login?url=$@"
+    "url": "https://luthersem.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -93.1967707,
+      "lat": 44.9858214
+    },
+    "country": "United States"
   },
   {
     "name": "Lycoming",
-    "url": "http://lyco2.lycoming.edu:2048/login?url=$@"
+    "url": "http://lyco2.lycoming.edu:2048/login?url=",
+    "location": {
+      "lng": -77.10249019999999,
+      "lat": 41.2720004
+    },
+    "country": "United States"
   },
   {
     "name": "Lynchburg College",
-    "url": "http://ezproxy.lynchburg.edu/login?url=$@"
+    "url": "http://ezproxy.lynchburg.edu/login?url=",
+    "location": {
+      "lng": -79.183153,
+      "lat": 37.4006
+    },
+    "country": "United States"
   },
   {
     "name": "Maastricht University",
-    "url": "http://ezproxy.ub.unimaas.nl/login?url=$@"
+    "url": "http://ezproxy.ub.unimaas.nl/login?url=",
+    "location": {
+      "lng": 5.6879801,
+      "lat": 50.8469602
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Macalester",
-    "url": "http://ezproxy.macalester.edu/login?url=$@"
+    "url": "http://ezproxy.macalester.edu/login?url=",
+    "location": {
+      "lng": -93.1670857,
+      "lat": 44.934297
+    },
+    "country": "United States"
   },
   {
     "name": "MacEwan University",
-    "url": "http://ezproxy.macewan.ca/login?url=$@"
+    "url": "http://ezproxy.macewan.ca/login?url=",
+    "location": {
+      "lng": -113.5063721,
+      "lat": 53.5470544
+    },
+    "country": "Canada"
   },
   {
     "name": "Macquarie University",
-    "url": "https://simsrad.net.ocs.mq.edu.au/login?qurl=$@"
+    "url": "https://simsrad.net.ocs.mq.edu.au/login?qurl=",
+    "location": {
+      "lng": 151.1126498,
+      "lat": -33.77382370000001
+    },
+    "country": "Australia"
   },
   {
     "name": "Madison",
-    "url": "http://ezproxy.madisoncollege.edu/login?url=$@"
+    "url": "http://ezproxy.madisoncollege.edu/login?url=",
+    "location": {
+      "lng": -89.4007501,
+      "lat": 43.0721661
+    },
+    "country": "United States"
   },
   {
     "name": "Madonna University",
-    "url": "http://madonnaezp.liblime.com/login?url=$@"
+    "url": "http://madonnaezp.liblime.com/login?url=",
+    "location": {
+      "lng": -83.40627452064103,
+      "lat": 42.38593207187496
+    },
+    "country": "United States"
   },
   {
     "name": "Mahec Digital Library",
-    "url": "http://ezproxy.maheclibrary.org/login?url=$@"
+    "url": "http://ezproxy.maheclibrary.org/login?url=",
+    "location": {
+      "lng": -91.7845624,
+      "lat": 37.9525019
+    },
+    "country": "United States"
   },
   {
     "name": "Mahidol University",
-    "url": "https://ejournal.mahidol.ac.th/login?url=$@"
+    "url": "https://ejournal.mahidol.ac.th/login?url=",
+    "location": {
+      "lng": 100.3256274,
+      "lat": 13.7943814
+    },
+    "country": "Thailand"
   },
   {
     "name": "Maine's Virtual Library",
-    "url": "http://libraries.maine.edu/mainedatabases/authmaine.asp?url=$@"
+    "url": "http://libraries.maine.edu/mainedatabases/authmaine.asp?url=",
+    "location": {
+      "lng": -69.4454689,
+      "lat": 45.253783
+    },
+    "country": "United States"
   },
   {
     "name": "Malmo Hogskola",
-    "url": "http://proxy.mah.se/login?url=$@"
+    "url": "http://proxy.mah.se/login?url=",
+    "location": {
+      "lng": 12.994561,
+      "lat": 55.6087954
+    },
+    "country": "Sweden"
   },
   {
     "name": "Manchester Metropolitan University",
-    "url": "http://ezproxy.mmu.ac.uk/login?url=$@"
+    "url": "http://ezproxy.mmu.ac.uk/login?url=",
+    "location": {
+      "lng": -2.2392999,
+      "lat": 53.4703485
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Manhattanville",
-    "url": "http://librda.mville.edu:2048/login?url=$@"
+    "url": "http://librda.mville.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9558333,
+      "lat": 40.8169443
+    },
+    "country": "United States"
   },
   {
     "name": "Manipal Institute of Technology",
-    "url": "https://mitezproxy.manipal.edu/login?url=$@"
+    "url": "https://mitezproxy.manipal.edu/login?url=",
+    "location": {
+      "lng": 74.79282239999999,
+      "lat": 13.3525321
+    },
+    "country": "India"
   },
   {
     "name": "Mansfield University",
-    "url": "http://proxy-mansfield.klnpa.org/login?url=$@"
+    "url": "http://proxy-mansfield.klnpa.org/login?url=",
+    "location": {
+      "lng": -77.07042799999999,
+      "lat": 41.8047541
+    },
+    "country": "United States"
   },
   {
     "name": "Marist College",
-    "url": "http://login.online.library.marist.edu/login?url=$@"
+    "url": "http://login.online.library.marist.edu/login?url=",
+    "location": {
+      "lng": -73.9344876,
+      "lat": 41.7231052
+    },
+    "country": "United States"
   },
   {
     "name": "Marlboro College Archives (Emerson College)",
-    "url": "http://libproxy.marlboro.edu/login?url=$@"
+    "url": "http://libproxy.marlboro.edu/login?url=",
+    "location": {
+      "lng": -72.73475190898273,
+      "lat": 42.83921258087876
+    },
+    "country": "United States"
   },
   {
     "name": "Marshall University",
-    "url": "http://marshall.idm.oclc.org/login?url=$@"
+    "url": "http://marshall.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -82.42471979999999,
+      "lat": 38.4236597
+    },
+    "country": "United States"
   },
   {
     "name": "Marshall University",
-    "url": "http://ezproxy.marshall.edu:2048/login?url=$@"
+    "url": "http://ezproxy.marshall.edu:2048/login?url=",
+    "location": {
+      "lng": -82.42497995923164,
+      "lat": 38.42435645107813
+    },
+    "country": "United States"
   },
   {
     "name": "Marygrove",
-    "url": "http://library.marygrove.edu:2048/login?url=$@"
+    "url": "http://library.marygrove.edu:2048/login?url=",
+    "location": {
+      "lng": -90.35697139999999,
+      "lat": 38.8231165
+    },
+    "country": "United States"
   },
   {
     "name": "Maryland Institute College of Art",
-    "url": "http://ezproxy.mica.edu:2048/login?url=$@"
+    "url": "http://ezproxy.mica.edu:2048/login?url=",
+    "location": {
+      "lng": -76.62108358440929,
+      "lat": 39.30805373243502
+    },
+    "country": "United States"
   },
   {
     "name": "Marylhurst",
-    "url": "http://marylhurst.idm.oclc.org/login?url=$@"
+    "url": "http://marylhurst.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.6543286,
+      "lat": 45.3891078
+    },
+    "country": "United States"
   },
   {
     "name": "Maryville",
-    "url": "http://proxy.library.maryville.edu/login?url=$@"
+    "url": "http://proxy.library.maryville.edu/login?url=",
+    "location": {
+      "lng": -83.9704593,
+      "lat": 35.7564719
+    },
+    "country": "United States"
   },
   {
     "name": "Marywood",
-    "url": "http://marywood1.marywood.edu:2048/login?url=$@"
+    "url": "http://marywood1.marywood.edu:2048/login?url=",
+    "location": {
+      "lng": -75.6324234,
+      "lat": 41.43513189999999
+    },
+    "country": "United States"
   },
   {
     "name": "Massachusetts College of Liberal Arts",
-    "url": "http://libproxy.mcla.edu:2048/login?url=$@"
+    "url": "http://libproxy.mcla.edu:2048/login?url=",
+    "location": {
+      "lng": -73.1033372,
+      "lat": 42.691554
+    },
+    "country": "United States"
   },
   {
     "name": "Massachusetts Institute of Technology",
-    "url": "http://libproxy.mit.edu/login?url=$@"
+    "url": "http://libproxy.mit.edu/login?url=",
+    "location": {
+      "lng": -71.09416,
+      "lat": 42.360091
+    },
+    "country": "United States"
   },
   {
     "name": "Massey Universtiy",
-    "url": "http://ezproxy.massey.ac.nz/login?url=$@"
+    "url": "http://ezproxy.massey.ac.nz/login?url=",
+    "location": {
+      "lng": 174.68605294966477,
+      "lat": -36.69417903509752
+    },
+    "country": "New Zealand"
   },
   {
     "name": "Max Planck Institute for Human Cognitive and Brain Sciences",
-    "url": "https://browser.cbs.mpg.de/login?url=$@"
+    "url": "https://browser.cbs.mpg.de/login?url=",
+    "location": {
+      "lng": 12.3889266,
+      "lat": 51.3349446
+    },
+    "country": "Germany"
   },
   {
     "name": "Max-Planck-Institut für molekulare Genetik",
-    "url": "https://login.ezproxy.molgen.mpg.de/login?url=$@"
+    "url": "https://login.ezproxy.molgen.mpg.de/login?url=",
+    "location": {
+      "lng": 13.2736288,
+      "lat": 52.4449769
+    },
+    "country": "Germany"
   },
   {
     "name": "Maynooth",
-    "url": "https://login.jproxy.nuim.ie/login?url=$@"
+    "url": "https://login.jproxy.nuim.ie/login?url=",
+    "location": {
+      "lng": -6.5918499,
+      "lat": 53.3812896
+    },
+    "country": "Ireland"
   },
   {
     "name": "Mayo Clinic",
-    "url": "https://mclibrary.idm.oclc.org/login?url=$@"
+    "url": "https://mclibrary.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -92.4663757,
+      "lat": 44.0230449
+    },
+    "country": "United States"
   },
   {
     "name": "McGill University",
-    "url": "http://proxy.library.mcgill.ca/login?url=$@"
+    "url": "http://proxy.library.mcgill.ca/login?url=",
+    "location": {
+      "lng": -73.5771511,
+      "lat": 45.50478469999999
+    },
+    "country": "Canada"
   },
   {
     "name": "McMaster University",
-    "url": "http://libaccess.lib.mcmaster.ca/login?url=$@"
+    "url": "http://libaccess.lib.mcmaster.ca/login?url=",
+    "location": {
+      "lng": -79.9192254,
+      "lat": 43.260879
+    },
+    "country": "Canada"
   },
   {
     "name": "MCPHS (Massachusetts College of Pharmacy and Health Science)",
-    "url": "https://ezproxymcp.flo.org/login?qurl=$@"
+    "url": "https://ezproxymcp.flo.org/login?qurl=",
+    "location": {
+      "lng": -71.1012629,
+      "lat": 42.3367556
+    },
+    "country": "United States"
   },
   {
     "name": "Medical College of Wisconsin",
-    "url": "https://login.proxy.lib.mcw.edu/login?url=$@"
+    "url": "https://login.proxy.lib.mcw.edu/login?url=",
+    "location": {
+      "lng": -88.02116509999999,
+      "lat": 43.0435728
+    },
+    "country": "United States"
   },
   {
     "name": "Medical University of Bialystok",
-    "url": "http://ebazy.umb.edu.pl/login?url=$@"
+    "url": "http://ebazy.umb.edu.pl/login?url=",
+    "location": {
+      "lng": 23.1653094,
+      "lat": 53.13058119999999
+    },
+    "country": "Poland"
   },
   {
     "name": "Medical University of South Carolina",
-    "url": "http://ezproxy.musc.edu/login?url=$@"
+    "url": "http://ezproxy.musc.edu/login?url=",
+    "location": {
+      "lng": -79.9497334,
+      "lat": 32.784891
+    },
+    "country": "United States"
   },
   {
     "name": "Medical University Vienna",
-    "url": "http://ez.srv.meduniwien.ac.at/login?url=$@"
+    "url": "http://ez.srv.meduniwien.ac.at/login?url=",
+    "location": {
+      "lng": 16.3475329,
+      "lat": 48.2196447
+    },
+    "country": "Austria"
   },
   {
     "name": "MEF University",
-    "url": "http://ezproxy.mef.edu.tr/login?url=$@"
+    "url": "http://ezproxy.mef.edu.tr/login?url=",
+    "location": {
+      "lng": 29.0085964,
+      "lat": 41.1088445
+    },
+    "country": "Türkiye"
   },
   {
     "name": "Memorial Sloan Kettering Cancer Center",
-    "url": "https://login.libauth.mskcc.org/login?url=$@"
+    "url": "https://login.libauth.mskcc.org/login?url=",
+    "location": {
+      "lng": -73.95652612801905,
+      "lat": 40.76602947564234
+    },
+    "country": "United States"
   },
   {
     "name": "Memorial University of Newfoundland",
-    "url": "https://qe2a-proxy.mun.ca/Login?url=$@"
+    "url": "https://qe2a-proxy.mun.ca/Login?url=",
+    "location": {
+      "lng": -57.6604364,
+      "lat": 53.1355091
+    },
+    "country": "Canada"
   },
   {
     "name": "Mercer University",
-    "url": "http://proxy-s.mercer.edu/login?url=$@"
+    "url": "http://proxy-s.mercer.edu/login?url=",
+    "location": {
+      "lng": -83.64969909999999,
+      "lat": 32.8284878
+    },
+    "country": "United States"
   },
   {
     "name": "Mercy College",
-    "url": "http://rdas-proxy.mercy.edu:2048/login?url=$@"
+    "url": "http://rdas-proxy.mercy.edu:2048/login?url=",
+    "location": {
+      "lng": -73.98719830324937,
+      "lat": 40.75027162459241
+    },
+    "country": "United States"
   },
   {
     "name": "Metropolitan College of New York",
-    "url": "https://ezproxy.mcny.edu/login?qurl=$@"
+    "url": "https://ezproxy.mcny.edu/login?qurl=",
+    "location": {
+      "lng": -74.0149887,
+      "lat": 40.7085735
+    },
+    "country": "United States"
   },
   {
     "name": "Miami University Oxford Ohio",
-    "url": "http://proxy.lib.miamioh.edu/login?url=$@"
+    "url": "http://proxy.lib.miamioh.edu/login?url=",
+    "location": {
+      "lng": -84.73449149999999,
+      "lat": 39.5087485
+    },
+    "country": "United States"
   },
   {
     "name": "Michigan State",
-    "url": "http://proxy1.cl.msu.edu/login?url=$@"
+    "url": "http://proxy1.cl.msu.edu/login?url=",
+    "location": {
+      "lng": -85.60236429999999,
+      "lat": 44.3148443
+    },
+    "country": "United States"
   },
   {
     "name": "Michigan State University",
-    "url": "http://ezproxy.msu.edu/login?url=$@"
+    "url": "http://ezproxy.msu.edu/login?url=",
+    "location": {
+      "lng": -84.4821719,
+      "lat": 42.701848
+    },
+    "country": "United States"
   },
   {
     "name": "Michigan Technological",
-    "url": "https://services.lib.mtu.edu/login?url=$@"
+    "url": "https://services.lib.mtu.edu/login?url=",
+    "location": {
+      "lng": -88.5452004,
+      "lat": 47.1150259
+    },
+    "country": "United States"
   },
   {
     "name": "Mid-America Christian",
-    "url": "http://webserver.macu.edu:2048/login?url=$@"
+    "url": "http://webserver.macu.edu:2048/login?url=",
+    "location": {
+      "lng": -97.5784864,
+      "lat": 35.3477803
+    },
+    "country": "United States"
   },
   {
     "name": "Mid-State Technical",
-    "url": "http://ezproxy.mstc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.mstc.edu:2048/login?url=",
+    "location": {
+      "lng": -90.2095658,
+      "lat": 44.666031
+    },
+    "country": "United States"
   },
   {
     "name": "Middle Tennessee State",
-    "url": "https://ezproxy.mtsu.edu:3443/login?url=$@"
+    "url": "https://ezproxy.mtsu.edu:3443/login?url=",
+    "location": {
+      "lng": -86.36691549999999,
+      "lat": 35.8486229
+    },
+    "country": "United States"
   },
   {
     "name": "Middlebury",
-    "url": "http://ezproxy.middlebury.edu/login?url=$@"
+    "url": "http://ezproxy.middlebury.edu/login?url=",
+    "location": {
+      "lng": -73.16734,
+      "lat": 44.0153371
+    },
+    "country": "United States"
   },
   {
     "name": "Middlesex University London",
-    "url": "http://ezproxy.mdx.ac.uk/login?url=$@"
+    "url": "http://ezproxy.mdx.ac.uk/login?url=",
+    "location": {
+      "lng": -0.2293488,
+      "lat": 51.5897112
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Miles Community College",
-    "url": "https://library.milescc.edu:8443/login?url=$@"
+    "url": "https://library.milescc.edu:8443/login?url=",
+    "location": {
+      "lng": -105.8262634,
+      "lat": 46.4053077
+    },
+    "country": "United States"
   },
   {
     "name": "Millersville University",
-    "url": "http://proxy-millersville.klnpa.org/login?url=$@"
+    "url": "http://proxy-millersville.klnpa.org/login?url=",
+    "location": {
+      "lng": -76.3527392,
+      "lat": 39.9987943
+    },
+    "country": "United States"
   },
   {
     "name": "Mills College",
-    "url": "https://intra.mills.edu:2443/login?url=$@"
+    "url": "https://intra.mills.edu:2443/login?url=",
+    "location": {
+      "lng": -122.1825631,
+      "lat": 37.78059880000001
+    },
+    "country": "United States"
   },
   {
     "name": "Millsaps",
-    "url": "http://ezproxy.millsaps.edu/login?url=$@"
+    "url": "http://ezproxy.millsaps.edu/login?url=",
+    "location": {
+      "lng": -90.1780014,
+      "lat": 32.3223479
+    },
+    "country": "United States"
   },
   {
-    "name": "Ming Chuan University",
-    "url": "http://proxy.mcu.edu.tw/login?url=$@"
+    "name": "Ming Chuan University ",
+    "url": "http://proxy.mcu.edu.tw/login?url=",
+    "location": {
+      "lng": 121.3423518,
+      "lat": 24.9844808
+    },
+    "country": "Taiwan"
   },
   {
     "name": "Minnesota State",
-    "url": "https://login.ezproxy.mnsu.edu/login?url=$@"
+    "url": "https://login.ezproxy.mnsu.edu/login?url=",
+    "location": {
+      "lng": -94.6858998,
+      "lat": 46.729553
+    },
+    "country": "United States"
   },
   {
     "name": "Minot State",
-    "url": "http://ezproxy.minotstateu.edu:2048/login?url=$@"
+    "url": "http://ezproxy.minotstateu.edu:2048/login?url=",
+    "location": {
+      "lng": -101.3014106,
+      "lat": 48.2486186
+    },
+    "country": "United States"
   },
   {
     "name": "Missouri State University",
-    "url": "http://proxy.missouristate.edu/login?url=$@"
+    "url": "http://proxy.missouristate.edu/login?url=",
+    "location": {
+      "lng": -93.2806806,
+      "lat": 37.2005546
+    },
+    "country": "United States"
   },
   {
     "name": "Missouri University of Science and Technology",
-    "url": "http://libproxy.mst.edu:2048/login?url=$@"
+    "url": "http://libproxy.mst.edu:2048/login?url=",
+    "location": {
+      "lng": -91.7756271,
+      "lat": 37.9537078
+    },
+    "country": "United States"
   },
   {
     "name": "MIT",
-    "url": "https://libproxy.mit.edu/cgi-bin/ezpauth?url=$@"
+    "url": "https://libproxy.mit.edu/cgi-bin/ezpauth?url=",
+    "location": {
+      "lng": -71.09416,
+      "lat": 42.360091
+    },
+    "country": "United States"
   },
   {
     "name": "Mohawk College",
-    "url": "http://ezproxy.mohawkcollege.ca:2048/login?url=$@"
+    "url": "http://ezproxy.mohawkcollege.ca:2048/login?url=",
+    "location": {
+      "lng": -79.88859727632705,
+      "lat": 43.24151882835353
+    },
+    "country": "Canada"
   },
   {
     "name": "Molloy",
-    "url": "http://molloy.idm.oclc.org/login?url=$@"
+    "url": "http://molloy.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -73.6272086,
+      "lat": 40.6862503
+    },
+    "country": "United States"
   },
   {
     "name": "Monash University",
-    "url": "http://ezproxy.lib.monash.edu.au/login?url=$@"
+    "url": "http://ezproxy.lib.monash.edu.au/login?url=",
+    "location": {
+      "lng": 145.1346592,
+      "lat": -37.9142416
+    },
+    "country": "Australia"
   },
   {
     "name": "Montana State",
-    "url": "http://proxybz.lib.montana.edu/login?url=$@"
+    "url": "http://proxybz.lib.montana.edu/login?url=",
+    "location": {
+      "lng": -110.3625658,
+      "lat": 46.8796822
+    },
+    "country": "United States"
   },
   {
     "name": "Montgomery",
-    "url": "https://montgomerycollege.idm.oclc.org/login?url=$@"
+    "url": "https://montgomerycollege.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -86.3077368,
+      "lat": 32.3792233
+    },
+    "country": "United States"
   },
   {
     "name": "Montgomery County",
-    "url": "https://ezproxy.mc3.edu/login?url=$@"
+    "url": "https://ezproxy.mc3.edu/login?url=",
+    "location": {
+      "lng": -77.2405153,
+      "lat": 39.1547426
+    },
+    "country": "United States"
   },
   {
     "name": "Monticello",
-    "url": "https://tjportal.idm.oclc.org/login?url=$@"
+    "url": "https://tjportal.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -78.4531994,
+      "lat": 38.0086043
+    },
+    "country": "United States"
   },
   {
     "name": "Morgan Community College",
-    "url": "http://ezproxy.morgancc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.morgancc.edu:2048/login?url=",
+    "location": {
+      "lng": -103.77592475860006,
+      "lat": 40.259184164619775
+    },
+    "country": "United States"
   },
   {
     "name": "Morningside",
-    "url": "http://ezproxy.morningside.edu:2048/login?url=$@"
+    "url": "http://ezproxy.morningside.edu:2048/login?url=",
+    "location": {
+      "lng": -96.3584236,
+      "lat": 42.4731744
+    },
+    "country": "United States"
   },
   {
     "name": "Morrisville State",
-    "url": "http://ezproxy.librarylinks.morrisville.edu:2048/login?url=$@"
+    "url": "http://ezproxy.librarylinks.morrisville.edu:2048/login?url=",
+    "location": {
+      "lng": -75.6401825,
+      "lat": 42.8986791
+    },
+    "country": "United States"
   },
   {
     "name": "Mount Allison University",
-    "url": "https://login.libproxy.mta.ca/login?url=$@"
+    "url": "https://login.libproxy.mta.ca/login?url=",
+    "location": {
+      "lng": -64.3731482,
+      "lat": 45.8983431
+    },
+    "country": "Canada"
   },
   {
     "name": "Mount Holyoke",
-    "url": "http://proxy.mtholyoke.edu:2048/login?url=$@"
+    "url": "http://proxy.mtholyoke.edu:2048/login?url=",
+    "location": {
+      "lng": -72.5728843,
+      "lat": 42.255425
+    },
+    "country": "United States"
   },
   {
     "name": "Mount Royal",
-    "url": "http://library.mtroyal.ca:2048/login?url=$@"
+    "url": "http://library.mtroyal.ca:2048/login?url=",
+    "location": {
+      "lng": -73.5874072,
+      "lat": 45.5071024
+    },
+    "country": "Canada"
   },
   {
     "name": "Mount Royal University",
-    "url": "https://login.libproxy.mtroyal.ca/login?qurl=$@"
+    "url": "https://login.libproxy.mtroyal.ca/login?qurl=",
+    "location": {
+      "lng": -114.1318513,
+      "lat": 51.01113609999999
+    },
+    "country": "Canada"
   },
   {
     "name": "Mount Saint Marys",
-    "url": "https://msm.idm.oclc.org/login?url=$@"
+    "url": "https://msm.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -77.3486971,
+      "lat": 39.6799914
+    },
+    "country": "United States"
   },
   {
     "name": "MPI for Human Development Berlin",
-    "url": "http://ezproxy.mpib-berlin.mpg.de/login?url=$@"
+    "url": "http://ezproxy.mpib-berlin.mpg.de/login?url=",
+    "location": {
+      "lng": 13.303832,
+      "lat": 52.468554
+    },
+    "country": "Germany"
   },
   {
     "name": "Mt. Sinai School of Medicine (NYU)",
-    "url": "http://eresources.library.mssm.edu:2048/login?url=$@"
+    "url": "http://eresources.library.mssm.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9531097,
+      "lat": 40.7897148
+    },
+    "country": "United States"
   },
   {
     "name": "Mt.San Antonio College",
-    "url": "https://libris.mtsac.edu/login?url=$@"
+    "url": "https://libris.mtsac.edu/login?url=",
+    "location": {
+      "lng": -117.8421321,
+      "lat": 34.0487487
+    },
+    "country": "United States"
   },
   {
     "name": "Muhlenberg",
-    "url": "http://muhlenberg.idm.oclc.org/login?url=$@"
+    "url": "http://muhlenberg.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -75.5081076,
+      "lat": 40.5981933
+    },
+    "country": "United States"
   },
   {
     "name": "Munich University of Applied Sciences",
-    "url": "https://ezproxy.bib.hm.edu/login?url=$@"
+    "url": "https://ezproxy.bib.hm.edu/login?url=",
+    "location": {
+      "lng": 11.5527259,
+      "lat": 48.1534199
+    },
+    "country": "Germany"
   },
   {
     "name": "Murray State University",
-    "url": "https://ezproxy.waterfield.murraystate.edu/login?url=$@"
+    "url": "https://ezproxy.waterfield.murraystate.edu/login?url=",
+    "location": {
+      "lng": -88.3209372,
+      "lat": 36.616251
+    },
+    "country": "United States"
   },
   {
     "name": "Mälardalens universitet",
-    "url": "https://ep.bib.mdh.se/login?url=$@"
+    "url": "https://ep.bib.mdh.se/login?url=",
+    "location": {
+      "lng": 16.5407143,
+      "lat": 59.61857819999999
+    },
+    "country": "Sweden"
   },
   {
     "name": "Médiathèques FM6",
-    "url": "http://proxy.mediatheque-fm6.ma/login?url=$@"
+    "url": "http://proxy.mediatheque-fm6.ma/login?url=",
+    "location": {
+      "lng": -5.818574505466633,
+      "lat": 35.77789186557232
+    },
+    "country": "Morocco"
   },
   {
     "name": "Nacionalna i sveucilisna knjiznica u Zagrebu",
-    "url": "http://ezproxy.nsk.hr/login?url=$@"
+    "url": "http://ezproxy.nsk.hr/login?url=",
+    "location": {
+      "lng": 15.9775578,
+      "lat": 45.7966353
+    },
+    "country": "Croatia"
   },
   {
     "name": "Nagoya",
-    "url": "http://ejgw.nul.nagoya-u.ac.jp/login?url=$@"
+    "url": "http://ejgw.nul.nagoya-u.ac.jp/login?url=",
+    "location": {
+      "lng": 136.9065571,
+      "lat": 35.18145060000001
+    },
+    "country": "Japan"
   },
   {
     "name": "Nanyang Technological",
-    "url": "http://ezlibproxy1.ntu.edu.sg/login?url=$@"
+    "url": "http://ezlibproxy1.ntu.edu.sg/login?url=",
+    "location": {
+      "lng": 103.6831347,
+      "lat": 1.3483099
+    },
+    "country": "Singapore"
   },
   {
     "name": "Nanyang Technological University",
-    "url": "https://remotexs.ntu.edu.sg/user/login?dest=$@"
+    "url": "https://remotexs.ntu.edu.sg/user/login?dest=",
+    "location": {
+      "lng": 103.6831347,
+      "lat": 1.3483099
+    },
+    "country": "Singapore"
   },
   {
     "name": "Naropa",
-    "url": "http://ezproxy.naropa.edu:2048/login?url=$@"
+    "url": "http://ezproxy.naropa.edu:2048/login?url=",
+    "location": {
+      "lng": -105.2670571,
+      "lat": 40.0142329
+    },
+    "country": "United States"
   },
   {
     "name": "Nashua",
-    "url": "https://ezproxyncc.ccsnh.edu/login?url=$@"
+    "url": "https://ezproxyncc.ccsnh.edu/login?url=",
+    "location": {
+      "lng": -71.46756599999999,
+      "lat": 42.7653662
+    },
+    "country": "United States"
   },
   {
     "name": "National Cancer Institute",
-    "url": "http://ezlib.ncifcrf.gov/login?url=$@"
+    "url": "http://ezlib.ncifcrf.gov/login?url=",
+    "location": {
+      "lng": -77.43460436628231,
+      "lat": 39.43532429492162
+    },
+    "country": "United States"
   },
   {
     "name": "National Central University, Taiwan",
-    "url": "https://ezproxy.lib.ncu.edu.tw/login?url=$@"
+    "url": "https://ezproxy.lib.ncu.edu.tw/login?url=",
+    "location": {
+      "lng": 121.1952988,
+      "lat": 24.9681558
+    },
+    "country": "Taiwan"
   },
   {
     "name": "National College of Natural Medicine",
-    "url": "http://ncnm.idm.oclc.org/login?url=$@"
+    "url": "http://ncnm.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.6764952,
+      "lat": 45.5018378
+    },
+    "country": "United States"
   },
   {
     "name": "National Endowment for Democracy",
-    "url": "https://login.ned.idm.oclc.org/login?url=$@"
+    "url": "https://login.ned.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -77.02861097284573,
+      "lat": 38.89590383968619
+    },
+    "country": "United States"
   },
   {
     "name": "National Institute of Standards & Technology",
-    "url": "https://nist.idm.oclc.org/login?url=$@"
+    "url": "https://nist.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -77.21849422151341,
+      "lat": 39.140354778103784
+    },
+    "country": "United States"
   },
   {
     "name": "National Institutes of Health",
-    "url": "http://ezproxy.nihlibrary.nih.gov/login?url=$@"
+    "url": "http://ezproxy.nihlibrary.nih.gov/login?url=",
+    "location": {
+      "lng": -77.10454978367835,
+      "lat": 39.00308529679233
+    },
+    "country": "United States"
   },
   {
     "name": "National Louis University (Kendall)",
-    "url": "http://ezp.kendall.edu/login?url=$@"
+    "url": "http://ezp.kendall.edu/login?url=",
+    "location": {
+      "lng": -87.62463814448434,
+      "lat": 41.880522223965656
+    },
+    "country": "United States"
   },
   {
     "name": "National Research Council Canada",
-    "url": "https://login.pass.cisti-icist.nrc-cnrc.gc.ca/login?url=$@"
+    "url": "https://login.pass.cisti-icist.nrc-cnrc.gc.ca/login?url=",
+    "location": {
+      "lng": -106.346771,
+      "lat": 56.130366
+    },
+    "country": "Canada"
   },
   {
     "name": "National Sun Yat-sen",
-    "url": "http://ezproxy.lib.nsysu.edu.tw:8080/login?url=$@"
+    "url": "http://ezproxy.lib.nsysu.edu.tw:8080/login?url=",
+    "location": {
+      "lng": 120.2647299,
+      "lat": 22.6283384
+    },
+    "country": "Taiwan"
   },
   {
     "name": "National Taichung University of Science and Technology",
-    "url": "http://libsw.nutc.edu.tw:2048/login?url=$@"
+    "url": "http://libsw.nutc.edu.tw:2048/login?url=",
+    "location": {
+      "lng": 120.6837712,
+      "lat": 24.1497433
+    },
+    "country": "Taiwan"
   },
   {
     "name": "National Taipei University",
-    "url": "http://sw.library.ntpu.edu.tw:81/login?url=$@"
+    "url": "http://sw.library.ntpu.edu.tw:81/login?url=",
+    "location": {
+      "lng": 121.3709602,
+      "lat": 24.9440905
+    },
+    "country": "Taiwan"
   },
   {
     "name": "National Tsing Hua University",
-    "url": "https://nthulib-oc.nthu.edu.tw/login?url=$@"
+    "url": "https://nthulib-oc.nthu.edu.tw/login?url=",
+    "location": {
+      "lng": 120.9966699,
+      "lat": 24.7961217
+    },
+    "country": "Taiwan"
   },
   {
     "name": "National University of Colombia",
-    "url": "https://login.ezproxy.unal.edu.co/login?url=$@"
+    "url": "https://login.ezproxy.unal.edu.co/login?url=",
+    "location": {
+      "lng": -74.08404639999999,
+      "lat": 4.6381938
+    },
+    "country": "Colombia"
   },
   {
     "name": "National University of Ireland, Galway",
-    "url": "https://nuigalway.idm.oclc.org/login?url=$@"
+    "url": "https://nuigalway.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -9.0617372,
+      "lat": 53.27915489999999
+    },
+    "country": "Ireland"
   },
   {
     "name": "National University of Kaohsiung",
-    "url": "http://libsw.nuk.edu.tw/login?url=$@"
+    "url": "http://libsw.nuk.edu.tw/login?url=",
+    "location": {
+      "lng": 120.2845572,
+      "lat": 22.7333814
+    },
+    "country": "Taiwan"
   },
   {
     "name": "National University of Natural Medicine",
-    "url": "https://nunm.idm.oclc.org/login?url=$@"
+    "url": "https://nunm.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.6764952,
+      "lat": 45.5018378
+    },
+    "country": "United States"
   },
   {
     "name": "National University of Singapore",
-    "url": "http://libproxy1.nus.edu.sg/login?url=$@"
+    "url": "http://libproxy1.nus.edu.sg/login?url=",
+    "location": {
+      "lng": 103.7763939,
+      "lat": 1.2966426
+    },
+    "country": "Singapore"
   },
   {
-    "name": "National Yang Ming Chiao Tung University",
-    "url": "https://ezproxy.lib.nctu.edu.tw/login?url=$@"
+    "name": "National Yang Ming Chiao Tung Univeristy",
+    "url": "https://ezproxy.lib.nctu.edu.tw/login?url=",
+    "location": {
+      "lng": 120.9974969,
+      "lat": 24.7868862
+    },
+    "country": "Taiwan"
   },
   {
     "name": "National Yang-Ming",
-    "url": "http://ezproxy.lib.ym.edu.tw/login?url=$@"
+    "url": "http://ezproxy.lib.ym.edu.tw/login?url=",
+    "location": {
+      "lng": 120.9974969,
+      "lat": 24.7868862
+    },
+    "country": "Taiwan"
   },
   {
     "name": "Naval Postgraduate School",
-    "url": "http://libproxy.nps.edu/login?url=$@"
+    "url": "http://libproxy.nps.edu/login?url=",
+    "location": {
+      "lng": -121.8741343,
+      "lat": 36.5968995
+    },
+    "country": "United States"
   },
   {
     "name": "Navitas Professional Institute",
-    "url": "https://ezproxy.navitas.com/login?url=$@"
+    "url": "https://ezproxy.navitas.com/login?url=",
+    "location": {
+      "lng": 115.85499447386246,
+      "lat": -31.954140310146638
+    },
+    "country": "Australia"
   },
   {
     "name": "Nazarbayev University",
-    "url": "http://ezproxy.nu.edu.kz:2048/login?url=$@"
+    "url": "http://ezproxy.nu.edu.kz:2048/login?url=",
+    "location": {
+      "lng": 71.3981646,
+      "lat": 51.0905303
+    },
+    "country": "Kazakhstan"
   },
   {
     "name": "Nebraska Wesleyan",
-    "url": "https://login.thor.nebrwesleyan.edu/login?url=$@"
+    "url": "https://login.thor.nebrwesleyan.edu/login?url=",
+    "location": {
+      "lng": -96.6509439,
+      "lat": 40.838785
+    },
+    "country": "United States"
   },
   {
     "name": "Nelson Marlborough Institute of Technology",
-    "url": "http://llcp.nmit.ac.nz:2048/login?url=$@"
+    "url": "http://llcp.nmit.ac.nz:2048/login?url=",
+    "location": {
+      "lng": 173.2885334,
+      "lat": -41.2753759
+    },
+    "country": "New Zealand"
   },
   {
     "name": "Neosho County",
-    "url": "http://ezproxy.neosho.edu:2048/login?url=$@"
+    "url": "http://ezproxy.neosho.edu:2048/login?url=",
+    "location": {
+      "lng": -95.3102505,
+      "lat": 37.6045688
+    },
+    "country": "United States"
   },
   {
     "name": "Netherlands Institute of Ecology (NIOO-KNAW)",
-    "url": "http://ezproxy.nioo.knaw.nl/login?url=$@"
+    "url": "http://ezproxy.nioo.knaw.nl/login?url=",
+    "location": {
+      "lng": 5.6711618,
+      "lat": 51.9869795
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Nevada State",
-    "url": "http://ozone.nsc.edu:8080/login?url=$@"
+    "url": "http://ozone.nsc.edu:8080/login?url=",
+    "location": {
+      "lng": -116.419389,
+      "lat": 38.8026097
+    },
+    "country": "United States"
   },
   {
     "name": "New Jersey City",
-    "url": "http://draweb.njcu.edu:2048/login?url=$@"
+    "url": "http://draweb.njcu.edu:2048/login?url=",
+    "location": {
+      "lng": -74.0431435,
+      "lat": 40.7177545
+    },
+    "country": "United States"
   },
   {
     "name": "New Jersey Institute of Technology",
-    "url": "http://libdb.njit.edu:8888/login?url=$@"
+    "url": "http://libdb.njit.edu:8888/login?url=",
+    "location": {
+      "lng": -74.1793225,
+      "lat": 40.7423462
+    },
+    "country": "United States"
   },
   {
     "name": "New Mexico Highlands",
-    "url": "http://donnelly.nmhu.edu:2048/login?url=$@"
+    "url": "http://donnelly.nmhu.edu:2048/login?url=",
+    "location": {
+      "lng": -105.2192167,
+      "lat": 35.5962101
+    },
+    "country": "United States"
   },
   {
     "name": "New Mexico Junior",
-    "url": "http://ezproxy.nmjc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.nmjc.edu:2048/login?url=",
+    "location": {
+      "lng": -103.181831,
+      "lat": 32.759944
+    },
+    "country": "United States"
   },
   {
     "name": "New Mexico State University",
-    "url": "http://libezp.nmsu.edu:2048/login?url=$@"
+    "url": "http://libezp.nmsu.edu:2048/login?url=",
+    "location": {
+      "lng": -106.7491391,
+      "lat": 32.2792887
+    },
+    "country": "United States"
   },
   {
     "name": "New River Community and Technical",
-    "url": "http://nrproxy.newriver.edu/login?url=$@"
+    "url": "http://nrproxy.newriver.edu/login?url=",
+    "location": {
+      "lng": -81.1357293,
+      "lat": 37.7674765
+    },
+    "country": "United States"
   },
   {
     "name": "New York Chiropractic",
-    "url": "http://ezproxy.nycc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.nycc.edu:2048/login?url=",
+    "location": {
+      "lng": -74.0059728,
+      "lat": 40.7127753
+    },
+    "country": "United States"
   },
   {
     "name": "New York College of Podiatric Medicine",
-    "url": "https://nycpm.idm.oclc.org/login?url=$@"
+    "url": "https://nycpm.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -73.9403658,
+      "lat": 40.8049519
+    },
+    "country": "United States"
   },
   {
     "name": "New York Institute of Technology",
-    "url": "http://arktos.nyit.edu/login?url=$@"
+    "url": "http://arktos.nyit.edu/login?url=",
+    "location": {
+      "lng": -73.6033947070762,
+      "lat": 40.817338995275186
+    },
+    "country": "United States"
   },
   {
     "name": "New York Public Library",
-    "url": "https://login.i.ezproxy.nypl.org/login?qurl=$@"
+    "url": "https://login.i.ezproxy.nypl.org/login?qurl=",
+    "location": {
+      "lng": -74.0059728,
+      "lat": 40.7127753
+    },
+    "country": "United States"
   },
   {
     "name": "New York University (NYU)",
-    "url": "https://ezproxy.library.nyu.edu/login?url=$@"
+    "url": "https://ezproxy.library.nyu.edu/login?url=",
+    "location": {
+      "lng": -73.9964609,
+      "lat": 40.72951339999999
+    },
+    "country": "United States"
   },
   {
     "name": "Newcastle University",
-    "url": "http://libproxy.ncl.ac.uk/login?url=$@"
+    "url": "http://libproxy.ncl.ac.uk/login?url=",
+    "location": {
+      "lng": -1.6147156868252108,
+      "lat": 54.97932243520263
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Niagara",
-    "url": "http://ezproxy.niagara.edu:2048/login?url=$@"
+    "url": "http://ezproxy.niagara.edu:2048/login?url=",
+    "location": {
+      "lng": -79.07416289999999,
+      "lat": 43.0828162
+    },
+    "country": "United States"
   },
   {
     "name": "Nipissing University",
-    "url": "http://roxy.nipissingu.ca/login?url=$@"
+    "url": "http://roxy.nipissingu.ca/login?url=",
+    "location": {
+      "lng": -79.49083460000001,
+      "lat": 46.3410121
+    },
+    "country": "Canada"
   },
   {
     "name": "NMIMS",
-    "url": "https://ezproxy.svkm.ac.in/login?url=$@"
+    "url": "https://ezproxy.svkm.ac.in/login?url=",
+    "location": {
+      "lng": 72.83659879999999,
+      "lat": 19.1033037
+    },
+    "country": "India"
   },
   {
     "name": "Noble and Greenough School",
-    "url": "https://ezproxy.nobles.edu/login?url=$@"
+    "url": "https://ezproxy.nobles.edu/login?url=",
+    "location": {
+      "lng": -71.18503494443523,
+      "lat": 42.262370254761706
+    },
+    "country": "United States"
   },
   {
     "name": "North Carolina A&T State University",
-    "url": "http://ncat.idm.oclc.org/login?url=$@"
+    "url": "http://ncat.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -79.01929969999999,
+      "lat": 35.7595731
+    },
+    "country": "United States"
   },
   {
     "name": "North Carolina State University",
-    "url": "http://proxying.lib.ncsu.edu/index.php?url=$@"
+    "url": "http://proxying.lib.ncsu.edu/index.php?url=",
+    "location": {
+      "lng": -78.6820946,
+      "lat": 35.7846633
+    },
+    "country": "United States"
   },
   {
     "name": "North Central Texas College",
-    "url": "http://www.ezproxy.nctc.edu/login?url=$@"
+    "url": "http://www.ezproxy.nctc.edu/login?url=",
+    "location": {
+      "lng": -97.16594049999999,
+      "lat": 33.6187918
+    },
+    "country": "United States"
   },
   {
     "name": "North Central University",
-    "url": "https://ezproxy.northcentral.edu/login?url=$@"
+    "url": "https://ezproxy.northcentral.edu/login?url=",
+    "location": {
+      "lng": -93.26217525999988,
+      "lat": 44.968981873484374
+    },
+    "country": "United States"
   },
   {
     "name": "North Dakota State University",
-    "url": "https://ezproxy.lib.ndsu.nodak.edu/login?url=$@"
+    "url": "https://ezproxy.lib.ndsu.nodak.edu/login?url=",
+    "location": {
+      "lng": -96.8024367,
+      "lat": 46.8977528
+    },
+    "country": "United States"
   },
   {
     "name": "North Idaho",
-    "url": "http://ezproxy1.nic.edu:2048/login?url=$@"
+    "url": "http://ezproxy1.nic.edu:2048/login?url=",
+    "location": {
+      "lng": -117.0018462,
+      "lat": 46.4152745
+    },
+    "country": "United States"
   },
   {
     "name": "North Iowa Area",
-    "url": "http://ezproxy.niacc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.niacc.edu:2048/login?url=",
+    "location": {
+      "lng": -93.13282079999999,
+      "lat": 43.156929
+    },
+    "country": "United States"
   },
   {
     "name": "North-West University",
-    "url": "http://nwulib.nwu.ac.za/login?url=$@"
+    "url": "http://nwulib.nwu.ac.za/login?url=",
+    "location": {
+      "lng": 27.0928977,
+      "lat": -26.6906445
+    },
+    "country": "South Africa"
   },
   {
     "name": "Northeast Texas",
-    "url": "http://unicorn.ntcc.edu:2048/login?url=$@"
+    "url": "http://unicorn.ntcc.edu:2048/login?url=",
+    "location": {
+      "lng": -94.75097939999999,
+      "lat": 32.4990747
+    },
+    "country": "United States"
   },
   {
     "name": "Northeast Wisconsin Technical",
-    "url": "http://ezproxy.nwtc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.nwtc.edu:2048/login?url=",
+    "location": {
+      "lng": -88.10732639999999,
+      "lat": 44.5272605
+    },
+    "country": "United States"
   },
   {
     "name": "Northeastern Illinois",
-    "url": "http://neiulibrary.idm.oclc.org/login?url=$@"
+    "url": "http://neiulibrary.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -87.7188527,
+      "lat": 41.9794789
+    },
+    "country": "United States"
   },
   {
     "name": "Northeastern University",
-    "url": "http://ezproxy.neu.edu/login?URL=$@"
+    "url": "http://ezproxy.neu.edu/login?URL=",
+    "location": {
+      "lng": -71.0891717,
+      "lat": 42.3398067
+    },
+    "country": "United States"
   },
   {
     "name": "Northern Arizona",
-    "url": "http://libproxy.nau.edu/login?url=$@"
+    "url": "http://libproxy.nau.edu/login?url=",
+    "location": {
+      "lng": -111.6540336,
+      "lat": 35.1802684
+    },
+    "country": "United States"
   },
   {
     "name": "Northern Kentucky",
-    "url": "http://proxy1.nku.edu/login?url=$@"
+    "url": "http://proxy1.nku.edu/login?url=",
+    "location": {
+      "lng": -84.4625345,
+      "lat": 39.0312035
+    },
+    "country": "United States"
   },
   {
     "name": "Northern Kentucky University",
-    "url": "https://ezproxy.lib.nku.edu/login?url=$@"
+    "url": "https://ezproxy.lib.nku.edu/login?url=",
+    "location": {
+      "lng": -84.4625345,
+      "lat": 39.0312035
+    },
+    "country": "United States"
   },
   {
     "name": "Northern Michigan",
-    "url": "http://ezpolson.nmu.edu:2048/login?url=$@"
+    "url": "http://ezpolson.nmu.edu:2048/login?url=",
+    "location": {
+      "lng": -87.4076051,
+      "lat": 46.5601965
+    },
+    "country": "United States"
   },
   {
     "name": "Northern Ontario School of Medicine",
-    "url": "http://normedproxy.lakeheadu.ca/login?URL=$@"
+    "url": "http://normedproxy.lakeheadu.ca/login?URL=",
+    "location": {
+      "lng": -80.9640026,
+      "lat": 46.463603
+    },
+    "country": "Canada"
   },
   {
     "name": "Northern Ontario School of Medicine (NOSM)",
-    "url": "https://proxy.lib.nosm.ca/login?url=$@"
+    "url": "https://proxy.lib.nosm.ca/login?url=",
+    "location": {
+      "lng": -80.9640026,
+      "lat": 46.463603
+    },
+    "country": "Canada"
   },
   {
     "name": "Northern Territory Health Library",
-    "url": "https://login.www.ezpdhcs.nt.gov.au/login?url=$@"
+    "url": "https://login.www.ezpdhcs.nt.gov.au/login?url=",
+    "location": {
+      "lng": 132.5509603,
+      "lat": -19.4914108
+    },
+    "country": "Australia"
   },
   {
     "name": "Northwest Mississippi",
-    "url": "http://ezproxy.northwestms.edu:2048/login?url=$@"
+    "url": "http://ezproxy.northwestms.edu:2048/login?url=",
+    "location": {
+      "lng": -89.96948119999999,
+      "lat": 34.6254741
+    },
+    "country": "United States"
   },
   {
     "name": "Northwest Missouri State",
-    "url": "http://ezproxy.nwmissouri.edu:2048/login?url=$@"
+    "url": "http://ezproxy.nwmissouri.edu:2048/login?url=",
+    "location": {
+      "lng": -94.8825243,
+      "lat": 40.3519854
+    },
+    "country": "United States"
   },
   {
     "name": "Northwestern",
-    "url": "http://ezproxy.galter.northwestern.edu/login?url=$@"
+    "url": "http://ezproxy.galter.northwestern.edu/login?url=",
+    "location": {
+      "lng": -87.67526699999999,
+      "lat": 42.0564594
+    },
+    "country": "United States"
   },
   {
     "name": "Northwestern Michigan",
-    "url": "https://login.proxy.nmc.edu/login?url=$@"
+    "url": "https://login.proxy.nmc.edu/login?url=",
+    "location": {
+      "lng": -85.5824341,
+      "lat": 44.7659019
+    },
+    "country": "United States"
   },
   {
     "name": "Northwestern State University of Louisiana",
-    "url": "http://ezproxy.nsula.edu/login?url=$@"
+    "url": "http://ezproxy.nsula.edu/login?url=",
+    "location": {
+      "lng": -93.097876,
+      "lat": 31.7489726
+    },
+    "country": "United States"
   },
   {
     "name": "Northwestern University",
-    "url": "http://turing.library.northwestern.edu/login?url=$@"
+    "url": "http://turing.library.northwestern.edu/login?url=",
+    "location": {
+      "lng": -87.67526699999999,
+      "lat": 42.0564594
+    },
+    "country": "United States"
   },
   {
     "name": "Norwegian School of Economics",
-    "url": "https://ezproxy.nhh.no/login?url=$@"
+    "url": "https://ezproxy.nhh.no/login?url=",
+    "location": {
+      "lng": 5.3024087,
+      "lat": 60.42293759999999
+    },
+    "country": "Norway"
   },
   {
     "name": "Norwich",
-    "url": "http://library.norwich.edu/login?url=$@"
+    "url": "http://library.norwich.edu/login?url=",
+    "location": {
+      "lng": 1.2978802,
+      "lat": 52.6292567
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Notre Dame",
-    "url": "http://proxy.library.nd.edu/login?url=$@"
+    "url": "http://proxy.library.nd.edu/login?url=",
+    "location": {
+      "lng": 2.3499021,
+      "lat": 48.85296820000001
+    },
+    "country": "France"
   },
   {
     "name": "Notre Dame University-Louaize",
-    "url": "http://http://neptune.ndu.edu.lb:2048/login?url=$@"
+    "url": "http://http://neptune.ndu.edu.lb:2048/login?url=",
+    "location": {
+      "lng": 35.6151545,
+      "lat": 33.9506781
+    },
+    "country": "Lebanon"
   },
   {
     "name": "Nottingham Trent University",
-    "url": "http://ntu.idm.oclc.org/login?url=$@"
+    "url": "http://ntu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -1.1542327,
+      "lat": 52.9581371
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Nova Southeastern",
-    "url": "http://ezproxylocal.library.nova.edu/login?url=$@"
+    "url": "http://ezproxylocal.library.nova.edu/login?url=",
+    "location": {
+      "lng": -80.2457075,
+      "lat": 26.0786011
+    },
+    "country": "United States"
   },
   {
     "name": "Nova Southeastern University",
-    "url": "https://sherman.library.nova.edu/auth/index.php?qurl=$@"
+    "url": "https://sherman.library.nova.edu/auth/index.php?qurl=",
+    "location": {
+      "lng": -80.2457075,
+      "lat": 26.0786011
+    },
+    "country": "United States"
   },
   {
     "name": "Nunez Community College",
-    "url": "https://nunez.idm.oclc.org/login?url=$@"
+    "url": "https://nunez.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -89.96083921920405,
+      "lat": 29.954783117551013
+    },
+    "country": "United States"
   },
   {
     "name": "NYU Alumni",
-    "url": "http://alumniproxy.library.nyu.edu/login?url=$@"
+    "url": "http://alumniproxy.library.nyu.edu/login?url=",
+    "location": {
+      "lng": -73.9964609,
+      "lat": 40.72951339999999
+    },
+    "country": "United States"
   },
   {
     "name": "NYU Medical",
-    "url": "https://ezproxy.med.nyu.edu/login?url=$@"
+    "url": "https://ezproxy.med.nyu.edu/login?url=",
+    "location": {
+      "lng": -73.9964609,
+      "lat": 40.72951339999999
+    },
+    "country": "United States"
   },
   {
     "name": "Národní technická knihovna",
-    "url": "https://ezproxy.techlib.cz/login/?url=$@"
+    "url": "https://ezproxy.techlib.cz/login/?url=",
+    "location": {
+      "lng": 14.3906537,
+      "lat": 50.1038974
+    },
+    "country": "Czechia"
   },
   {
     "name": "Oak Ridge National Laboratory",
-    "url": "http://orproxy.lib.utk.edu:2048/login?url=$@"
+    "url": "http://orproxy.lib.utk.edu:2048/login?url=",
+    "location": {
+      "lng": -84.3101161,
+      "lat": 35.9311679
+    },
+    "country": "United States"
   },
   {
     "name": "Oakland Public Library",
-    "url": "http://opl.idm.oclc.org/login?url=$@"
+    "url": "http://opl.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.26378808263769,
+      "lat": 37.80113784781194
+    },
+    "country": "United States"
   },
   {
     "name": "Oakland University William Beaumont SOM",
-    "url": "https://huaryu.kl.oakland.edu/login?url=$@"
+    "url": "https://huaryu.kl.oakland.edu/login?url=",
+    "location": {
+      "lng": -83.2152964,
+      "lat": 42.6744905
+    },
+    "country": "United States"
   },
   {
     "name": "Oakton",
-    "url": "http://oaktonlibrary.oakton.edu:2048/login?url=$@"
+    "url": "http://oaktonlibrary.oakton.edu:2048/login?url=",
+    "location": {
+      "lng": -77.3008172,
+      "lat": 38.8809451
+    },
+    "country": "United States"
   },
   {
     "name": "Oakwood University",
-    "url": "http://www.oakwood.edu:2048/login?url=$@"
+    "url": "http://www.oakwood.edu:2048/login?url=",
+    "location": {
+      "lng": -86.65561848524791,
+      "lat": 34.75229782171196
+    },
+    "country": "United States"
   },
   {
     "name": "Oberlin",
-    "url": "http://ezproxy.oberlin.edu/login?url=$@"
+    "url": "http://ezproxy.oberlin.edu/login?url=",
+    "location": {
+      "lng": -82.21737859999999,
+      "lat": 41.2939386
+    },
+    "country": "United States"
   },
   {
     "name": "Observatoire de Paris",
-    "url": "http://ezproxy.obspm.fr/login?url=$@"
+    "url": "http://ezproxy.obspm.fr/login?url=",
+    "location": {
+      "lng": 2.334253,
+      "lat": 48.83596530000001
+    },
+    "country": "France"
   },
   {
     "name": "OCAD",
-    "url": "https://ocadu.idm.oclc.org/login?url=$@"
+    "url": "https://ocadu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -79.3914842,
+      "lat": 43.65318449999999
+    },
+    "country": "Canada"
   },
   {
     "name": "Ohio",
-    "url": "http://proxy.library.ohiou.edu/login?url=$@"
+    "url": "http://proxy.library.ohiou.edu/login?url=",
+    "location": {
+      "lng": -82.90712300000001,
+      "lat": 40.4172871
+    },
+    "country": "United States"
   },
   {
     "name": "Ohio State University",
-    "url": "https://proxy.lib.ohio-state.edu/login?url=$@"
+    "url": "https://proxy.lib.ohio-state.edu/login?url=",
+    "location": {
+      "lng": -83.0304546,
+      "lat": 40.0066723
+    },
+    "country": "United States"
   },
   {
     "name": "OhioLink",
-    "url": "http://proxy.ohiolink.edu:9099/login?url=$@"
+    "url": "http://proxy.ohiolink.edu:9099/login?url=",
+    "location": {
+      "lng": -83.04053266136894,
+      "lat": 40.00012431476218
+    },
+    "country": "United States"
   },
   {
     "name": "Okinawa Institute of Science and Technology",
-    "url": "https://login.ezproxy.oist.jp/login?url=$@"
+    "url": "https://login.ezproxy.oist.jp/login?url=",
+    "location": {
+      "lng": 127.8301869,
+      "lat": 26.4643027
+    },
+    "country": "Japan"
   },
   {
     "name": "Oklahoma Baptist",
-    "url": "http://ezproxy.okbu.edu:2048/login?url=$@"
+    "url": "http://ezproxy.okbu.edu:2048/login?url=",
+    "location": {
+      "lng": -96.93511160000001,
+      "lat": 35.3614905
+    },
+    "country": "United States"
   },
   {
     "name": "Oklahoma Christian",
-    "url": "http://proxy.oc.edu:2048/login?url=$@"
+    "url": "http://proxy.oc.edu:2048/login?url=",
+    "location": {
+      "lng": -97.4697937,
+      "lat": 35.6126232
+    },
+    "country": "United States"
   },
   {
     "name": "Oklahoma State",
-    "url": "https://login.argo.library.okstate.edu/login?url=$@"
+    "url": "https://login.argo.library.okstate.edu/login?url=",
+    "location": {
+      "lng": -97.092877,
+      "lat": 35.0077519
+    },
+    "country": "United States"
   },
   {
     "name": "Oklahoma State University Tulsa",
-    "url": "http://ezproxy.osu-tulsa.okstate.edu/login?url=$@"
+    "url": "http://ezproxy.osu-tulsa.okstate.edu/login?url=",
+    "location": {
+      "lng": -95.9880553,
+      "lat": 36.1638478
+    },
+    "country": "United States"
   },
   {
     "name": "Old Dominion University",
-    "url": "http://proxy.lib.odu.edu/login?url=$@"
+    "url": "http://proxy.lib.odu.edu/login?url=",
+    "location": {
+      "lng": -76.3058786,
+      "lat": 36.8853217
+    },
+    "country": "United States"
   },
   {
     "name": "Olympic College",
-    "url": "http://ezproxy.olympic.edu:2048/login?url=$@"
+    "url": "http://ezproxy.olympic.edu:2048/login?url=",
+    "location": {
+      "lng": -122.63518312430871,
+      "lat": 47.575379406817625
+    },
+    "country": "United States"
   },
   {
     "name": "Open Polytechnic",
-    "url": "http://campus-gw.openpolytechnic.ac.nz/login?url=$@"
+    "url": "http://campus-gw.openpolytechnic.ac.nz/login?url=",
+    "location": {
+      "lng": 174.9313866,
+      "lat": -41.2185012
+    },
+    "country": "New Zealand"
   },
   {
     "name": "Open Universiteit",
-    "url": "http://login.ezproxy.elib10.ub.unimaas.nl/login?url=$@"
+    "url": "http://login.ezproxy.elib10.ub.unimaas.nl/login?url=",
+    "location": {
+      "lng": 5.9582757,
+      "lat": 50.8783644
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Open Universiteit Nederland",
-    "url": "https://login.ezproxy.elib11.ub.unimaas.nl/login?url=$@"
+    "url": "https://login.ezproxy.elib11.ub.unimaas.nl/login?url=",
+    "location": {
+      "lng": 5.9582757,
+      "lat": 50.8783644
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Open University",
-    "url": "http://libezproxy.open.ac.uk/login?url=$@"
+    "url": "http://libezproxy.open.ac.uk/login?url=",
+    "location": {
+      "lng": -0.7081895,
+      "lat": 52.02492950000001
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Open University of Israel",
-    "url": "https://elib.openu.ac.il/login?url=$@"
+    "url": "https://elib.openu.ac.il/login?url=",
+    "location": {
+      "lng": 34.887685,
+      "lat": 32.188588
+    },
+    "country": "Israel"
   },
   {
     "name": "Oral Roberts University",
-    "url": "http://ezproxy.oru.edu:2048/login?url=$@"
+    "url": "http://ezproxy.oru.edu:2048/login?url=",
+    "location": {
+      "lng": -95.95294944511247,
+      "lat": 36.05101629198966
+    },
+    "country": "United States"
   },
   {
     "name": "Oregon College of Oriental Medicine",
-    "url": "https://ezproxy.ocom.edu:2443/login?url=$@"
+    "url": "https://ezproxy.ocom.edu:2443/login?url=",
+    "location": {
+      "lng": -122.6710932,
+      "lat": 45.52396419999999
+    },
+    "country": "United States"
   },
   {
     "name": "Oregon Health & Sciences University",
-    "url": "http://liboff.ohsu.edu/login?url=$@"
+    "url": "http://liboff.ohsu.edu/login?url=",
+    "location": {
+      "lng": -120.5542012,
+      "lat": 43.8041334
+    },
+    "country": "United States"
   },
   {
     "name": "Oregon Institute of Technology",
-    "url": "https://libproxy.oit.edu/login?url=$@"
+    "url": "https://libproxy.oit.edu/login?url=",
+    "location": {
+      "lng": -121.7851951,
+      "lat": 42.2570051
+    },
+    "country": "United States"
   },
   {
     "name": "Oregon State",
-    "url": "http://proxy.library.oregonstate.edu/login?url=$@"
+    "url": "http://proxy.library.oregonstate.edu/login?url=",
+    "location": {
+      "lng": -120.5542012,
+      "lat": 43.8041334
+    },
+    "country": "United States"
   },
   {
     "name": "Oregon State University",
-    "url": "https://login.ezproxy.proxy.library.oregonstate.edu/login?url=$@"
+    "url": "https://login.ezproxy.proxy.library.oregonstate.edu/login?url=",
+    "location": {
+      "lng": -123.2794442,
+      "lat": 44.5637806
+    },
+    "country": "United States"
   },
   {
     "name": "Osaka",
-    "url": "http://remote.library.osaka-u.ac.jp/login?url=$@"
+    "url": "http://remote.library.osaka-u.ac.jp/login?url=",
+    "location": {
+      "lng": 135.5022535,
+      "lat": 34.6937249
+    },
+    "country": "Japan"
   },
   {
     "name": "OSF HealthCare",
-    "url": "http://libproxy.osfhealthcare.org/login?url=$@"
+    "url": "http://libproxy.osfhealthcare.org/login?url=",
+    "location": {
+      "lng": -89.59037028021434,
+      "lat": 40.69113410998877
+    },
+    "country": "United States"
   },
   {
     "name": "Ottawa Public Library",
-    "url": "http://ezproxy.biblioottawalibrary.ca/login?url=$@"
+    "url": "http://ezproxy.biblioottawalibrary.ca/login?url=",
+    "location": {
+      "lng": -75.89525642850435,
+      "lat": 45.32146161398508
+    },
+    "country": "Canada"
   },
   {
     "name": "Otterbein",
-    "url": "http://ezproxy2.otterbein.edu/login?url=$@"
+    "url": "http://ezproxy2.otterbein.edu/login?url=",
+    "location": {
+      "lng": -82.9371852,
+      "lat": 40.1268746
+    },
+    "country": "United States"
   },
   {
     "name": "Oxford Brookes University",
-    "url": "https://oxfordbrookes.idm.oclc.org/login?url=$@"
+    "url": "https://oxfordbrookes.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -1.2243230010788608,
+      "lat": 51.755559360640696
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Pace University",
-    "url": "http://rlib.pace.edu/login?url=$@"
+    "url": "http://rlib.pace.edu/login?url=",
+    "location": {
+      "lng": -74.00508364400669,
+      "lat": 40.71233338492282
+    },
+    "country": "United States"
   },
   {
     "name": "Pacific",
-    "url": "http://proxy.lib.pacificu.edu:2048/login?url=$@"
+    "url": "http://proxy.lib.pacificu.edu:2048/login?url=",
+    "location": {
+      "lng": -124.508523,
+      "lat": -8.783195
+    },
+    "country": ""
   },
   {
     "name": "Pacific Lutheran",
-    "url": "http://ezproxy.plu.edu/login?url=$@"
+    "url": "http://ezproxy.plu.edu/login?url=",
+    "location": {
+      "lng": -122.4436669,
+      "lat": 47.14519310000001
+    },
+    "country": "United States"
   },
   {
     "name": "Pacific Union College",
-    "url": "http://libproxy.puc.edu/login?url=$@"
+    "url": "http://libproxy.puc.edu/login?url=",
+    "location": {
+      "lng": -122.43973618566122,
+      "lat": 38.57053060829952
+    },
+    "country": "United States"
   },
   {
     "name": "Pacifica Graduate Institute",
-    "url": "http://pgi.idm.oclc.org/login?url=$@"
+    "url": "http://pgi.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -119.5805358,
+      "lat": 34.4219474
+    },
+    "country": "United States"
   },
   {
     "name": "Palestine Polytechnic University",
-    "url": "http://ezproxy.ppu.edu:8080/login?url=$@"
+    "url": "http://ezproxy.ppu.edu:8080/login?url=",
+    "location": {
+      "lng": 35.0903491,
+      "lat": 31.5066556
+    },
+    "country": ""
   },
   {
     "name": "Palomar",
-    "url": "http://prozy.palomar.edu/login?url=$@"
+    "url": "http://prozy.palomar.edu/login?url=",
+    "location": {
+      "lng": -117.1821885,
+      "lat": 33.1512505
+    },
+    "country": "United States"
   },
   {
     "name": "Panola College",
-    "url": "http://pas.panola.edu:2048/login?url=$@"
+    "url": "http://pas.panola.edu:2048/login?url=",
+    "location": {
+      "lng": -94.3564504,
+      "lat": 32.1560799
+    },
+    "country": "United States"
   },
   {
     "name": "Paracelsus Medizinischen PrivatUni",
-    "url": "https://ez.srv.pmu.ac.at/login?url=$@"
+    "url": "https://ez.srv.pmu.ac.at/login?url=",
+    "location": {
+      "lng": 12.983645206177853,
+      "lat": 47.912340440840325
+    },
+    "country": "Austria"
   },
   {
     "name": "Pellissippi State Technical",
-    "url": "http://ezproxy.pstcc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.pstcc.edu:2048/login?url=",
+    "location": {
+      "lng": -84.16579779999999,
+      "lat": 35.9487513
+    },
+    "country": "United States"
   },
   {
     "name": "Peninsula Library System",
-    "url": "https://login.ezproxy.plsinfo.org/login?url=$@"
+    "url": "https://login.ezproxy.plsinfo.org/login?url=",
+    "location": {
+      "lng": -71.9544571892695,
+      "lat": 41.57848918077987
+    },
+    "country": "United States"
   },
   {
     "name": "Penn Foster College",
-    "url": "https://my.pennfoster.edu/login?url=$@"
+    "url": "https://my.pennfoster.edu/login?url=",
+    "location": {
+      "lng": -111.8982122,
+      "lat": 33.6161804
+    },
+    "country": "United States"
   },
   {
     "name": "Pennsylvania State University",
-    "url": "http://ezaccess.libraries.psu.edu/login?url=$@"
+    "url": "http://ezaccess.libraries.psu.edu/login?url=",
+    "location": {
+      "lng": -77.8599084,
+      "lat": 40.7982133
+    },
+    "country": "United States"
   },
   {
     "name": "Pepperdine",
-    "url": "http://lib.pepperdine.edu/login?url=$@"
+    "url": "http://lib.pepperdine.edu/login?url=",
+    "location": {
+      "lng": -118.7095814,
+      "lat": 34.0414045
+    },
+    "country": "United States"
   },
   {
     "name": "Peru State",
-    "url": "https://ezproxy.peru.edu/login?url=$@"
+    "url": "https://ezproxy.peru.edu/login?url=",
+    "location": {
+      "lng": -95.7321485,
+      "lat": 40.4747647
+    },
+    "country": "United States"
   },
   {
     "name": "Philadelphia",
-    "url": "https://ezproxy.philau.edu/login?url=$@"
+    "url": "https://ezproxy.philau.edu/login?url=",
+    "location": {
+      "lng": -75.1652215,
+      "lat": 39.9525839
+    },
+    "country": "United States"
   },
   {
     "name": "Philadelphia College of Ostheopathic Medicine",
-    "url": "http://ezproxy.pcom.edu:2048/login?url=$@"
+    "url": "http://ezproxy.pcom.edu:2048/login?url=",
+    "location": {
+      "lng": -75.1652215,
+      "lat": 39.9525839
+    },
+    "country": "United States"
   },
   {
     "name": "Piedmont",
-    "url": "https://login.ezproxy.piedmont.edu/login?url=$@"
+    "url": "https://login.ezproxy.piedmont.edu/login?url=",
+    "location": {
+      "lng": 7.5153885,
+      "lat": 45.0522366
+    },
+    "country": "Italy"
   },
   {
     "name": "Piedmont Virginia Community College",
-    "url": "https://ezpvcc.vccs.edu:2443/login?url=$@"
+    "url": "https://ezpvcc.vccs.edu:2443/login?url=",
+    "location": {
+      "lng": -78.484332,
+      "lat": 38.0063054
+    },
+    "country": "United States"
   },
   {
     "name": "Pisa University",
-    "url": "http://ezproxy.pisa.edu/login?url=$@"
+    "url": "http://ezproxy.pisa.edu/login?url=",
+    "location": {
+      "lng": 10.3988593,
+      "lat": 43.7167235
+    },
+    "country": "Italy"
   },
   {
     "name": "Plymouth",
-    "url": "https://plymouth.idm.oclc.org/login?url=$@"
+    "url": "https://plymouth.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -4.1426565,
+      "lat": 50.3754565
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Point Park",
-    "url": "https://proxy.pointpark.edu/login?url=$@"
+    "url": "https://proxy.pointpark.edu/login?url=",
+    "location": {
+      "lng": -80.0017987,
+      "lat": 40.4384916
+    },
+    "country": "United States"
   },
   {
     "name": "Point University",
-    "url": "http://ezproxy.point.edu:2048/login?url=$@"
+    "url": "http://ezproxy.point.edu:2048/login?url=",
+    "location": {
+      "lng": -85.18485164878003,
+      "lat": 32.879303413312634
+    },
+    "country": "United States"
   },
   {
     "name": "Politecnico di Torino",
-    "url": "https://www.ezproxy.biblio.polito.it/login?url=$@"
+    "url": "https://www.ezproxy.biblio.polito.it/login?url=",
+    "location": {
+      "lng": 7.660124700000001,
+      "lat": 45.0632841
+    },
+    "country": "Italy"
   },
   {
     "name": "Pontificia Universidad Católica de Chile",
-    "url": "http://ezproxy.puc.cl/login?url=$@"
+    "url": "http://ezproxy.puc.cl/login?url=",
+    "location": {
+      "lng": -70.6399544,
+      "lat": -33.44180680000001
+    },
+    "country": "Chile"
   },
   {
     "name": "Pontificia Universidad Católica del Perú",
-    "url": "http://ezproxybib.pucp.edu.pe:2048/login?url=$@"
+    "url": "http://ezproxybib.pucp.edu.pe:2048/login?url=",
+    "location": {
+      "lng": -77.0780608,
+      "lat": -12.0689502
+    },
+    "country": "Peru"
   },
   {
     "name": "Pontificia Universidad Javeriana Bogotá",
-    "url": "https://login.ezproxy.javeriana.edu.co/login?url=$@"
+    "url": "https://login.ezproxy.javeriana.edu.co/login?url=",
+    "location": {
+      "lng": -74.06466449999999,
+      "lat": 4.628487499999999
+    },
+    "country": "Colombia"
   },
   {
     "name": "Pontificia Universidad Javeriana, Cali",
-    "url": "http://bdbib.javerianacali.edu.co/login?url=$@"
+    "url": "http://bdbib.javerianacali.edu.co/login?url=",
+    "location": {
+      "lng": -76.5316285,
+      "lat": 3.3487239
+    },
+    "country": "Colombia"
   },
   {
     "name": "Portland State",
-    "url": "http://proxy.lib.pdx.edu/login?url=$@"
+    "url": "http://proxy.lib.pdx.edu/login?url=",
+    "location": {
+      "lng": -122.6833385,
+      "lat": 45.5111153
+    },
+    "country": "United States"
   },
   {
     "name": "Prairie View A M",
-    "url": "http://pvamu.idm.oclc.org/login?url=$@"
+    "url": "http://pvamu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -95.9907076,
+      "lat": 30.0954974
+    },
+    "country": "United States"
   },
   {
     "name": "Pratt Institute",
-    "url": "https://ezproxy.pratt.edu/login?url=$@"
+    "url": "https://ezproxy.pratt.edu/login?url=",
+    "location": {
+      "lng": -73.9629858,
+      "lat": 40.6913844
+    },
+    "country": "United States"
   },
   {
     "name": "Prescott",
-    "url": "http://ezproxy.prescott.edu:2048/login?url=$@"
+    "url": "http://ezproxy.prescott.edu:2048/login?url=",
+    "location": {
+      "lng": -112.4685025,
+      "lat": 34.5400242
+    },
+    "country": "United States"
   },
   {
     "name": "Princeton Theological Seminary",
-    "url": "http://yeshebi.ptsem.edu:2048/login?url=$@"
+    "url": "http://yeshebi.ptsem.edu:2048/login?url=",
+    "location": {
+      "lng": -74.6635221,
+      "lat": 40.3447493
+    },
+    "country": "United States"
   },
   {
     "name": "Princeton University",
-    "url": "http://ezproxy.princeton.edu/login?url=$@"
+    "url": "http://ezproxy.princeton.edu/login?url=",
+    "location": {
+      "lng": -74.65507389999999,
+      "lat": 40.3430942
+    },
+    "country": "United States"
   },
   {
     "name": "Purchase",
-    "url": "http://ezproxy.purchase.edu:2048/login?url=$@"
+    "url": "http://ezproxy.purchase.edu:2048/login?url=",
+    "location": {
+      "lng": -73.700419,
+      "lat": 41.0470553
+    },
+    "country": "United States"
   },
   {
     "name": "Purdue University",
-    "url": "https://login.ezproxy.lib.purdue.edu/login?url=$@"
+    "url": "https://login.ezproxy.lib.purdue.edu/login?url=",
+    "location": {
+      "lng": -86.92119459999999,
+      "lat": 40.4237054
+    },
+    "country": "United States"
   },
   {
     "name": "Purdue University Fort Wayne",
-    "url": "https://ezproxy.library.pfw.edu/login?url=h$@"
+    "url": "https://ezproxy.library.pfw.edu/login?url=h",
+    "location": {
+      "lng": -85.1059405,
+      "lat": 41.1184535
+    },
+    "country": "United States"
   },
   {
     "name": "Queen Mary University of London",
-    "url": "https://login.ezproxy.library.qmul.ac.uk/login?url=$@"
+    "url": "https://login.ezproxy.library.qmul.ac.uk/login?url=",
+    "location": {
+      "lng": -0.0403745,
+      "lat": 51.5240671
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Queen Mary, University of London",
-    "url": "http://ezproxy.library.qmul.ac.uk/login?url=$@"
+    "url": "http://ezproxy.library.qmul.ac.uk/login?url=",
+    "location": {
+      "lng": -0.0403745,
+      "lat": 51.5240671
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Queen's University",
-    "url": "https://proxy.queensu.ca/login?qurl=$@"
+    "url": "https://proxy.queensu.ca/login?qurl=",
+    "location": {
+      "lng": -76.49514119999999,
+      "lat": 44.2252795
+    },
+    "country": "Canada"
   },
   {
     "name": "Queens",
-    "url": "http://proxy.queensu.ca/login?url=$@"
+    "url": "http://proxy.queensu.ca/login?url=",
+    "location": {
+      "lng": -73.7948516,
+      "lat": 40.7282239
+    },
+    "country": "United States"
   },
   {
     "name": "Queensland University of Teachnology",
-    "url": "https://go.openathens.net/redirector/qut.edu.au?url=$@"
+    "url": "https://go.openathens.net/redirector/qut.edu.au?url=",
+    "location": {
+      "lng": 153.0281982,
+      "lat": -27.4773845
+    },
+    "country": "Australia"
   },
   {
     "name": "Queensland University of Technology",
-    "url": "http://ezp01.library.qut.edu.au/login?url=$@"
+    "url": "http://ezp01.library.qut.edu.au/login?url=",
+    "location": {
+      "lng": 153.0281982,
+      "lat": -27.4773845
+    },
+    "country": "Australia"
   },
   {
     "name": "Quinsigamond Community College",
-    "url": "https://ezproxyqcc.helmlib.org/login?url=$@"
+    "url": "https://ezproxyqcc.helmlib.org/login?url=",
+    "location": {
+      "lng": -71.7936924,
+      "lat": 42.3146459
+    },
+    "country": "United States"
   },
   {
     "name": "Radboud University, Nijmegen",
-    "url": "https://ru.idm.oclc.org/login?url=$@"
+    "url": "https://ru.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 5.863818699999999,
+      "lat": 51.8220189
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Radford",
-    "url": "http://lib-proxy.radford.edu/login?url=$@"
+    "url": "http://lib-proxy.radford.edu/login?url=",
+    "location": {
+      "lng": -80.5764477,
+      "lat": 37.13179239999999
+    },
+    "country": "United States"
   },
   {
     "name": "Reed College",
-    "url": "http://proxy.library.reed.edu/login?url=$@"
+    "url": "http://proxy.library.reed.edu/login?url=",
+    "location": {
+      "lng": -122.6308086,
+      "lat": 45.4810848
+    },
+    "country": "United States"
   },
   {
     "name": "Regent University",
-    "url": "https://library.regent.edu/wamvalidate?url=$@"
+    "url": "https://library.regent.edu/wamvalidate?url=",
+    "location": {
+      "lng": -76.1928949,
+      "lat": 36.8007899
+    },
+    "country": "United States"
   },
   {
     "name": "Regis",
-    "url": "http://dml.regis.edu/login?url=$@"
+    "url": "http://dml.regis.edu/login?url=",
+    "location": {
+      "lng": -105.0302396,
+      "lat": 39.7896087
+    },
+    "country": "United States"
   },
   {
     "name": "Reinhardt University",
-    "url": "http://ezproxy.reinhardt.edu:2048/login?url=$@"
+    "url": "http://ezproxy.reinhardt.edu:2048/login?url=",
+    "location": {
+      "lng": -84.5509513,
+      "lat": 34.3205083
+    },
+    "country": "United States"
   },
   {
     "name": "Rensselaer Polytechnic Institute",
-    "url": "https://libproxy.rpi.edu/login?url=$@"
+    "url": "https://libproxy.rpi.edu/login?url=",
+    "location": {
+      "lng": -73.67888839999999,
+      "lat": 42.7297628
+    },
+    "country": "United States"
   },
   {
     "name": "Rice University",
-    "url": "https://login.ezproxy.rice.edu/login?url=$@"
+    "url": "https://login.ezproxy.rice.edu/login?url=",
+    "location": {
+      "lng": -95.40183119999999,
+      "lat": 29.7173941
+    },
+    "country": "United States"
   },
   {
     "name": "Ripon",
-    "url": "https://login.ripon.idm.oclc.org/login?qurl=$@"
+    "url": "https://login.ripon.idm.oclc.org/login?qurl=",
+    "location": {
+      "lng": -1.5237756,
+      "lat": 54.1361346
+    },
+    "country": "United Kingdom"
+  },
+  {
+    "name": "RIT",
+    "url": "http://ezproxy.rit.edu/login?url=",
+    "location": {
+      "lng": -77.67153549999999,
+      "lat": 43.08484869999999
+    },
+    "country": "United States"
   },
   {
     "name": "Riverside City",
-    "url": "http://ezproxy.rcc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.rcc.edu:2048/login?url=",
+    "location": {
+      "lng": -117.3754942,
+      "lat": 33.9806005
+    },
+    "country": "United States"
   },
   {
-    "name": "RMIT University",
-    "url": "https://login.ezproxy.lib.rmit.edu.au/login?url=$@"
+    "name": "RMIT University ",
+    "url": "https://login.ezproxy.lib.rmit.edu.au/login?url=",
+    "location": {
+      "lng": 144.9639386,
+      "lat": -37.8083332
+    },
+    "country": "Australia"
   },
   {
     "name": "Robert Morris University",
-    "url": "https://reddog.rmu.edu/login?url=$@"
-  },
-  {
-    "name": "Rochester Institute of Technology",
-    "url": "http://ezproxy.rit.edu/login?url=$@"
+    "url": "https://reddog.rmu.edu/login?url=",
+    "location": {
+      "lng": -80.10201104140535,
+      "lat": 41.21315087360136
+    },
+    "country": "United States"
   },
   {
     "name": "Rollins",
-    "url": "http://ezproxy.rollins.edu:2048/login?url=$@"
+    "url": "http://ezproxy.rollins.edu:2048/login?url=",
+    "location": {
+      "lng": -81.3485013,
+      "lat": 28.5927153
+    },
+    "country": "United States"
   },
   {
     "name": "Roosevelt University",
-    "url": "http://ezproxy.roosevelt.edu:2048/login?url=$@"
+    "url": "http://ezproxy.roosevelt.edu:2048/login?url=",
+    "location": {
+      "lng": -86.57591665394143,
+      "lat": 42.99407383950141
+    },
+    "country": "United States"
   },
   {
     "name": "Rosalind Franklin University",
-    "url": "https://rosalindfranklin.idm.oclc.org/login?url=$@"
+    "url": "https://rosalindfranklin.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -87.8588156,
+      "lat": 42.3003584
+    },
+    "country": "United States"
   },
   {
     "name": "Rosemont",
-    "url": "https://rosemont.idm.oclc.org/login?url=$@"
+    "url": "https://rosemont.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -87.8721602,
+      "lat": 41.98675069999999
+    },
+    "country": "United States"
   },
   {
     "name": "Rowan",
-    "url": "http://ezproxy.rowan.edu/login?url=$@"
+    "url": "http://ezproxy.rowan.edu/login?url=",
+    "location": {
+      "lng": -75.1191932,
+      "lat": 39.7099689
+    },
+    "country": "United States"
   },
   {
     "name": "Royal Australasian College of Surgeons",
-    "url": "http://ezproxy.surgeons.org/login?url=$@"
+    "url": "http://ezproxy.surgeons.org/login?url=",
+    "location": {
+      "lng": 144.9728155,
+      "lat": -37.8085073
+    },
+    "country": "Australia"
   },
   {
     "name": "Royal College of Nursing",
-    "url": "https://rcn.idm.oclc.org/login?url=$@"
+    "url": "https://rcn.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -1.7647339349683775,
+      "lat": 52.72904889363981
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Royal College of Surgeons in Ireland - Medical University of Bahrain",
-    "url": "https://login.ezproxy.rcsi.com/login?url=$@"
+    "url": "https://login.ezproxy.rcsi.com/login?url=",
+    "location": {
+      "lng": 50.59699269999999,
+      "lat": 26.261768
+    },
+    "country": "Bahrain"
   },
   {
     "name": "Royal Holloway University of London",
-    "url": "http://ezproxy01.rhul.ac.uk:2048/login?url=$@"
+    "url": "http://ezproxy01.rhul.ac.uk:2048/login?url=",
+    "location": {
+      "lng": -0.5630625,
+      "lat": 51.425673
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Royal Holloway, University of London",
-    "url": "http://ezproxy01.rhul.ac.uk/login?url=$@"
+    "url": "http://ezproxy01.rhul.ac.uk/login?url=",
+    "location": {
+      "lng": -0.5630625,
+      "lat": 51.425673
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Royal Perth Hospital",
-    "url": "https://login.rplibresources.health.wa.gov.au/login?url=$@"
+    "url": "https://login.rplibresources.health.wa.gov.au/login?url=",
+    "location": {
+      "lng": 115.8664238,
+      "lat": -31.9540512
+    },
+    "country": "Australia"
   },
   {
     "name": "Royal Roads University",
-    "url": "https://ezproxy.royalroads.ca/login?url=$@"
+    "url": "https://ezproxy.royalroads.ca/login?url=",
+    "location": {
+      "lng": -123.4739689,
+      "lat": 48.4342047
+    },
+    "country": "Canada"
   },
   {
     "name": "Rush University Medical Center",
-    "url": "https://login.ezproxy.rush.edu/login?url=$@"
+    "url": "https://login.ezproxy.rush.edu/login?url=",
+    "location": {
+      "lng": -87.668836,
+      "lat": 41.8745746
+    },
+    "country": "United States"
   },
   {
     "name": "Rutgers University",
-    "url": "https://proxy.libraries.rutgers.edu/login?url=$@"
+    "url": "https://proxy.libraries.rutgers.edu/login?url=",
+    "location": {
+      "lng": -74.44990026192792,
+      "lat": 40.507370660344286
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Saint Louis",
-    "url": "http://ezp.slu.edu/login?url=$@"
+    "url": "http://ezp.slu.edu/login?url=",
+    "location": {
+      "lng": -90.19940419999999,
+      "lat": 38.6270025
+    },
+    "country": "United States"
   },
   {
     "name": "Saint Mary's",
-    "url": "http://smcproxy1.saintmarys.edu:2048/login?url=$@"
+    "url": "http://smcproxy1.saintmarys.edu:2048/login?url=",
+    "location": {
+      "lng": -86.25709416282052,
+      "lat": 41.70790941026819
+    },
+    "country": "United States"
   },
   {
     "name": "Saint Marys College CA",
-    "url": "https://stmarys-ca.idm.oclc.org/login?url=$@"
+    "url": "https://stmarys-ca.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.1089374,
+      "lat": 37.8408837
+    },
+    "country": "United States"
   },
   {
     "name": "Saint Marys University of Minnesota",
-    "url": "http://ezproxy.smumn.edu/login?url=$@"
+    "url": "http://ezproxy.smumn.edu/login?url=",
+    "location": {
+      "lng": -91.6957309,
+      "lat": 44.0447868
+    },
+    "country": "United States"
   },
   {
     "name": "Saint Michaels",
-    "url": "http://library.smcvt.edu/login?url=$@"
+    "url": "http://library.smcvt.edu/login?url=",
+    "location": {
+      "lng": -76.22332020000002,
+      "lat": 38.785393
+    },
+    "country": "United States"
   },
   {
     "name": "Saint Petersburg State University",
-    "url": "https://proxy.library.spbu.ru/login?url=$@"
+    "url": "https://proxy.library.spbu.ru/login?url=",
+    "location": {
+      "lng": 30.2989198,
+      "lat": 59.941894
+    },
+    "country": "Russia"
   },
   {
     "name": "Salem State",
-    "url": "http://corvette.salemstate.edu:2048/login?url=$@"
+    "url": "http://corvette.salemstate.edu:2048/login?url=",
+    "location": {
+      "lng": -70.8902384,
+      "lat": 42.5041326
+    },
+    "country": "United States"
   },
   {
     "name": "Salford University",
-    "url": "https://salford.idm.oclc.org/login?url=$@"
+    "url": "https://salford.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -2.2737375,
+      "lat": 53.48723260000001
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Salus University",
-    "url": "http://salus.idm.oclc.org/login?url=$@"
+    "url": "http://salus.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -75.12914920858499,
+      "lat": 40.08656103619193
+    },
+    "country": "United States"
   },
   {
     "name": "Sam Houston State University",
-    "url": "http://login.ezproxy.shsu.edu/login?url=$@"
+    "url": "http://login.ezproxy.shsu.edu/login?url=",
+    "location": {
+      "lng": -95.547276,
+      "lat": 30.7135813
+    },
+    "country": "United States"
   },
   {
     "name": "San Diego State",
-    "url": "http://libproxy.sdsu.edu/login?url=$@"
+    "url": "http://libproxy.sdsu.edu/login?url=",
+    "location": {
+      "lng": -117.0714068,
+      "lat": 32.7774047
+    },
+    "country": "United States"
   },
   {
     "name": "San Francisco Public Library",
-    "url": "http://ezproxy.sfpl.org/login?url=$@"
+    "url": "http://ezproxy.sfpl.org/login?url=",
+    "location": {
+      "lng": -122.4194155,
+      "lat": 37.7749295
+    },
+    "country": "United States"
   },
   {
     "name": "San Francisco State",
-    "url": "http://jpllnet.sfsu.edu/login?url=$@"
+    "url": "http://jpllnet.sfsu.edu/login?url=",
+    "location": {
+      "lng": -122.4799405,
+      "lat": 37.7241492
+    },
+    "country": "United States"
   },
   {
     "name": "San Jose State University",
-    "url": "http://libaccess.sjlibrary.org/login?url=$@"
+    "url": "http://libaccess.sjlibrary.org/login?url=",
+    "location": {
+      "lng": -121.8810715,
+      "lat": 37.3351874
+    },
+    "country": "United States"
   },
   {
     "name": "San José Public Library",
-    "url": "https://login.sjezpt01.sjlibrary.org/login?url=$@"
+    "url": "https://login.sjezpt01.sjlibrary.org/login?url=",
+    "location": {
+      "lng": -121.8852525,
+      "lat": 37.33874
+    },
+    "country": "United States"
   },
   {
     "name": "Santa Clara County Library",
-    "url": "http://rpa.sccl.org/login?url=$@"
+    "url": "http://rpa.sccl.org/login?url=",
+    "location": {
+      "lng": -121.7195459,
+      "lat": 37.2938907
+    },
+    "country": "United States"
   },
   {
     "name": "Sapienza Università di Roma",
-    "url": "https://login.ezproxy.uniroma1.it/login?url=$@"
+    "url": "https://login.ezproxy.uniroma1.it/login?url=",
+    "location": {
+      "lng": 12.5144384,
+      "lat": 41.9037626
+    },
+    "country": "Italy"
   },
   {
     "name": "Sarah Lawrence",
-    "url": "http://remote.slc.edu/login?url=$@"
+    "url": "http://remote.slc.edu/login?url=",
+    "location": {
+      "lng": -73.8455821,
+      "lat": 40.93459
+    },
+    "country": "United States"
   },
   {
     "name": "Saskatchewan Health Information Resource Partnership",
-    "url": "http://ezproxy.shirp.ca/login?url=$@"
+    "url": "http://ezproxy.shirp.ca/login?url=",
+    "location": {
+      "lng": -106.4508639,
+      "lat": 52.9399159
+    },
+    "country": "Canada"
   },
   {
     "name": "School for International Training",
-    "url": "http://reference.sit.edu:2048/login?url=$@"
+    "url": "http://reference.sit.edu:2048/login?url=",
+    "location": {
+      "lng": -72.5645828,
+      "lat": 42.8903298
+    },
+    "country": "United States"
   },
   {
     "name": "Scottsdale",
-    "url": "http://ezproxy.scottsdalecc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.scottsdalecc.edu:2048/login?url=",
+    "location": {
+      "lng": -111.9260519,
+      "lat": 33.4941704
+    },
+    "country": "United States"
   },
   {
     "name": "Seattle Pacific University",
-    "url": "http://ezproxy.spu.edu/login?url=$@"
+    "url": "http://ezproxy.spu.edu/login?url=",
+    "location": {
+      "lng": -122.3618554,
+      "lat": 47.6491714
+    },
+    "country": "United States"
   },
   {
     "name": "Seattle Public Library",
-    "url": "https://ezproxy.spl.org/login?url=$@"
+    "url": "https://ezproxy.spl.org/login?url=",
+    "location": {
+      "lng": -122.3320708,
+      "lat": 47.6062095
+    },
+    "country": "United States"
   },
   {
     "name": "Seattle University",
-    "url": "http://proxy.seattleu.edu/login?url=$@"
+    "url": "http://proxy.seattleu.edu/login?url=",
+    "location": {
+      "lng": -122.3178465,
+      "lat": 47.6091765
+    },
+    "country": "United States"
   },
   {
     "name": "Seneca",
-    "url": "http://lcweb.senecac.on.ca:2048/login?url=$@"
+    "url": "http://lcweb.senecac.on.ca:2048/login?url=",
+    "location": {
+      "lng": -79.34809038106465,
+      "lat": 43.79704149159459
+    },
+    "country": "Canada"
   },
   {
     "name": "Seoul National University",
-    "url": "https://ezproxy.snu.ac.kr/login?url=$@"
+    "url": "https://lib.snu.ac.kr/user/login?proxyurl=",
+    "location": {
+      "lng": 126.9500385,
+      "lat": 37.4565095
+    },
+    "country": "South Korea"
   },
   {
-    "name": "Seoul National University",
-    "url": "https://lib.snu.ac.kr/user/login?proxyurl=$@"
+    "name": "Seoul National University (Alternative)",
+    "url": "https://ezproxy.snu.ac.kr/login?url=",
+    "location": {
+      "lng": 126.9500385,
+      "lat": 37.4565095
+    },
+    "country": "South Korea"
   },
   {
     "name": "Seton Hall University",
-    "url": "http://ezproxy.shu.edu/login?url=$@"
+    "url": "http://ezproxy.shu.edu/login?url=",
+    "location": {
+      "lng": -74.246082,
+      "lat": 40.7430841
+    },
+    "country": "United States"
   },
   {
     "name": "Shanghai University of Finance and Economics",
-    "url": "http://ezlibrary.sufe.edu.cn/login?url=$@"
+    "url": "http://ezlibrary.sufe.edu.cn/login?url=",
+    "location": {
+      "lng": 121.494038,
+      "lat": 31.306594
+    },
+    "country": "China"
   },
   {
     "name": "Shasta College",
-    "url": "http://ezproxy.shastacollege.edu:2048/login?url=$@"
+    "url": "http://ezproxy.shastacollege.edu:2048/login?url=",
+    "location": {
+      "lng": -122.31812778116573,
+      "lat": 40.62572461708596
+    },
+    "country": "United States"
   },
   {
     "name": "Sheba Medical Center Library",
-    "url": "https://sheba-tdnetdiscover-com.sheba.idm.oclc.org/logging/outgoing?url=$@"
+    "url": "https://sheba-tdnetdiscover-com.sheba.idm.oclc.org/logging/outgoing?url=",
+    "location": {
+      "lng": 34.8460728,
+      "lat": 32.0486696
+    },
+    "country": "Israel"
   },
   {
     "name": "Sheffield Hallam University",
-    "url": "https://hallam.idm.oclc.org/login?url=$@"
+    "url": "https://hallam.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -1.4659387,
+      "lat": 53.3785622
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Shenandoah",
-    "url": "http://suproxy.su.edu/login?url=$@"
+    "url": "http://suproxy.su.edu/login?url=",
+    "location": {
+      "lng": -78.4534573,
+      "lat": 38.4754706
+    },
+    "country": "United States"
   },
   {
     "name": "Shenzhen University",
-    "url": "http://ezproxy.lib.szu.edu.cn//login?url=$@"
+    "url": "http://ezproxy.lib.szu.edu.cn//login?url=",
+    "location": {
+      "lng": 113.932813,
+      "lat": 22.53306
+    },
+    "country": "China"
   },
   {
     "name": "Shippensburg University",
-    "url": "http://proxy-ship.klnpa.org/login?url=$@"
+    "url": "http://proxy-ship.klnpa.org/login?url=",
+    "location": {
+      "lng": -77.521684,
+      "lat": 40.0609352
+    },
+    "country": "United States"
   },
   {
     "name": "SHIRP (University of Saskatchewan)",
-    "url": "http://www.shirp.ca/doproxy?url=$@"
+    "url": "http://www.shirp.ca/doproxy?url=",
+    "location": {
+      "lng": -106.63133844875824,
+      "lat": 52.13349456776281
+    },
+    "country": "Canada"
   },
   {
     "name": "Siberian Federal University",
-    "url": "https://libproxy.bik.sfu-kras.ru/login?url=$@"
+    "url": "https://libproxy.bik.sfu-kras.ru/login?url=",
+    "location": {
+      "lng": 92.765776,
+      "lat": 56.004056
+    },
+    "country": "Russia"
   },
   {
     "name": "Siena",
-    "url": "http://ezproxy.siena.edu:2048/login?url=$@"
+    "url": "http://ezproxy.siena.edu:2048/login?url=",
+    "location": {
+      "lng": 11.3307574,
+      "lat": 43.31880899999999
+    },
+    "country": "Italy"
   },
   {
     "name": "Simmons",
-    "url": "http://ezproxy.simmons.edu:2048/login?url=$@"
+    "url": "http://ezproxy.simmons.edu:2048/login?url=",
+    "location": {
+      "lng": -71.10043759999999,
+      "lat": 42.339063
+    },
+    "country": "United States"
   },
   {
     "name": "Simon Fraser University",
-    "url": "http://proxy.lib.sfu.ca/login?url=$@"
+    "url": "http://proxy.lib.sfu.ca/login?url=",
+    "location": {
+      "lng": -122.9198833,
+      "lat": 49.2780937
+    },
+    "country": "Canada"
   },
   {
     "name": "Singapore Institute of Management",
-    "url": "http://libproxy.sim.edu.sg/login?url=$@"
+    "url": "http://libproxy.sim.edu.sg/login?url=",
+    "location": {
+      "lng": 103.7761745,
+      "lat": 1.3294012
+    },
+    "country": "Singapore"
   },
   {
     "name": "Singapore Management University (SMU)",
-    "url": "http://libproxy.smu.edu.sg/login?url=$@"
+    "url": "http://libproxy.smu.edu.sg/login?url=",
+    "location": {
+      "lng": 103.8501578,
+      "lat": 1.2962727
+    },
+    "country": "Singapore"
   },
   {
     "name": "Slippery Rock University",
-    "url": "http://proxy-sru.klnpa.org/login?url=$@"
+    "url": "http://proxy-sru.klnpa.org/login?url=",
+    "location": {
+      "lng": -80.04119899999999,
+      "lat": 41.0629938
+    },
+    "country": "United States"
   },
   {
     "name": "Smith",
-    "url": "http://libproxy.smith.edu:2048/login?url=$@"
+    "url": "http://libproxy.smith.edu:2048/login?url=",
+    "location": {
+      "lng": -72.64026739705753,
+      "lat": 42.31646706621614
+    },
+    "country": "United States"
   },
   {
     "name": "SNDL Systeme National de Documentation en Ligne",
-    "url": "http://www.sndl1.arn.dz/login?url=$@"
+    "url": "http://www.sndl1.arn.dz/login?url=",
+    "location": {
+      "lng": 3.0814079492144626,
+      "lat": 36.73940747345419
+    },
+    "country": "Algeria"
   },
   {
     "name": "Sofia",
-    "url": "http://ezproxy.sofia.edu:2048/login?url=$@"
+    "url": "http://ezproxy.sofia.edu:2048/login?url=",
+    "location": {
+      "lng": 23.3218675,
+      "lat": 42.6977082
+    },
+    "country": "Bulgaria"
   },
   {
     "name": "Solano",
-    "url": "https://ezproxy.solano.edu/login?url=$@"
+    "url": "https://ezproxy.solano.edu/login?url=",
+    "location": {
+      "lng": -121.9017954,
+      "lat": 38.3104969
+    },
+    "country": "United States"
   },
   {
     "name": "Sonoma State",
-    "url": "https://sonoma.idm.oclc.org/login?url=$@"
+    "url": "https://sonoma.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.6730677,
+      "lat": 38.3409222
+    },
+    "country": "United States"
   },
   {
     "name": "Sookmyung University",
-    "url": "http://libproxy.sookmyung.ac.kr/_Lib_Proxy_Url/login?url=$@"
+    "url": "http://libproxy.sookmyung.ac.kr/_Lib_Proxy_Url/login?url=",
+    "location": {
+      "lng": 126.9646916,
+      "lat": 37.54647500000001
+    },
+    "country": "South Korea"
   },
   {
     "name": "Sorbonne Université",
-    "url": "http://accesdistant.sorbonne-universite.fr/login?url=$@"
+    "url": "http://accesdistant.sorbonne-universite.fr/login?url=",
+    "location": {
+      "lng": 2.3403275,
+      "lat": 48.85055149999999
+    },
+    "country": "France"
   },
   {
     "name": "Sothebys Institute of Art",
-    "url": "http://ezproxy.sothebysinstitute.com:2048/login?url=$@"
+    "url": "http://ezproxy.sothebysinstitute.com:2048/login?url=",
+    "location": {
+      "lng": -0.1312174,
+      "lat": 51.51863849999999
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "South and East Metropolitan Health Service",
-    "url": "https://login.smhslibresources.health.wa.gov.au/login?url=$@"
+    "url": "https://login.smhslibresources.health.wa.gov.au/login?url=",
+    "location": {
+      "lng": 115.8646998,
+      "lat": -31.9546179
+    },
+    "country": "Australia"
   },
   {
     "name": "South Asian University (SAU)",
-    "url": "https://sau.idm.oclc.org/login?url=$@"
+    "url": "https://sau.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 77.19023020000002,
+      "lat": 28.5852347
+    },
+    "country": "India"
   },
   {
     "name": "South College",
-    "url": "http://proxy.southcollegetn.edu:2048/login?url=$@"
+    "url": "http://proxy.southcollegetn.edu:2048/login?url=",
+    "location": {
+      "lng": -83.97313136352469,
+      "lat": 35.961129109913685
+    },
+    "country": "United States"
   },
   {
     "name": "South Dakota State University",
-    "url": "https://excelsior.sdstate.edu/login?url=$@"
+    "url": "https://excelsior.sdstate.edu/login?url=",
+    "location": {
+      "lng": -96.78351819999999,
+      "lat": 44.3191071
+    },
+    "country": "United States"
   },
   {
     "name": "South Plains",
-    "url": "https://ezproxy.southplainscollege.edu:2443/login?url=$@"
+    "url": "https://ezproxy.southplainscollege.edu:2443/login?url=",
+    "location": {
+      "lng": -102.3669395,
+      "lat": 33.578406
+    },
+    "country": "United States"
   },
   {
     "name": "South Texas",
-    "url": "http://ezproxy.southtexascollege.edu:2048/login?url=$@"
+    "url": "http://ezproxy.southtexascollege.edu:2048/login?url=",
+    "location": {
+      "lng": -99.9018131,
+      "lat": 31.9685988
+    },
+    "country": "United States"
   },
   {
     "name": "Southern College of Optometry",
-    "url": "http://sco.idm.oclc.org/login?url=$@"
+    "url": "http://sco.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -90.0200838,
+      "lat": 35.1383947
+    },
+    "country": "United States"
   },
   {
     "name": "Southern Illinois University Carbondale",
-    "url": "https://proxy.lib.siu.edu/login?url=$@"
+    "url": "https://proxy.lib.siu.edu/login?url=",
+    "location": {
+      "lng": -89.2229983,
+      "lat": 37.7079717
+    },
+    "country": "United States"
   },
   {
     "name": "Southern Illinois University School of Medicine",
-    "url": "https://libproxy.siumed.edu/login?url=$@"
+    "url": "https://libproxy.siumed.edu/login?url=",
+    "location": {
+      "lng": -89.657583,
+      "lat": 39.8101074
+    },
+    "country": "United States"
   },
   {
     "name": "Southern Methodist",
-    "url": "http://proxy.libraries.smu.edu/login?url=$@"
+    "url": "http://proxy.libraries.smu.edu/login?url=",
+    "location": {
+      "lng": -96.78451749999999,
+      "lat": 32.8412178
+    },
+    "country": "United States"
   },
   {
     "name": "Southern New Hampshire University SNHU",
-    "url": "http://ezproxy.snhu.edu/login?url=$@"
+    "url": "http://ezproxy.snhu.edu/login?url=",
+    "location": {
+      "lng": -71.4493554,
+      "lat": 43.0382166
+    },
+    "country": "United States"
   },
   {
     "name": "Southern Oregon",
-    "url": "http://glacier.sou.edu/login?url=$@"
+    "url": "http://glacier.sou.edu/login?url=",
+    "location": {
+      "lng": -122.4332992,
+      "lat": 42.7976791
+    },
+    "country": "United States"
   },
   {
     "name": "Southern University at New Orleans",
-    "url": "http://ezproxy.suno.edu:2048/login?url=$@"
+    "url": "http://ezproxy.suno.edu:2048/login?url=",
+    "location": {
+      "lng": -90.0449055,
+      "lat": 30.0259133
+    },
+    "country": "United States"
   },
   {
     "name": "Southwestern",
-    "url": "https://navigator.southwestern.edu/login?url=$@"
+    "url": "https://navigator.southwestern.edu/login?url=",
+    "location": {
+      "lng": -97.66285150000002,
+      "lat": 30.6369218
+    },
+    "country": "United States"
   },
   {
     "name": "Southwestern Illinois",
-    "url": "http://ezproxy.swic.edu/login?url=$@"
+    "url": "http://ezproxy.swic.edu/login?url=",
+    "location": {
+      "lng": -87.86479609999999,
+      "lat": 38.8742719
+    },
+    "country": "United States"
   },
   {
     "name": "Southwestern Oklahoma State University",
-    "url": "http://libnet.swosu.edu/login?url=$@"
+    "url": "http://libnet.swosu.edu/login?url=",
+    "location": {
+      "lng": -98.70789540000001,
+      "lat": 35.5357732
+    },
+    "country": "United States"
   },
   {
     "name": "St Cloud State",
-    "url": "https://login.libproxy.stcloudstate.edu/login?qurl=$@"
+    "url": "https://login.libproxy.stcloudstate.edu/login?qurl=",
+    "location": {
+      "lng": -94.1515367,
+      "lat": 45.548639
+    },
+    "country": "United States"
   },
   {
     "name": "St Edwards University in Austin",
-    "url": "https://ezproxy.stedwards.edu/login?url=$@"
+    "url": "https://ezproxy.stedwards.edu/login?url=",
+    "location": {
+      "lng": -97.75833,
+      "lat": 30.23218
+    },
+    "country": "United States"
   },
   {
     "name": "St Louis",
-    "url": "http://ezproxy.stlcc.edu/login?url=$@"
-  },
-  {
-    "name": "St Marys",
-    "url": "http://blume.stmarytx.edu:2048/login?url=$@"
+    "url": "http://ezproxy.stlcc.edu/login?url=",
+    "location": {
+      "lng": -90.19940419999999,
+      "lat": 38.6270025
+    },
+    "country": "United States"
   },
   {
     "name": "St Olaf",
-    "url": "http://ezproxy.stolaf.edu/login?url=$@"
+    "url": "http://ezproxy.stolaf.edu/login?url=",
+    "location": {
+      "lng": -93.18402809999999,
+      "lat": 44.4621319
+    },
+    "country": "United States"
   },
   {
     "name": "St Thomas",
-    "url": "http://proxy.stu.edu:2048/login?url=$@"
+    "url": "http://proxy.stu.edu:2048/login?url=",
+    "location": {
+      "lng": -64.8940946,
+      "lat": 18.3380965
+    },
+    "country": "U.S. Virgin Islands"
   },
   {
     "name": "St Vincents Health Australia",
-    "url": "https://svhm.idm.oclc.org/login?url=$@"
+    "url": "https://svhm.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 133.775136,
+      "lat": -25.274398
+    },
+    "country": "Australia"
   },
   {
     "name": "St. Francis Xavier University",
-    "url": "http://libproxy.stfx.ca/login?url=$@"
+    "url": "http://libproxy.stfx.ca/login?url=",
+    "location": {
+      "lng": -61.99539410000001,
+      "lat": 45.6177357
+    },
+    "country": "Canada"
   },
   {
     "name": "St. John's University",
-    "url": "https://jerome.stjohns.edu/login?url=$@"
+    "url": "https://jerome.stjohns.edu/login?url=",
+    "location": {
+      "lng": -73.7975501796871,
+      "lat": 40.72167369686328
+    },
+    "country": "United States"
   },
   {
     "name": "St. Lawrence University",
-    "url": "http://stlawu.idm.oclc.org/login?url=$@"
+    "url": "http://stlawu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -75.1608814,
+      "lat": 44.5892119
+    },
+    "country": "United States"
+  },
+  {
+    "name": "St. Mary's University",
+    "url": "http://blume.stmarytx.edu:2048/login?url=",
+    "location": {
+      "lng": -98.56502264652597,
+      "lat": 29.46030146736221
+    },
+    "country": "United States"
   },
   {
     "name": "Stanford",
-    "url": "http://laneproxy.stanford.edu/login?url=$@"
+    "url": "http://laneproxy.stanford.edu/login?url=",
+    "location": {
+      "lng": -122.1660756,
+      "lat": 37.42410599999999
+    },
+    "country": "United States"
   },
   {
     "name": "Stanford University",
-    "url": "https://stanford.idm.oclc.org/login?url=$@"
+    "url": "https://stanford.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.169719,
+      "lat": 37.4274745
+    },
+    "country": "United States"
   },
   {
     "name": "State and University Library, Aarhus",
-    "url": "http://ez.statsbiblioteket.dk:2048/login?url=$@"
+    "url": "http://ez.statsbiblioteket.dk:2048/login?url=",
+    "location": {
+      "lng": 10.203921,
+      "lat": 56.162939
+    },
+    "country": "Denmark"
   },
   {
     "name": "State Library of Pennsylvania",
-    "url": "http://proxy-stlib.klnpa.org/login?url=$@"
+    "url": "http://proxy-stlib.klnpa.org/login?url=",
+    "location": {
+      "lng": -76.8838428,
+      "lat": 40.2665447
+    },
+    "country": "United States"
   },
   {
     "name": "Stellenbosch University",
-    "url": "http://ez.sun.ac.za/login?url=$@"
+    "url": "http://ez.sun.ac.za/login?url=",
+    "location": {
+      "lng": 18.864447,
+      "lat": -33.9328078
+    },
+    "country": "South Africa"
   },
   {
     "name": "Stephen F. Austin State University",
-    "url": "http://steenproxy.sfasu.edu:2048/login?url=$@"
+    "url": "http://steenproxy.sfasu.edu:2048/login?url=",
+    "location": {
+      "lng": -94.64664379999999,
+      "lat": 31.6216141
+    },
+    "country": "United States"
   },
   {
     "name": "Stevens Institute of Technology",
-    "url": "http://www.stevens.edu/ezproxy/login?url=$@"
+    "url": "http://www.stevens.edu/ezproxy/login?url=",
+    "location": {
+      "lng": -74.0256485,
+      "lat": 40.74482030000001
+    },
+    "country": "United States"
   },
   {
     "name": "Stevenson University",
-    "url": "https://ezproxy.stevenson.edu/login?url=$@"
+    "url": "https://ezproxy.stevenson.edu/login?url=",
+    "location": {
+      "lng": -76.7798238427994,
+      "lat": 39.428483288859766
+    },
+    "country": "United States"
   },
   {
     "name": "Stockholm University",
-    "url": "http://ezp.sub.su.se/login?url=$@"
+    "url": "http://ezp.sub.su.se/login?url=",
+    "location": {
+      "lng": 18.0550487,
+      "lat": 59.3652343
+    },
+    "country": "Sweden"
   },
   {
     "name": "Stockton",
-    "url": "http://ezproxy.stockton.edu:2048/login?url=$@"
+    "url": "http://ezproxy.stockton.edu:2048/login?url=",
+    "location": {
+      "lng": -121.2907796,
+      "lat": 37.9577016
+    },
+    "country": "United States"
   },
   {
     "name": "Stony Brook University",
-    "url": "http://ezproxy.hsclib.sunysb.edu/login?url=$@"
+    "url": "http://ezproxy.hsclib.sunysb.edu/login?url=",
+    "location": {
+      "lng": -73.1204032,
+      "lat": 40.908119
+    },
+    "country": "United States"
   },
   {
     "name": "Stony Brook University West Campus",
-    "url": "http://proxy.library.stonybrook.edu/login?url=$@"
+    "url": "http://proxy.library.stonybrook.edu/login?url=",
+    "location": {
+      "lng": -73.1204032,
+      "lat": 40.908119
+    },
+    "country": "United States"
   },
   {
     "name": "Stowers Institute for Medical Research",
-    "url": "https://ezproxy.stowers.org/login?url=$@"
+    "url": "https://ezproxy.stowers.org/login?url=",
+    "location": {
+      "lng": -94.5742972,
+      "lat": 39.0365098
+    },
+    "country": "United States"
   },
   {
     "name": "Strathmore",
-    "url": "https://ezproxy.library.strathmore.edu/login?url=$@"
+    "url": "https://ezproxy.library.strathmore.edu/login?url=",
+    "location": {
+      "lng": -77.1032704,
+      "lat": 39.0314872
+    },
+    "country": "United States"
   },
   {
     "name": "Sultan Qaboos University",
-    "url": "http://ezproxysrv.squ.edu.om:2048/login?url=$@"
+    "url": "http://ezproxysrv.squ.edu.om:2048/login?url=",
+    "location": {
+      "lng": 58.17354719999999,
+      "lat": 23.5896334
+    },
+    "country": "Oman"
   },
   {
     "name": "Sungkyunkwan University, Campus of Natural Science",
-    "url": "https://sa.skku.edu:8443/link.n2s?url=$@"
+    "url": "https://sa.skku.edu:8443/link.n2s?url=",
+    "location": {
+      "lng": 126.993606,
+      "lat": 37.588227
+    },
+    "country": "South Korea"
   },
   {
     "name": "Sungkyunkwan University, Humanities/Social Science Campus",
-    "url": "https://ca.skku.edu:8443/link.n2s?url=$@"
+    "url": "https://ca.skku.edu:8443/link.n2s?url=",
+    "location": {
+      "lng": 126.993606,
+      "lat": 37.588227
+    },
+    "country": "South Korea"
   },
   {
     "name": "Sunway University",
-    "url": "http://ezproxy.sunway.edu.my/login?url=$@"
+    "url": "http://ezproxy.sunway.edu.my/login?url=",
+    "location": {
+      "lng": 101.603841,
+      "lat": 3.0672267
+    },
+    "country": "Malaysia"
   },
   {
     "name": "SUNY at Geneseo",
-    "url": "http://proxy.geneseo.edu:2048/login?url=$@"
+    "url": "http://proxy.geneseo.edu:2048/login?url=",
+    "location": {
+      "lng": -77.82386269999999,
+      "lat": 42.79600689999999
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY at Oswego",
-    "url": "http://ezproxy.oswego.edu:2048/login?url=$@"
+    "url": "http://ezproxy.oswego.edu:2048/login?url=",
+    "location": {
+      "lng": -76.5104973,
+      "lat": 43.4553461
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Buffalo State",
-    "url": "http://proxy.buffalostate.edu:2048/login?url=$@"
+    "url": "http://proxy.buffalostate.edu:2048/login?url=",
+    "location": {
+      "lng": -78.87901889999999,
+      "lat": 42.9325073
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Cobleskill",
-    "url": "http://ezproxy.cobleskill.edu:2048/login?url=$@"
+    "url": "http://ezproxy.cobleskill.edu:2048/login?url=",
+    "location": {
+      "lng": -74.49735629999999,
+      "lat": 42.6737238
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Corning Community College",
-    "url": "http://ezproxy.corning-cc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.corning-cc.edu:2048/login?url=",
+    "location": {
+      "lng": -77.0758942590317,
+      "lat": 42.117082291751025
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Cortland",
-    "url": "http://libproxy.cortland.edu/login?url=$@"
+    "url": "http://libproxy.cortland.edu/login?url=",
+    "location": {
+      "lng": -76.187797,
+      "lat": 42.599001
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Downstate",
-    "url": "http://newproxy.downstate.edu/login?url=$@"
+    "url": "http://newproxy.downstate.edu/login?url=",
+    "location": {
+      "lng": -73.94558649999999,
+      "lat": 40.6555364
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Dutchess",
-    "url": "http://is-ezproxy01.sunydutchess.edu:2048/login?url=$@"
+    "url": "http://is-ezproxy01.sunydutchess.edu:2048/login?url=",
+    "location": {
+      "lng": -73.9050871,
+      "lat": 41.7267034
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Empire State",
-    "url": "http://library.esc.edu/login?url=$@"
+    "url": "http://library.esc.edu/login?url=",
+    "location": {
+      "lng": -73.78239669999999,
+      "lat": 43.0773483
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Environmental Science and Forestry",
-    "url": "https://esf.idm.oclc.org/login?url=$@"
+    "url": "https://esf.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -76.1366182,
+      "lat": 43.0345102
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Farmingdale State",
-    "url": "http://hs1.farmingdale.edu:2048/login?url=$@"
+    "url": "http://hs1.farmingdale.edu:2048/login?url=",
+    "location": {
+      "lng": -73.4266988,
+      "lat": 40.7529167
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Jefferson",
-    "url": "http://jccweb.sunyjefferson.edu:2048/login?url=$@"
+    "url": "http://jccweb.sunyjefferson.edu:2048/login?url=",
+    "location": {
+      "lng": -75.934691,
+      "lat": 43.992231
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY New Paltz",
-    "url": "https://libdatabase.newpaltz.edu/login?url=$@"
+    "url": "https://libdatabase.newpaltz.edu/login?url=",
+    "location": {
+      "lng": -74.085197,
+      "lat": 41.73856199999999
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Onondaga",
-    "url": "http://ezproxy.sunyocc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.sunyocc.edu:2048/login?url=",
+    "location": {
+      "lng": -76.1981087649764,
+      "lat": 43.004495216327996
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Polytechnic Institute",
-    "url": "http://ezproxy.sunyit.edu/login?url=$@"
+    "url": "http://ezproxy.sunyit.edu/login?url=",
+    "location": {
+      "lng": -75.22732226529101,
+      "lat": 43.137653063759736
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Rockland",
-    "url": "http://ezproxy.sunyrockland.edu:2048/login?url=$@"
+    "url": "http://ezproxy.sunyrockland.edu:2048/login?url=",
+    "location": {
+      "lng": -73.98300290000002,
+      "lat": 41.1489458
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY Schenectady County",
-    "url": "http://libproxy.sunysccc.edu/login?url=$@"
+    "url": "http://libproxy.sunysccc.edu/login?url=",
+    "location": {
+      "lng": -73.949913,
+      "lat": 42.81469449999999
+    },
+    "country": "United States"
   },
   {
     "name": "SUNY University at Albany",
-    "url": "https://libproxy.albany.edu/login?url=$@"
+    "url": "https://libproxy.albany.edu/login?url=",
+    "location": {
+      "lng": -73.8247903,
+      "lat": 42.6850273
+    },
+    "country": "United States"
   },
   {
     "name": "Swarthmore",
-    "url": "http://proxy.swarthmore.edu/login?url=$@"
+    "url": "http://proxy.swarthmore.edu/login?url=",
+    "location": {
+      "lng": -75.3499123,
+      "lat": 39.9020565
+    },
+    "country": "United States"
   },
   {
     "name": "Swedish Defence University",
-    "url": "https://login.proxy.annalindhbiblioteket.se/login?url=$@"
+    "url": "https://login.proxy.annalindhbiblioteket.se/login?url=",
+    "location": {
+      "lng": 18.0694157,
+      "lat": 59.3490856
+    },
+    "country": "Sweden"
   },
   {
     "name": "Swinburne University",
-    "url": "https://go.openathens.net/redirector/swin.edu.au?url=$@"
+    "url": "https://go.openathens.net/redirector/swin.edu.au?url=",
+    "location": {
+      "lng": 145.0389546,
+      "lat": -37.8221504
+    },
+    "country": "Australia"
   },
   {
     "name": "Syracuse",
-    "url": "http://libezproxy.syr.edu/login?url=$@"
+    "url": "http://libezproxy.syr.edu/login?url=",
+    "location": {
+      "lng": -76.14742439999999,
+      "lat": 43.0481221
+    },
+    "country": "United States"
   },
   {
     "name": "Syracuse University",
-    "url": "https://login.libezproxy2.syr.edu/login?url=$@"
+    "url": "https://login.libezproxy2.syr.edu/login?url=",
+    "location": {
+      "lng": -76.1351158,
+      "lat": 43.0391534
+    },
+    "country": "United States"
   },
   {
     "name": "Tallinna Ulikool",
-    "url": "http://ezproxy.tlu.ee/login?url=$@"
+    "url": "http://ezproxy.tlu.ee/login?url=",
+    "location": {
+      "lng": 24.7713836,
+      "lat": 59.4387321
+    },
+    "country": "Estonia"
   },
   {
     "name": "Tarrant County",
-    "url": "http://ezp.tccd.edu/login?url=$@"
+    "url": "http://ezp.tccd.edu/login?url=",
+    "location": {
+      "lng": -97.35165579999999,
+      "lat": 32.7732044
+    },
+    "country": "United States"
   },
   {
     "name": "Tartu Ulikooli",
-    "url": "https://ezproxy.utlib.ut.ee/login?url=$@"
+    "url": "https://ezproxy.utlib.ut.ee/login?url=",
+    "location": {
+      "lng": 26.7290383,
+      "lat": 58.37798299999999
+    },
+    "country": "Estonia"
   },
   {
     "name": "Tatung university",
-    "url": "http://ezproxy.ttu.edu.tw/login?url=$@"
+    "url": "http://ezproxy.ttu.edu.tw/login?url=",
+    "location": {
+      "lng": 121.5217972,
+      "lat": 25.0671976
+    },
+    "country": "Taiwan"
   },
   {
     "name": "Taylor's University",
-    "url": "http://ezproxy.taylors.edu.my/login?url=$@"
+    "url": "http://ezproxy.taylors.edu.my/login?url=",
+    "location": {
+      "lng": 101.6168101,
+      "lat": 3.064785
+    },
+    "country": "Malaysia"
   },
   {
     "name": "Technical University of Denmark",
-    "url": "http://proxy.findit.cvt.dk/login?url=$@"
+    "url": "http://proxy.findit.cvt.dk/login?url=",
+    "location": {
+      "lng": 12.521381,
+      "lat": 55.7855742
+    },
+    "country": "Denmark"
   },
   {
     "name": "Technion",
-    "url": "http://ezlibrary.technion.ac.il/login?url=$@"
+    "url": "http://ezlibrary.technion.ac.il/login?url=",
+    "location": {
+      "lng": 35.0231271,
+      "lat": 32.7767783
+    },
+    "country": "Israel"
   },
   {
     "name": "Technische Hochschule Ingolstadt",
-    "url": "http://thi.idm.oclc.org/login?url=$@"
+    "url": "http://thi.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 11.4319822,
+      "lat": 48.7668196
+    },
+    "country": "Germany"
   },
   {
     "name": "Technische Uni Munchen",
-    "url": "https://eaccess.ub.tum.de:2443/login?url=$@"
+    "url": "https://eaccess.ub.tum.de:2443/login?url=",
+    "location": {
+      "lng": 11.5678602,
+      "lat": 48.14966
+    },
+    "country": "Germany"
   },
   {
     "name": "Technische Universiteit Delft",
-    "url": "http://tudelft.idm.oclc.org/login?url=$@"
+    "url": "http://tudelft.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 4.3735766,
+      "lat": 52.0021919
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Technische Universität München",
-    "url": "https://eaccess.ub.tum.de/login?url=$@"
+    "url": "https://eaccess.ub.tum.de/login?url=",
+    "location": {
+      "lng": 11.5678602,
+      "lat": 48.14966
+    },
+    "country": "Germany"
   },
   {
     "name": "Tel Aviv University (TAU)",
-    "url": "http://rproxy.tau.ac.il/login?url=$@"
+    "url": "http://rproxy.tau.ac.il/login?url=",
+    "location": {
+      "lng": 34.8043877,
+      "lat": 32.1133141
+    },
+    "country": "Israel"
   },
   {
     "name": "Temple University",
-    "url": "http://libproxy.temple.edu/login?url=$@"
+    "url": "http://libproxy.temple.edu/login?url=",
+    "location": {
+      "lng": -75.1553563,
+      "lat": 39.9811911
+    },
+    "country": "United States"
   },
   {
     "name": "Tennessee Tech",
-    "url": "https://login.ezproxy.tntech.edu/login?qurl=$@"
+    "url": "https://login.ezproxy.tntech.edu/login?qurl=",
+    "location": {
+      "lng": -85.50910859999999,
+      "lat": 36.1763138
+    },
+    "country": "United States"
   },
   {
     "name": "Texas A M",
-    "url": "http://lib-ezproxy.tamu.edu:2048/login?url=$@"
+    "url": "http://lib-ezproxy.tamu.edu:2048/login?url=",
+    "location": {
+      "lng": -96.33646549999999,
+      "lat": 30.6186806
+    },
+    "country": "United States"
   },
   {
     "name": "Texas A&M University - Texarkana",
-    "url": "http://dbproxy.tamut.edu/login?url=$@"
+    "url": "http://dbproxy.tamut.edu/login?url=",
+    "location": {
+      "lng": -96.33646549999999,
+      "lat": 30.6186806
+    },
+    "country": "United States"
   },
   {
     "name": "Texas A&M University School of Law",
-    "url": "http://lawresearch.tamu.edu/login?url=$@"
+    "url": "http://lawresearch.tamu.edu/login?url=",
+    "location": {
+      "lng": -96.33646549999999,
+      "lat": 30.6186806
+    },
+    "country": "United States"
   },
   {
     "name": "Texas A&M University-Commerce",
-    "url": "https://login.proxy.tamuc.edu/login?url=$@"
+    "url": "https://login.proxy.tamuc.edu/login?url=",
+    "location": {
+      "lng": -96.33646549999999,
+      "lat": 30.6186806
+    },
+    "country": "United States"
   },
   {
     "name": "Texas A&M University-Texarkana",
-    "url": "https://login.tamut.idm.oclc.org/login?qurl=$@"
+    "url": "https://login.tamut.idm.oclc.org/login?qurl=",
+    "location": {
+      "lng": -96.33646549999999,
+      "lat": 30.6186806
+    },
+    "country": "United States"
   },
   {
     "name": "Texas A&M Universtiy",
-    "url": "http://ezproxy.library.tamu.edu/login?url=$@"
+    "url": "http://ezproxy.library.tamu.edu/login?url=",
+    "location": {
+      "lng": -96.33646549999999,
+      "lat": 30.6186806
+    },
+    "country": "United States"
   },
   {
     "name": "Texas State University",
-    "url": "https://login.libproxy.txstate.edu/login?qurl=$@"
+    "url": "https://login.libproxy.txstate.edu/login?qurl=",
+    "location": {
+      "lng": -97.938351,
+      "lat": 29.888411
+    },
+    "country": "United States"
   },
   {
     "name": "Texas Tech",
-    "url": "http://ezp.lib.ttu.edu/login?url=$@"
+    "url": "http://ezp.lib.ttu.edu/login?url=",
+    "location": {
+      "lng": -101.8782822,
+      "lat": 33.5842591
+    },
+    "country": "United States"
   },
   {
     "name": "Texas Tech University Health Sciences Center",
-    "url": "http://ezproxy.ttuhsc.edu/login?url=$@"
+    "url": "http://ezproxy.ttuhsc.edu/login?url=",
+    "location": {
+      "lng": -101.8912035,
+      "lat": 33.5901499
+    },
+    "country": "United States"
   },
   {
     "name": "Texas Wesleyan",
-    "url": "https://ejwl.idm.oclc.org/login?url=$@"
+    "url": "https://ejwl.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -97.28020699999999,
+      "lat": 32.7323764
+    },
+    "country": "United States"
   },
   {
     "name": "Texas Woman's University",
-    "url": "http://ezp.twu.edu/login?url=$@"
+    "url": "http://ezp.twu.edu/login?url=",
+    "location": {
+      "lng": -97.12705199999999,
+      "lat": 33.2272211
+    },
+    "country": "United States"
   },
   {
     "name": "Texas Womans",
-    "url": "http://ezproxy.twu.edu:2048/login?url=$@"
+    "url": "http://ezproxy.twu.edu:2048/login?url=",
+    "location": {
+      "lng": -97.12705199999999,
+      "lat": 33.2272211
+    },
+    "country": "United States"
   },
   {
     "name": "Thammasat University",
-    "url": "https://ezproxy.tulibs.net/login?url=$@"
+    "url": "https://ezproxy.tulibs.net/login?url=",
+    "location": {
+      "lng": 100.60298781742311,
+      "lat": 14.129506395353289
+    },
+    "country": "Thailand"
   },
   {
     "name": "The American College of Greece",
-    "url": "https://acg.idm.oclc.org/login?url=$@"
+    "url": "https://acg.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 23.8303395,
+      "lat": 38.0036919
+    },
+    "country": "Greece"
   },
   {
     "name": "The Chinese University of Hong Kong",
-    "url": "http://easyaccess.lib.cuhk.edu.hk/login?url=$@"
+    "url": "http://easyaccess.lib.cuhk.edu.hk/login?url=",
+    "location": {
+      "lng": 114.2067606,
+      "lat": 22.419625
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "The College at Brockport",
-    "url": "http://ezproxy.drake.brockport.edu:2048/login?url=$@"
+    "url": "http://ezproxy.drake.brockport.edu:2048/login?url=",
+    "location": {
+      "lng": -77.95108309999999,
+      "lat": 43.2103817
+    },
+    "country": "United States"
   },
   {
     "name": "The Education University of Hong Kong",
-    "url": "https://ezproxy.eduhk.hk/login?qurl=$@"
+    "url": "https://ezproxy.eduhk.hk/login?qurl=",
+    "location": {
+      "lng": 114.1936333,
+      "lat": 22.4670285
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "The George Washington University",
-    "url": "http://proxygw.wrlc.org/login?url=$@"
+    "url": "http://proxygw.wrlc.org/login?url=",
+    "location": {
+      "lng": -77.0485992,
+      "lat": 38.8997145
+    },
+    "country": "United States"
   },
   {
     "name": "The Hong Kong Polytechnic University",
-    "url": "https://ezproxy.lb.polyu.edu.hk/login?url=$@"
+    "url": "https://ezproxy.lb.polyu.edu.hk/login?url=",
+    "location": {
+      "lng": 114.1798118,
+      "lat": 22.3042407
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "The Jackson Laboratory",
-    "url": "http://ezproxy.jax.org/login?url=$@"
+    "url": "http://ezproxy.jax.org/login?url=",
+    "location": {
+      "lng": -68.20073836543226,
+      "lat": 44.506799852553584
+    },
+    "country": "United States"
   },
   {
     "name": "The Jackson Laboratory for Genomic Medicine",
-    "url": "https://login.ezproxy.jax.org/login?url=$@"
+    "url": "https://login.ezproxy.jax.org/login?url=",
+    "location": {
+      "lng": -72.7934038,
+      "lat": 41.7322837
+    },
+    "country": "United States"
   },
   {
     "name": "The London School of Economics and Political Science (LSE)",
-    "url": "https://gate2.library.lse.ac.uk/login?url=$@"
+    "url": "https://gate2.library.lse.ac.uk/login?url=",
+    "location": {
+      "lng": -0.1164513,
+      "lat": 51.5144388
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "The New School",
-    "url": "http://libproxy.newschool.edu/login?url=$@"
+    "url": "http://libproxy.newschool.edu/login?url=",
+    "location": {
+      "lng": -73.9971361,
+      "lat": 40.7354925
+    },
+    "country": "United States"
   },
   {
     "name": "The Royal College of Surgeons in Ireland",
-    "url": "https://login.proxy.library.rcsi.ie/login?url=$@"
+    "url": "https://login.proxy.library.rcsi.ie/login?url=",
+    "location": {
+      "lng": -6.263110999999999,
+      "lat": 53.3391467
+    },
+    "country": "Ireland"
   },
   {
     "name": "The University at Buffalo",
-    "url": "https://gate.lib.buffalo.edu/login?url=$@"
+    "url": "https://gate.lib.buffalo.edu/login?url=",
+    "location": {
+      "lng": -78.7889697,
+      "lat": 43.0008093
+    },
+    "country": "United States"
   },
   {
     "name": "The University of Alabama at Birmingham",
-    "url": "http://ezproxy3.lhl.uab.edu/login?url=$@"
+    "url": "http://ezproxy3.lhl.uab.edu/login?url=",
+    "location": {
+      "lng": -86.80574949999999,
+      "lat": 33.5020323
+    },
+    "country": "United States"
   },
   {
     "name": "The University of Manchester",
-    "url": "http://manchester.idm.oclc.org/login?url=$@"
+    "url": "http://manchester.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -2.2338837,
+      "lat": 53.4668498
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "The Wikipedia Library",
-    "url": "https://wikipedialibrary.idm.oclc.org/login?auth=production&url=$@"
+    "url": "https://wikipedialibrary.idm.oclc.org/login?auth=production&url=",
+    "location": {
+      "lng": -122.4022865025427,
+      "lat": 37.78943853012844
+    },
+    "country": "United States"
   },
   {
     "name": "Thomas More",
-    "url": "http://library.thomasmore.edu:2048/login?url=$@"
+    "url": "http://library.thomasmore.edu:2048/login?url=",
+    "location": {
+      "lng": -84.58710197194668,
+      "lat": 39.13796015015666
+    },
+    "country": "United States"
   },
   {
     "name": "Toronto Metropolitan University",
-    "url": "https://ezproxy.lib.torontomu.ca/login?url=$@"
+    "url": "https://ezproxy.lib.torontomu.ca/login?url=",
+    "location": {
+      "lng": -79.3788017,
+      "lat": 43.6576585
+    },
+    "country": "Canada"
   },
   {
     "name": "Trent University",
-    "url": "http://web2.trentu.ca:2048/login?url=$@"
+    "url": "http://web2.trentu.ca:2048/login?url=",
+    "location": {
+      "lng": -78.2905232,
+      "lat": 44.3576781
+    },
+    "country": "Canada"
   },
   {
     "name": "Trent University",
-    "url": "http://cat1.lib.trentu.ca:2048/login?url=$@"
+    "url": "http://cat1.lib.trentu.ca:2048/login?url=",
+    "location": {
+      "lng": -78.29062294212818,
+      "lat": 44.358354457586834
+    },
+    "country": "Canada"
   },
   {
     "name": "Trinity College Dublin, Ireland",
-    "url": "http://elib.tcd.ie/login?url=$@"
+    "url": "http://elib.tcd.ie/login?url=",
+    "location": {
+      "lng": -6.254571599999999,
+      "lat": 53.3437935
+    },
+    "country": "Ireland"
   },
   {
     "name": "Trinity University",
-    "url": "http://libproxy.trinity.edu/login?url=$@"
+    "url": "http://libproxy.trinity.edu/login?url=",
+    "location": {
+      "lng": -98.4816717139737,
+      "lat": 29.460359894160632
+    },
+    "country": "United States"
   },
   {
     "name": "Tufts University",
-    "url": "http://ezproxy.library.tufts.edu/login?url=$@"
+    "url": "http://ezproxy.library.tufts.edu/login?url=",
+    "location": {
+      "lng": -71.1182729,
+      "lat": 42.4085371
+    },
+    "country": "United States"
   },
   {
     "name": "Tulane",
-    "url": "https://login.libproxy.tulane.edu/login?qurl=$@"
+    "url": "https://login.libproxy.tulane.edu/login?qurl=",
+    "location": {
+      "lng": -90.12031669999999,
+      "lat": 29.9407282
+    },
+    "country": "United States"
   },
   {
     "name": "Tulane University",
-    "url": "http://libproxy.tulane.edu:2048/login?url=$@"
+    "url": "http://libproxy.tulane.edu:2048/login?url=",
+    "location": {
+      "lng": -90.12031669999999,
+      "lat": 29.9407282
+    },
+    "country": "United States"
   },
   {
     "name": "Turun yliopisto",
-    "url": "http://ezproxy.utu.fi:2048/login?url=$@"
+    "url": "http://ezproxy.utu.fi:2048/login?url=",
+    "location": {
+      "lng": 22.284785,
+      "lat": 60.45422669999999
+    },
+    "country": "Finland"
   },
   {
     "name": "Tyndale University College Seminary",
-    "url": "http://ezproxy.mytyndale.ca:2048/login?url=$@"
+    "url": "http://ezproxy.mytyndale.ca:2048/login?url=",
+    "location": {
+      "lng": -79.39220639999999,
+      "lat": 43.7971607
+    },
+    "country": "Canada"
   },
   {
     "name": "U S Army Medical Department Center and School",
-    "url": "http://stimson.idm.oclc.org/login?url=$@"
+    "url": "http://stimson.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -95.712891,
+      "lat": 37.09024
+    },
+    "country": "United States"
   },
   {
     "name": "UC Berkeley",
-    "url": "https://libproxy.berkeley.edu/login?url=$@"
+    "url": "https://libproxy.berkeley.edu/login?url=",
+    "location": {
+      "lng": -122.2594606,
+      "lat": 37.87015100000001
+    },
+    "country": "United States"
   },
   {
     "name": "UC Hastings College of the Law",
-    "url": "http://uchastings.idm.oclc.org/login?url=$@"
+    "url": "http://uchastings.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.4157619,
+      "lat": 37.7811225
+    },
+    "country": "United States"
   },
   {
     "name": "UC San Diego",
-    "url": "http://proxy.library.ucsd.edu:2048/login?url=$@"
+    "url": "http://proxy.library.ucsd.edu:2048/login?url=",
+    "location": {
+      "lng": -117.2340135,
+      "lat": 32.8800604
+    },
+    "country": "United States"
   },
   {
     "name": "UC Santa Cruz",
-    "url": "http://oca.ucsc.edu/login?url=$@"
+    "url": "http://oca.ucsc.edu/login?url=",
+    "location": {
+      "lng": -122.0584354,
+      "lat": 36.9905322
+    },
+    "country": "United States"
   },
   {
     "name": "UIC Peoria Library",
-    "url": "https://proxy.cc.uic.edu/login?url=$@"
+    "url": "https://proxy.cc.uic.edu/login?url=",
+    "location": {
+      "lng": -89.5972747,
+      "lat": 40.6984596
+    },
+    "country": "United States"
   },
   {
     "name": "Umea University",
-    "url": "http://proxy.ub.umu.se/login?url=$@"
+    "url": "http://proxy.ub.umu.se/login?url=",
+    "location": {
+      "lng": 20.3054461,
+      "lat": 63.82022240000001
+    },
+    "country": "Sweden"
   },
   {
     "name": "UNED",
-    "url": "http://ezproxy.uned.es/login?url=$@"
+    "url": "http://ezproxy.uned.es/login?url=",
+    "location": {
+      "lng": -3.7040528,
+      "lat": 40.4380164
+    },
+    "country": "Spain"
   },
   {
     "name": "Uni Heidelberg",
-    "url": "http://ubproxy.ub.uni-heidelberg.de/login?qurl=$@"
+    "url": "http://ubproxy.ub.uni-heidelberg.de/login?qurl=",
+    "location": {
+      "lng": 8.6702507,
+      "lat": 49.4190991
+    },
+    "country": "Germany"
   },
   {
     "name": "Uni Heidelberg Medizinischen Fakultat Mannheim",
-    "url": "http://ezproxy.medma.uni-heidelberg.de/login?url=$@"
+    "url": "http://ezproxy.medma.uni-heidelberg.de/login?url=",
+    "location": {
+      "lng": 8.6702507,
+      "lat": 49.4190991
+    },
+    "country": "Germany"
   },
   {
     "name": "Uni Passau",
-    "url": "http://docweb.rz.uni-passau.de:2048/login?url=$@"
+    "url": "http://docweb.rz.uni-passau.de:2048/login?url=",
+    "location": {
+      "lng": 13.4527974,
+      "lat": 48.5677779
+    },
+    "country": "Germany"
   },
   {
     "name": "Uni Zurich",
-    "url": "http://ezproxy.uzh.ch/login?url=$@"
+    "url": "http://ezproxy.uzh.ch/login?url=",
+    "location": {
+      "lng": 8.5486629,
+      "lat": 47.3745896
+    },
+    "country": "Switzerland"
   },
   {
     "name": "Uniformed Services",
-    "url": "http://lrc1.usuhs.edu/login?url=$@"
+    "url": "http://lrc1.usuhs.edu/login?url=",
+    "location": {
+      "lng": -98.44018395832336,
+      "lat": 29.458764300608614
+    },
+    "country": "United States"
   },
   {
     "name": "Union College",
-    "url": "https://linus.ucollege.edu:8443/login?url=$@"
+    "url": "https://linus.ucollege.edu:8443/login?url=",
+    "location": {
+      "lng": -96.65243256977679,
+      "lat": 40.77355371239728
+    },
+    "country": "United States"
   },
   {
     "name": "United Nations Office at Geneva",
-    "url": "http://lib-ezproxy.unog.ch/login?url=$@"
+    "url": "http://lib-ezproxy.unog.ch/login?url=",
+    "location": {
+      "lng": 6.140292199999999,
+      "lat": 46.2266738
+    },
+    "country": "Switzerland"
+  },
+  {
+    "name": "Univeristy of New Mexico",
+    "url": "http://libproxy.unm.edu/login?url=",
+    "location": {
+      "lng": -105.8700901,
+      "lat": 34.5199402
+    },
+    "country": "United States"
   },
   {
     "name": "Universal College of Learning",
-    "url": "http://ezproxy.ucol.ac.nz/login?url=$@"
+    "url": "http://ezproxy.ucol.ac.nz/login?url=",
+    "location": {
+      "lng": 175.6134364,
+      "lat": -40.3522695
+    },
+    "country": "New Zealand"
   },
   {
     "name": "Universidad Alfonso X El Sabio",
-    "url": "https://login.ezproxy.uax.es/login?url=$@"
+    "url": "https://login.ezproxy.uax.es/login?url=",
+    "location": {
+      "lng": -3.5614483977684137,
+      "lat": 40.624031690762735
+    },
+    "country": "Spain"
   },
   {
     "name": "Universidad Autonoma Metropolitana",
-    "url": "http://www.bidi.uam.mx:2048/login?url=$@"
+    "url": "http://www.bidi.uam.mx:2048/login?url=",
+    "location": {
+      "lng": -99.1368474,
+      "lat": 19.2870551
+    },
+    "country": "Mexico"
   },
   {
     "name": "Universidad Autónoma Metropolitana",
-    "url": "https://bidi.uam.mx:2048/login?url=$@"
+    "url": "https://bidi.uam.mx:2048/login?url=",
+    "location": {
+      "lng": -99.1368474,
+      "lat": 19.2870551
+    },
+    "country": "Mexico"
   },
   {
     "name": "Universidad Carlos III de Madrid",
-    "url": "https://strauss.uc3m.es:2443/login?url=$@"
+    "url": "https://strauss.uc3m.es:2443/login?url=",
+    "location": {
+      "lng": -3.730530787359002,
+      "lat": 40.33200858610548
+    },
+    "country": "Spain"
   },
   {
     "name": "Universidad Catolica del Norte",
-    "url": "http://ezproxy.ucn.cl/login?url=$@"
+    "url": "http://ezproxy.ucn.cl/login?url=",
+    "location": {
+      "lng": -68.1995587,
+      "lat": -22.9099822
+    },
+    "country": "Chile"
   },
   {
     "name": "Universidad Complutense de Madrid",
-    "url": "http://bucm.idm.oclc.org/login?url=$@"
+    "url": "http://bucm.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -3.7299424,
+      "lat": 40.4454368
+    },
+    "country": "Spain"
   },
   {
     "name": "Universidad Cooperativa de Colombia",
-    "url": "http://bbibliograficas.ucc.edu.co/login?url=$@"
+    "url": "http://bbibliograficas.ucc.edu.co/login?url=",
+    "location": {
+      "lng": -75.54555221975593,
+      "lat": 6.837254128453907
+    },
+    "country": "Colombia"
   },
   {
     "name": "Universidad de Chile",
-    "url": "https://uchile.idm.oclc.org/login?url=$@"
+    "url": "https://uchile.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -70.6509277,
+      "lat": -33.4445204
+    },
+    "country": "Chile"
   },
   {
     "name": "Universidad de Concepción",
-    "url": "http://ezproxy.udec.cl/login?url=$@"
+    "url": "http://ezproxy.udec.cl/login?url=",
+    "location": {
+      "lng": -73.0341825,
+      "lat": -36.8294765
+    },
+    "country": "Chile"
   },
   {
     "name": "Universidad de Costa Rica",
-    "url": "http://ezproxy.sibdi.ucr.ac.cr:2048/login?url=$@"
+    "url": "http://ezproxy.sibdi.ucr.ac.cr:2048/login?url=",
+    "location": {
+      "lng": -84.0503749,
+      "lat": 9.937380899999999
+    },
+    "country": "Costa Rica"
   },
   {
     "name": "Universidad de Guadalajara",
-    "url": "https://login.wdg.biblio.udg.mx:8443/login?url=$@"
+    "url": "https://login.wdg.biblio.udg.mx:8443/login?url=",
+    "location": {
+      "lng": -103.3589843,
+      "lat": 20.6748238
+    },
+    "country": "Mexico"
   },
   {
     "name": "Universidad de Lleida",
-    "url": "http://proxy.alumnes.udl.cat:8080/log=$@"
+    "url": "http://proxy.alumnes.udl.cat:8080/log=",
+    "location": {
+      "lng": 0.6196167,
+      "lat": 41.6147654
+    },
+    "country": "Spain"
   },
   {
     "name": "Universidad de los Andes",
-    "url": "https://login.ezproxy.uniandes.edu.co:8443/login?url=$@"
+    "url": "https://login.ezproxy.uniandes.edu.co:8443/login?url=",
+    "location": {
+      "lng": -74.0661334,
+      "lat": 4.601458099999999
+    },
+    "country": "Colombia"
   },
   {
     "name": "Universidad de Navarra",
-    "url": "http://ezproxy.unav.es:2048/login?url=$@"
+    "url": "http://ezproxy.unav.es:2048/login?url=",
+    "location": {
+      "lng": -75.38034871029625,
+      "lat": 3.3748728756568958
+    },
+    "country": "Colombia"
   },
   {
     "name": "Universidad de Oviedo",
-    "url": "http://uniovi.idm.oclc.org/login?url=$@"
+    "url": "http://uniovi.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -5.8463007,
+      "lat": 43.36194649999999
+    },
+    "country": "Spain"
   },
   {
     "name": "Universidad del Valle",
-    "url": "http://bd.univalle.edu.co/login?url=$@"
+    "url": "http://bd.univalle.edu.co/login?url=",
+    "location": {
+      "lng": -76.5222438089478,
+      "lat": 3.4271129544677175
+    },
+    "country": "Colombia"
   },
   {
     "name": "Universidad EAFIT",
-    "url": "http://ezproxy.eafit.edu.co/login?url=$@"
+    "url": "http://ezproxy.eafit.edu.co/login?url=",
+    "location": {
+      "lng": -75.5792681,
+      "lat": 6.1997094
+    },
+    "country": "Colombia"
   },
   {
     "name": "Universidad Industrial de Santander",
-    "url": "http://ezproxy.uis.edu.co:2048/login?url=$@"
+    "url": "http://ezproxy.uis.edu.co:2048/login?url=",
+    "location": {
+      "lng": -73.05371177230583,
+      "lat": 7.742045158351845
+    },
+    "country": "Colombia"
   },
   {
     "name": "Universidad Interamericana de Puerto Rico Recinto de Arecibo",
-    "url": "http://ezproxy.arecibo.inter.edu:2048/login?url=$@"
+    "url": "http://ezproxy.arecibo.inter.edu:2048/login?url=",
+    "location": {
+      "lng": -66.75943819999999,
+      "lat": 18.4757179
+    },
+    "country": "Puerto Rico"
   },
   {
     "name": "Universidad Nacional Autónoma de México",
-    "url": "http://pbidi.unam.mx:8080/login?url=$@"
+    "url": "http://pbidi.unam.mx:8080/login?url=",
+    "location": {
+      "lng": -99.1876103,
+      "lat": 19.332795
+    },
+    "country": "Mexico"
   },
   {
     "name": "Universidad Nacional Autónoma de México Campus Morelos",
-    "url": "https://biblioteca.ibt.unam.mx:8080/login?url=$@"
+    "url": "https://biblioteca.ibt.unam.mx:8080/login?url=",
+    "location": {
+      "lng": -99.1013498,
+      "lat": 18.6813049
+    },
+    "country": "Mexico"
   },
   {
     "name": "Universidad Nacional de Colombia",
-    "url": "http://ezproxy.unal.edu.co/login?url=$@"
+    "url": "http://ezproxy.unal.edu.co/login?url=",
+    "location": {
+      "lng": -74.08404639999999,
+      "lat": 4.6381938
+    },
+    "country": "Colombia"
   },
   {
     "name": "Universidad Nacional de Villa María",
-    "url": "http://ezproxy.unvm.edu.ar/login?url=$@"
+    "url": "http://ezproxy.unvm.edu.ar/login?url=",
+    "location": {
+      "lng": -63.2607983,
+      "lat": -32.3822336
+    },
+    "country": "Argentina"
   },
   {
     "name": "Universidad Técnica Federico Santa María (UTFSM)",
-    "url": "https://login.usm.idm.oclc.org/login?url=$@"
+    "url": "https://login.usm.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -71.5967794,
+      "lat": -33.0352386
+    },
+    "country": "Chile"
   },
   {
     "name": "Universidade da Coruña (UdC)",
-    "url": "https://accedys.udc.es/login?url=$@"
+    "url": "https://accedys.udc.es/login?url=",
+    "location": {
+      "lng": -8.4115401,
+      "lat": 43.3623436
+    },
+    "country": "Spain"
   },
   {
     "name": "Universidade de Santiago de Compostela (BUSC)",
-    "url": "https://ezbusc.usc.gal/login?url=$@"
+    "url": "https://ezbusc.usc.gal/login?url=",
+    "location": {
+      "lng": -8.5452013,
+      "lat": 42.87912360000001
+    },
+    "country": "Spain"
   },
   {
     "name": "Universidade Federal do Rio de Janeiro (UFRJ)",
-    "url": "http://ez29.periodicos.capes.gov.br/login?url=$@"
+    "url": "http://ez29.periodicos.capes.gov.br/login?url=",
+    "location": {
+      "lng": -43.2234737,
+      "lat": -22.8625345
+    },
+    "country": "Brazil"
   },
   {
     "name": "Universidade Federal do Rio Grande do Sul",
-    "url": "https://http://Ez45.periodicos.capes.gov.br/login?=$@"
+    "url": "https://http://Ez45.periodicos.capes.gov.br/login?=",
+    "location": {
+      "lng": -51.2190483,
+      "lat": -30.0339726
+    },
+    "country": "Brazil"
   },
   {
     "name": "Universita degli studi di Milano",
-    "url": "http://ezproxy.pros.lib.unimi.it/login?url=$@"
+    "url": "http://ezproxy.pros.lib.unimi.it/login?url=",
+    "location": {
+      "lng": 9.189982,
+      "lat": 45.4642035
+    },
+    "country": "Italy"
   },
   {
     "name": "Universita degli Studi di Sassari",
-    "url": "http://proxysba.uniss.it:2048/login?url=$@"
+    "url": "http://proxysba.uniss.it:2048/login?url=",
+    "location": {
+      "lng": 8.5596912,
+      "lat": 40.7248609
+    },
+    "country": "Italy"
   },
   {
     "name": "Universita degli Studi di Siena",
-    "url": "http://asbproxy.unisi.it:2048/login?url=$@"
+    "url": "http://asbproxy.unisi.it:2048/login?url=",
+    "location": {
+      "lng": 11.3328421,
+      "lat": 43.3191155
+    },
+    "country": "Italy"
   },
   {
     "name": "Universita degli Studi di Trento",
-    "url": "http://ezp.biblio.unitn.it/login?url=$@"
+    "url": "http://ezp.biblio.unitn.it/login?url=",
+    "location": {
+      "lng": 11.1231091,
+      "lat": 46.0668672
+    },
+    "country": "Italy"
   },
   {
     "name": "Universita degli Studi G dAnnunzio Chieti",
-    "url": "http://biblioproxy.unich.it/login?url=$@"
+    "url": "http://biblioproxy.unich.it/login?url=",
+    "location": {
+      "lng": 14.1360532,
+      "lat": 42.3498508
+    },
+    "country": "Italy"
   },
   {
     "name": "Universitas Indonesia",
-    "url": "http://remote-lib.ui.ac.id/login?url=$@"
+    "url": "http://remote-lib.ui.ac.id/login?url=",
+    "location": {
+      "lng": 106.8272343,
+      "lat": -6.3606229
+    },
+    "country": "Indonesia"
   },
   {
     "name": "Universitat Autonoma de Barcelona",
-    "url": "https://login.are.uab.cat/login?url=$@"
+    "url": "https://login.are.uab.cat/login?url=",
+    "location": {
+      "lng": 2.1038536,
+      "lat": 41.5021421
+    },
+    "country": "Spain"
   },
   {
     "name": "Universitat Politècnica de Catalunya",
-    "url": "http://recursos.biblioteca.upc.edu/login?url=$@"
+    "url": "http://recursos.biblioteca.upc.edu/login?url=",
+    "location": {
+      "lng": 2.1157401,
+      "lat": 41.3892675
+    },
+    "country": "Spain"
   },
   {
     "name": "Universitatea Tehnică Gheorghe Asachi din Iași",
-    "url": "http://am.e-nformation.ro/login?url=$@"
+    "url": "http://am.e-nformation.ro/login?url=",
+    "location": {
+      "lng": 27.599396,
+      "lat": 47.1545977
+    },
+    "country": "Romania"
   },
   {
     "name": "Universite catholique de Louvain",
-    "url": "http://proxy.bib.ucl.ac.be:888/login?url=$@"
+    "url": "http://proxy.bib.ucl.ac.be:888/login?url=",
+    "location": {
+      "lng": 4.615875,
+      "lat": 50.6696767
+    },
+    "country": "Belgium"
   },
   {
     "name": "Universite dAngers",
-    "url": "http://buadistant.univ-angers.fr/login?url=$@"
+    "url": "http://buadistant.univ-angers.fr/login?url=",
+    "location": {
+      "lng": -0.5499261999999999,
+      "lat": 47.4771248
+    },
+    "country": "France"
   },
   {
     "name": "Universite de Bourgogne",
-    "url": "http://proxy-scd.u-bourgogne.fr/login?url=$@"
+    "url": "http://proxy-scd.u-bourgogne.fr/login?url=",
+    "location": {
+      "lng": 5.0713319,
+      "lat": 47.3119618
+    },
+    "country": "France"
   },
   {
     "name": "Universite de la Reunion",
-    "url": "http://elgebar.univ-reunion.fr/login?url=$@"
+    "url": "http://elgebar.univ-reunion.fr/login?url=",
+    "location": {
+      "lng": 55.48522209999999,
+      "lat": -20.9017358
+    },
+    "country": "Réunion"
   },
   {
     "name": "Universite de Lille 1",
-    "url": "http://docproxy.univ-lille1.fr/login?url=$@"
+    "url": "http://docproxy.univ-lille1.fr/login?url=",
+    "location": {
+      "lng": 3.1417556,
+      "lat": 50.6085867
+    },
+    "country": "France"
   },
   {
     "name": "Universite de Limoges",
-    "url": "http://ezproxy.unilim.fr/login?url=$@"
+    "url": "http://ezproxy.unilim.fr/login?url=",
+    "location": {
+      "lng": 1.2600835,
+      "lat": 45.8245713
+    },
+    "country": "France"
   },
   {
     "name": "Universite de Lorraine",
-    "url": "http://bases-doc.univ-lorraine.fr/login?url=$@"
+    "url": "http://bases-doc.univ-lorraine.fr/login?url=",
+    "location": {
+      "lng": 6.1765379,
+      "lat": 48.6961769
+    },
+    "country": "France"
   },
   {
     "name": "Universite de Moncton",
-    "url": "http://proxy.cm.umoncton.ca/login?url=$@"
+    "url": "http://proxy.cm.umoncton.ca/login?url=",
+    "location": {
+      "lng": -64.78176189999999,
+      "lat": 46.1050904
+    },
+    "country": "Canada"
   },
   {
     "name": "Universite de Nice Sophia Antipolis",
-    "url": "http://proxy.unice.fr/login?url=$@"
+    "url": "http://proxy.unice.fr/login?url=",
+    "location": {
+      "lng": 7.244464002644414,
+      "lat": 43.696173476554364
+    },
+    "country": "France"
   },
   {
     "name": "Universite de technologie de Troyes",
-    "url": "http://proxy.utt.fr/login?url=$@"
+    "url": "http://proxy.utt.fr/login?url=",
+    "location": {
+      "lng": 4.066776100000001,
+      "lat": 48.26916199999999
+    },
+    "country": "France"
   },
   {
     "name": "Universite du Quebec a Chicoutimi",
-    "url": "http://sbiproxy.uqac.ca/login?url=$@"
+    "url": "http://sbiproxy.uqac.ca/login?url=",
+    "location": {
+      "lng": -71.052621,
+      "lat": 48.419008
+    },
+    "country": "Canada"
   },
   {
     "name": "Universite du Quebec a Montreal",
-    "url": "http://proxy.bibliotheques.uqam.ca:2048/login?url=$@"
+    "url": "http://proxy.bibliotheques.uqam.ca:2048/login?url=",
+    "location": {
+      "lng": -73.5602937,
+      "lat": 45.5131547
+    },
+    "country": "Canada"
   },
   {
     "name": "Universite Lille 2",
-    "url": "http://doc-distant.univ-lille2.fr/login?url=$@"
+    "url": "http://doc-distant.univ-lille2.fr/login?url=",
+    "location": {
+      "lng": 3.057256,
+      "lat": 50.62925
+    },
+    "country": "France"
   },
   {
     "name": "Universite Ouest Nanterre La Defense",
-    "url": "http://faraway.u-paris10.fr/login?url=$@"
+    "url": "http://faraway.u-paris10.fr/login?url=",
+    "location": {
+      "lng": 2.2418428,
+      "lat": 48.8897359
+    },
+    "country": "France"
   },
   {
     "name": "Universite Paris 1 Pantheon-Sorbonne",
-    "url": "http://ezproxy.univ-paris1.fr/login?url=$@"
+    "url": "http://ezproxy.univ-paris1.fr/login?url=",
+    "location": {
+      "lng": 2.3448603,
+      "lat": 48.8468057
+    },
+    "country": "France"
   },
   {
     "name": "Universite Paris Diderot",
-    "url": "http://rproxy.sc.univ-paris-diderot.fr:80/login?url=$@"
+    "url": "http://rproxy.sc.univ-paris-diderot.fr:80/login?url=",
+    "location": {
+      "lng": 2.3434592,
+      "lat": 48.8483803
+    },
+    "country": "France"
   },
   {
     "name": "Universite Rennes 2",
-    "url": "http://distant.bu.univ-rennes2.fr/login?url=$@"
+    "url": "http://distant.bu.univ-rennes2.fr/login?url=",
+    "location": {
+      "lng": -1.7028658,
+      "lat": 48.1179154
+    },
+    "country": "France"
   },
   {
     "name": "Universiteit Hasselt",
-    "url": "https://login.bib-proxy.uhasselt.be/login?url=$@"
+    "url": "https://login.bib-proxy.uhasselt.be/login?url=",
+    "location": {
+      "lng": 5.3419586,
+      "lat": 50.9334607
+    },
+    "country": "Belgium"
   },
   {
     "name": "Universiteit Leiden",
-    "url": "http://ezproxy.leidenuniv.nl:2048/login?url=$@"
+    "url": "http://ezproxy.leidenuniv.nl:2048/login?url=",
+    "location": {
+      "lng": 4.4863129,
+      "lat": 52.1565752
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Universiteit van Amsterdam",
-    "url": "http://proxy.uba.uva.nl:2048/login?url=$@"
+    "url": "http://proxy.uba.uva.nl:2048/login?url=",
+    "location": {
+      "lng": 4.955726299999999,
+      "lat": 52.35581819999999
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Universitetet i Bergen",
-    "url": "https://login.pva.uib.no/login?url=$@"
+    "url": "https://login.pva.uib.no/login?url=",
+    "location": {
+      "lng": 5.3217549,
+      "lat": 60.3878586
+    },
+    "country": "Norway"
   },
   {
     "name": "Universiti Malaya",
-    "url": "http://ezproxy.um.edu.my/login.htm?url=$@"
+    "url": "http://ezproxy.um.edu.my/login.htm?url=",
+    "location": {
+      "lng": 101.6536844,
+      "lat": 3.1217233
+    },
+    "country": "Malaysia"
   },
   {
     "name": "Universiti Malaysia Pahang",
-    "url": "https://ezproxy.ump.edu.my/login?url=$@"
+    "url": "https://ezproxy.ump.edu.my/login?url=",
+    "location": {
+      "lng": 103.4288926,
+      "lat": 3.5436412
+    },
+    "country": "Malaysia"
   },
   {
     "name": "Universiti Malaysia Perlis",
-    "url": "http://ezproxy.unimap.edu.my/login?url=$@"
+    "url": "http://ezproxy.unimap.edu.my/login?url=",
+    "location": {
+      "lng": 100.351832,
+      "lat": 6.4604292
+    },
+    "country": "Malaysia"
   },
   {
     "name": "Universiti Putra Malaysia",
-    "url": "http://ezproxy.upm.edu.my/login?url=$@"
+    "url": "http://ezproxy.upm.edu.my/login?url=",
+    "location": {
+      "lng": 101.7056305,
+      "lat": 2.999541
+    },
+    "country": "Malaysia"
   },
   {
     "name": "Universiti Sains Malaysia",
-    "url": "https://ezproxy.usm.my/login?url=$@"
+    "url": "https://ezproxy.usm.my/login?url=",
+    "location": {
+      "lng": 100.3025177,
+      "lat": 5.3559337
+    },
+    "country": "Malaysia"
   },
   {
     "name": "Universiti Teknologi MARA",
-    "url": "http://ezaccess.library.uitm.edu.my/login?url=$@"
+    "url": "http://ezaccess.library.uitm.edu.my/login?url=",
+    "location": {
+      "lng": 101.5036823,
+      "lat": 3.0697652
+    },
+    "country": "Malaysia"
   },
   {
     "name": "Universiti Tun Hussein Onn Malaysia (UTHM)",
-    "url": "https://ezproxy.uthm.edu.my/login?url=$@"
+    "url": "https://ezproxy.uthm.edu.my/login?url=",
+    "location": {
+      "lng": 103.0820799,
+      "lat": 1.8572606
+    },
+    "country": "Malaysia"
   },
   {
     "name": "Universiti Tunku Abdul Rahman",
-    "url": "https://libezp.utar.edu.my/login?url=$@"
+    "url": "https://libezp.utar.edu.my/login?url=",
+    "location": {
+      "lng": 101.1351317,
+      "lat": 4.3348363
+    },
+    "country": "Malaysia"
   },
   {
     "name": "University at Albany, State University of New York (SUNY)",
-    "url": "https://libproxy.albany.edu/login?url=$@"
+    "url": "https://libproxy.albany.edu/login?url=",
+    "location": {
+      "lng": -73.8247903,
+      "lat": 42.6850273
+    },
+    "country": "United States"
   },
   {
     "name": "University College Cork",
-    "url": "http://ucc.idm.oclc.org/login?url=$@"
+    "url": "http://ucc.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -8.492070499999999,
+      "lat": 51.893486
+    },
+    "country": "Ireland"
   },
   {
     "name": "University College London",
-    "url": "https://libproxy.ucl.ac.uk/login?url=$@"
+    "url": "https://libproxy.ucl.ac.uk/login?url=",
+    "location": {
+      "lng": -0.1340401,
+      "lat": 51.52455920000001
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University for the Creative Arts",
-    "url": "https://ucreative.idm.oclc.org/login?url=$@"
+    "url": "https://ucreative.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -0.805373,
+      "lat": 51.2150866
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University Giessen",
-    "url": "https://ezproxy.uni-giessen.de/login?url=$@"
+    "url": "https://ezproxy.uni-giessen.de/login?url=",
+    "location": {
+      "lng": 8.6771403,
+      "lat": 50.5804674
+    },
+    "country": "Germany"
   },
   {
     "name": "University of Adelaide",
-    "url": "https://proxy.library.adelaide.edu.au/login?url=$@"
+    "url": "https://proxy.library.adelaide.edu.au/login?url=",
+    "location": {
+      "lng": 138.60629182100143,
+      "lat": -34.919333123847764
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Akron",
-    "url": "http://ezproxy.uakron.edu:2048/login?url=$@"
+    "url": "http://ezproxy.uakron.edu:2048/login?url=",
+    "location": {
+      "lng": -81.5123424,
+      "lat": 41.0753688
+    },
+    "country": "United States"
   },
   {
     "name": "University of Alabama",
-    "url": "http://libdata.lib.ua.edu/login?url=$@"
+    "url": "http://libdata.lib.ua.edu/login?url=",
+    "location": {
+      "lng": -87.5356121,
+      "lat": 33.2152668
+    },
+    "country": "United States"
   },
   {
     "name": "University of Alabama in Huntsville",
-    "url": "https://elib.uah.edu/login?url=$@"
+    "url": "https://elib.uah.edu/login?url=",
+    "location": {
+      "lng": -86.6404712,
+      "lat": 34.7251606
+    },
+    "country": "United States"
   },
   {
     "name": "University of Alaska Anchorage",
-    "url": "http://proxy.consortiumlibrary.org/login?url=$@"
+    "url": "http://proxy.consortiumlibrary.org/login?url=",
+    "location": {
+      "lng": -149.8195598,
+      "lat": 61.1910421
+    },
+    "country": "United States"
   },
   {
     "name": "University of Alaska Southeast",
-    "url": "http://egandb.uas.alaska.edu:2048/login?url=$@"
+    "url": "http://egandb.uas.alaska.edu:2048/login?url=",
+    "location": {
+      "lng": -134.6407459,
+      "lat": 58.38552139999999
+    },
+    "country": "United States"
   },
   {
     "name": "University of Alberta",
-    "url": "http://login.ezproxy.library.ualberta.ca/login?url=$@"
+    "url": "http://login.ezproxy.library.ualberta.ca/login?url=",
+    "location": {
+      "lng": -113.5263186,
+      "lat": 53.5232189
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Amsterdam",
-    "url": "https://proxy.uba.uva.nl:2443/login?url=$@"
+    "url": "https://proxy.uba.uva.nl:2443/login?url=",
+    "location": {
+      "lng": 4.955726299999999,
+      "lat": 52.35581819999999
+    },
+    "country": "Netherlands"
   },
   {
     "name": "University of Applied Sciences Upper Austria",
-    "url": "https://fhooe.idm.oclc.org/login?url=$@"
+    "url": "https://fhooe.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 14.0267157,
+      "lat": 48.1610538
+    },
+    "country": "Austria"
   },
   {
     "name": "University of Arizona",
-    "url": "http://ezproxy.library.arizona.edu/login?url=$@"
+    "url": "http://ezproxy.library.arizona.edu/login?url=",
+    "location": {
+      "lng": -110.9501094,
+      "lat": 32.2318851
+    },
+    "country": "United States"
   },
   {
     "name": "University of Arkansas for Medical Sciences",
-    "url": "http://ezproxy.libproxy.uams.edu/login?url=$@"
+    "url": "http://ezproxy.libproxy.uams.edu/login?url=",
+    "location": {
+      "lng": -92.3204416,
+      "lat": 34.7490846
+    },
+    "country": "United States"
   },
   {
     "name": "University of Auckland",
-    "url": "http://ezproxy.auckland.ac.nz/login?url=$@"
+    "url": "http://ezproxy.auckland.ac.nz/login?url=",
+    "location": {
+      "lng": 174.7644881,
+      "lat": -36.85088270000001
+    },
+    "country": "New Zealand"
   },
   {
     "name": "University of Bath",
-    "url": "http://libproxy.bath.ac.uk/login?url=$@"
+    "url": "http://libproxy.bath.ac.uk/login?url=",
+    "location": {
+      "lng": -2.3263987,
+      "lat": 51.3782228
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Birmingham",
-    "url": "http://ezproxy.bham.ac.uk/login?url=$@"
+    "url": "http://ezproxy.bham.ac.uk/login?url=",
+    "location": {
+      "lng": -1.9305135,
+      "lat": 52.4508168
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Bradford",
-    "url": "https://brad.idm.oclc.org/login?url=$@"
+    "url": "https://brad.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -1.766069,
+      "lat": 53.7914677
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Brighton",
-    "url": "http://ezproxy.brighton.ac.uk/login?url=$@"
+    "url": "http://ezproxy.brighton.ac.uk/login?url=",
+    "location": {
+      "lng": -0.1362672,
+      "lat": 50.8229402
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Bristol",
-    "url": "http://bris.idm.oclc.org/login?url=$@"
+    "url": "http://bris.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -2.6021758,
+      "lat": 51.4585376
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of British Columbia",
-    "url": "http://ezproxy.library.ubc.ca/login?url=$@"
+    "url": "http://ezproxy.library.ubc.ca/login?url=",
+    "location": {
+      "lng": -123.2459939,
+      "lat": 49.26060520000001
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Calgary",
-    "url": "https://login.ezproxy.lib.ucalgary.ca/login?url=$@"
+    "url": "https://login.ezproxy.lib.ucalgary.ca/login?url=",
+    "location": {
+      "lng": -114.1346659,
+      "lat": 51.0783739
+    },
+    "country": "Canada"
   },
   {
     "name": "University of California San Francisco",
-    "url": "https://ucsf.idm.oclc.org/login?qurl=$@"
+    "url": "https://ucsf.idm.oclc.org/login?qurl=",
+    "location": {
+      "lng": -122.4587106,
+      "lat": 37.7626459
+    },
+    "country": "United States"
   },
   {
     "name": "University of California Santa Barbara",
-    "url": "http://proxy.library.ucsb.edu:2048/login?url=$@"
+    "url": "http://proxy.library.ucsb.edu:2048/login?url=",
+    "location": {
+      "lng": -119.848947,
+      "lat": 34.4139629
+    },
+    "country": "United States"
   },
   {
     "name": "University of California, Santa Cruz",
-    "url": "https://login.oca.ucsc.edu/login?url=$@"
+    "url": "https://login.oca.ucsc.edu/login?url=",
+    "location": {
+      "lng": -122.0584354,
+      "lat": 36.9905322
+    },
+    "country": "United States"
   },
   {
     "name": "University of Cambridge",
-    "url": "http://ezproxy.lib.cam.ac.uk:2048/login?url=$@"
+    "url": "http://ezproxy.lib.cam.ac.uk:2048/login?url=",
+    "location": {
+      "lng": 0.113168,
+      "lat": 52.205356
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Canberra",
-    "url": "https://login.ezproxy.canberra.edu.au/login?url=$@"
+    "url": "https://login.ezproxy.canberra.edu.au/login?url=",
+    "location": {
+      "lng": 149.0838384,
+      "lat": -35.2381421
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Canterbury, NZ",
-    "url": "http://ezproxy.canterbury.ac.nz/login?url=$@"
+    "url": "http://ezproxy.canterbury.ac.nz/login?url=",
+    "location": {
+      "lng": 172.5794354,
+      "lat": -43.5224836
+    },
+    "country": "New Zealand"
   },
   {
     "name": "University of Cape Town",
-    "url": "http://ezproxy.uct.ac.za/login?url=$@"
+    "url": "http://ezproxy.uct.ac.za/login?url=",
+    "location": {
+      "lng": 18.4611991,
+      "lat": -33.957652
+    },
+    "country": "South Africa"
   },
   {
     "name": "University of Central Florida",
-    "url": "https://go.openathens.net/redirector/ucf.edu?url=$@"
+    "url": "https://go.openathens.net/redirector/ucf.edu?url=",
+    "location": {
+      "lng": -81.2000599,
+      "lat": 28.6024274
+    },
+    "country": "United States"
   },
   {
     "name": "University of Central Missouri",
-    "url": "https://login.cyrano.ucmo.edu/login?url=$@"
+    "url": "https://login.cyrano.ucmo.edu/login?url=",
+    "location": {
+      "lng": -93.7405067,
+      "lat": 38.7565603
+    },
+    "country": "United States"
   },
   {
     "name": "University of Chicago",
-    "url": "http://proxy.uchicago.edu/login?url=$@"
+    "url": "http://proxy.uchicago.edu/login?url=",
+    "location": {
+      "lng": -87.5987133,
+      "lat": 41.7886079
+    },
+    "country": "United States"
   },
   {
     "name": "University of Cincinnati",
-    "url": "https://uc.idm.oclc.org/login?url=$@"
+    "url": "https://uc.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -84.51495039999999,
+      "lat": 39.1329219
+    },
+    "country": "United States"
   },
   {
     "name": "University of Colorado Anschutz Medical Campus",
-    "url": "http://proxy.hsl.ucdenver.edu/login?url=$@"
+    "url": "http://proxy.hsl.ucdenver.edu/login?url=",
+    "location": {
+      "lng": -104.8378882,
+      "lat": 39.7453568
+    },
+    "country": "United States"
   },
   {
     "name": "University of Colorado Boulder",
-    "url": "https://colorado.idm.oclc.org/login?url=$@"
+    "url": "https://colorado.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -105.2659417,
+      "lat": 40.00758099999999
+    },
+    "country": "United States"
   },
   {
     "name": "University of Colorado Colorado Springs",
-    "url": "https://libproxy.uccs.edu/login?url=$@"
+    "url": "https://libproxy.uccs.edu/login?url=",
+    "location": {
+      "lng": -104.8048874,
+      "lat": 38.8965518
+    },
+    "country": "United States"
   },
   {
     "name": "University of Colorado Denver",
-    "url": "https://hsl-ezproxy.ucdenver.edu/login?url=$@"
+    "url": "https://hsl-ezproxy.ucdenver.edu/login?url=",
+    "location": {
+      "lng": -105.002342,
+      "lat": 39.7463596
+    },
+    "country": "United States"
   },
   {
     "name": "University of Connecticut",
-    "url": "http://ezproxy.lib.uconn.edu/login?url=$@"
+    "url": "http://ezproxy.lib.uconn.edu/login?url=",
+    "location": {
+      "lng": -72.25396435165646,
+      "lat": 41.80786956340674
+    },
+    "country": "United States"
   },
   {
     "name": "University of Connecticut Health",
-    "url": "https://online.uchc.edu/login?qurl=$@"
+    "url": "https://online.uchc.edu/login?qurl=",
+    "location": {
+      "lng": -72.79146159999999,
+      "lat": 41.7322247
+    },
+    "country": "United States"
   },
   {
     "name": "University of Dayton",
-    "url": "http://libproxy.udayton.edu/login?url=$@"
+    "url": "http://libproxy.udayton.edu/login?url=",
+    "location": {
+      "lng": -84.17904449999999,
+      "lat": 39.7401454
+    },
+    "country": "United States"
   },
   {
     "name": "University of Delaware Newark",
-    "url": "https://udel.idm.oclc.org/login?url=$@"
+    "url": "https://udel.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -75.74965720000002,
+      "lat": 39.6837226
+    },
+    "country": "United States"
   },
   {
     "name": "University of Delhi",
-    "url": "https://du.remotlog.com/login/#login$@"
+    "url": "https://du.remotlog.com/login/#login",
+    "location": {
+      "lng": 77.1638282,
+      "lat": 28.5842523
+    },
+    "country": "India"
   },
   {
     "name": "University of Denver",
-    "url": "http://du.idm.oclc.org/login?url=$@"
+    "url": "http://du.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -104.9652808,
+      "lat": 39.6748442
+    },
+    "country": "United States"
   },
   {
     "name": "University of Derby",
-    "url": "http://ezproxy.derby.ac.uk/login?url=$@"
+    "url": "http://ezproxy.derby.ac.uk/login?url=",
+    "location": {
+      "lng": -1.4971764,
+      "lat": 52.9378882
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Detroit Mercy",
-    "url": "https://ezproxy.libraries.udmercy.edu/login?url=$@"
+    "url": "https://ezproxy.libraries.udmercy.edu/login?url=",
+    "location": {
+      "lng": -83.1379388,
+      "lat": 42.4140847
+    },
+    "country": "United States"
   },
   {
     "name": "University of Dubuque",
-    "url": "http://ezproxy.dbq.edu:2048/login?url=$@"
+    "url": "http://ezproxy.dbq.edu:2048/login?url=",
+    "location": {
+      "lng": -90.6952695,
+      "lat": 42.495403
+    },
+    "country": "United States"
   },
   {
     "name": "University of Dundee",
-    "url": "http://libproxy.dundee.ac.uk/login?url=$@"
+    "url": "http://libproxy.dundee.ac.uk/login?url=",
+    "location": {
+      "lng": -2.9821428,
+      "lat": 56.45824469999999
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of East Anglia",
-    "url": "http://ezproxy.sts.uea.ac.uk/adfs/ls=$@"
+    "url": "http://ezproxy.sts.uea.ac.uk/adfs/ls=",
+    "location": {
+      "lng": 1.2410838,
+      "lat": 52.6220523
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Eastern Finland",
-    "url": "https://ezproxy.uef.fi:2443/login?url=$@"
+    "url": "https://ezproxy.uef.fi:2443/login?url=",
+    "location": {
+      "lng": 27.6327062,
+      "lat": 62.89027650000001
+    },
+    "country": "Finland"
   },
   {
     "name": "University of Edinburgh",
-    "url": "http://ezproxy.is.ed.ac.uk/login?url=$@"
+    "url": "http://ezproxy.is.ed.ac.uk/login?url=",
+    "location": {
+      "lng": -3.1892413,
+      "lat": 55.9445158
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Florida",
-    "url": "https://login.lp.hscl.ufl.edu/login?url=$@"
+    "url": "https://login.lp.hscl.ufl.edu/login?url=",
+    "location": {
+      "lng": -82.3549302,
+      "lat": 29.6436325
+    },
+    "country": "United States"
   },
   {
     "name": "University of Georgia",
-    "url": "http://proxy-remote.galib.uga.edu/login?url=$@"
+    "url": "http://proxy-remote.galib.uga.edu/login?url=",
+    "location": {
+      "lng": -83.375192,
+      "lat": 33.9566656
+    },
+    "country": "United States"
   },
   {
     "name": "University of Ghana",
-    "url": "http://ezproxy.ug.edu.gh:2100/login?url=$@"
+    "url": "http://ezproxy.ug.edu.gh:2100/login?url=",
+    "location": {
+      "lng": -0.1962244,
+      "lat": 5.650562
+    },
+    "country": "Ghana"
   },
   {
     "name": "University of Glasgow",
-    "url": "https://ezproxy.lib.gla.ac.uk/login?url=$@"
+    "url": "https://ezproxy.lib.gla.ac.uk/login?url=",
+    "location": {
+      "lng": -4.2900009,
+      "lat": 55.8724256
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Gothenburg",
-    "url": "http://ezproxy.ub.gu.se/login?url=$@"
+    "url": "http://ezproxy.ub.gu.se/login?url=",
+    "location": {
+      "lng": 11.9715823,
+      "lat": 57.6983855
+    },
+    "country": "Sweden"
   },
   {
     "name": "University of Great Falls",
-    "url": "http://ezproxy.ugf.edu:2048/login?url=$@"
+    "url": "http://ezproxy.ugf.edu:2048/login?url=",
+    "location": {
+      "lng": -111.2707539,
+      "lat": 47.4906921
+    },
+    "country": "United States"
   },
   {
     "name": "University of Groningen",
-    "url": "https://login.proxy-ub.rug.nl/login?url=$@"
+    "url": "https://login.proxy-ub.rug.nl/login?url=",
+    "location": {
+      "lng": 6.562987199999999,
+      "lat": 53.2192634
+    },
+    "country": "Netherlands"
   },
   {
     "name": "University of Guelph",
-    "url": "http://subzero.lib.uoguelph.ca/login?url=$@"
+    "url": "http://subzero.lib.uoguelph.ca/login?url=",
+    "location": {
+      "lng": -80.22618039999999,
+      "lat": 43.5327217
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Haifa",
-    "url": "https://ezproxy.haifa.ac.il/login?url=$@"
+    "url": "https://ezproxy.haifa.ac.il/login?url=",
+    "location": {
+      "lng": 35.0195184,
+      "lat": 32.7614296
+    },
+    "country": "Israel"
   },
   {
     "name": "University of Hartford",
-    "url": "http://libill.hartford.edu:2048/login?url=$@"
+    "url": "http://libill.hartford.edu:2048/login?url=",
+    "location": {
+      "lng": -72.7138039,
+      "lat": 41.7984942
+    },
+    "country": "United States"
   },
   {
     "name": "University of Hawaii",
-    "url": "http://micro189.lib3.hawaii.edu:2048/login?url=$@"
+    "url": "http://micro189.lib3.hawaii.edu:2048/login?url=",
+    "location": {
+      "lng": -157.8148228,
+      "lat": 21.299824
+    },
+    "country": "United States"
   },
   {
     "name": "University of Hawaii, Manoa",
-    "url": "http://eres.library.manoa.hawaii.edu/login?url=$@"
+    "url": "http://eres.library.manoa.hawaii.edu/login?url=",
+    "location": {
+      "lng": -157.8148228,
+      "lat": 21.299824
+    },
+    "country": "United States"
   },
   {
     "name": "University of Hong Kong Libraries",
-    "url": "http://eproxy.lib.hku.hk/login?url=$@"
+    "url": "http://eproxy.lib.hku.hk/login?url=",
+    "location": {
+      "lng": 114.1365621,
+      "lat": 22.2830891
+    },
+    "country": "Hong Kong"
   },
   {
     "name": "University of Houston",
-    "url": "http://ezproxy.lib.uh.edu/login?url=$@"
+    "url": "http://ezproxy.lib.uh.edu/login?url=",
+    "location": {
+      "lng": -95.3422334,
+      "lat": 29.7199489
+    },
+    "country": "United States"
   },
   {
     "name": "University of Houston - Clear Lake",
-    "url": "http://libproxy.uhcl.edu/login?url=$@"
+    "url": "http://libproxy.uhcl.edu/login?url=",
+    "location": {
+      "lng": -95.0989342,
+      "lat": 29.5824608
+    },
+    "country": "United States"
   },
   {
     "name": "University of Idaho",
-    "url": "http://ida.lib.uidaho.edu:2048/login?url=$@"
+    "url": "http://ida.lib.uidaho.edu:2048/login?url=",
+    "location": {
+      "lng": -117.0126084,
+      "lat": 46.7288124
+    },
+    "country": "United States"
   },
   {
     "name": "University of Illinois at Chicago",
-    "url": "http://proxy.cc.uic.edu/login?url=$@"
+    "url": "http://proxy.cc.uic.edu/login?url=",
+    "location": {
+      "lng": -87.6484497,
+      "lat": 41.8685636
+    },
+    "country": "United States"
   },
   {
     "name": "University of Illinois at Urbana-Champaign",
-    "url": "https://proxy2.library.illinois.edu/login?url=$@"
+    "url": "https://proxy2.library.illinois.edu/login?url=",
+    "location": {
+      "lng": -88.2271615,
+      "lat": 40.1019523
+    },
+    "country": "United States"
   },
   {
     "name": "University of Illinois Springfield",
-    "url": "http://login.ezproxy.uis.edu/login?url=$@"
+    "url": "http://login.ezproxy.uis.edu/login?url=",
+    "location": {
+      "lng": -89.6176711,
+      "lat": 39.7305338
+    },
+    "country": "United States"
   },
   {
     "name": "University of Indiaia",
-    "url": "http://ezproxy.lib.indiana.edu/login?url=$@"
+    "url": "http://ezproxy.lib.indiana.edu/login?url=",
+    "location": {
+      "lng": -86.52300729999999,
+      "lat": 39.1682449
+    },
+    "country": "United States"
   },
   {
     "name": "University of Indianapolis",
-    "url": "https://ezproxy.uindy.edu/login?url=$@"
+    "url": "https://ezproxy.uindy.edu/login?url=",
+    "location": {
+      "lng": -86.1346712,
+      "lat": 39.7095679
+    },
+    "country": "United States"
   },
   {
     "name": "University of Iowa",
-    "url": "https://login.proxy.lib.uiowa.edu/login?qurl=$@"
+    "url": "https://login.proxy.lib.uiowa.edu/login?qurl=",
+    "location": {
+      "lng": -91.5549771,
+      "lat": 41.66270780000001
+    },
+    "country": "United States"
   },
   {
     "name": "University of Jordan",
-    "url": "http://ezlibrary.ju.edu.jo/login?url=$@"
+    "url": "http://ezlibrary.ju.edu.jo/login?url=",
+    "location": {
+      "lng": 35.8695456,
+      "lat": 32.0161048
+    },
+    "country": "Jordan"
   },
   {
     "name": "University of Kansas",
-    "url": "http://www2.lib.ku.edu:2048/login?url=$@"
+    "url": "http://www2.lib.ku.edu:2048/login?url=",
+    "location": {
+      "lng": -95.2557961,
+      "lat": 38.9543439
+    },
+    "country": "United States"
   },
   {
     "name": "University of Kansas Medical Center",
-    "url": "https://login.proxy.kumc.edu/login?qurl=$@"
+    "url": "https://login.proxy.kumc.edu/login?qurl=",
+    "location": {
+      "lng": -94.60966789999999,
+      "lat": 39.0573742
+    },
+    "country": "United States"
   },
   {
     "name": "University of Kent",
-    "url": "http://chain.kent.ac.uk/login?url=$@"
+    "url": "http://chain.kent.ac.uk/login?url=",
+    "location": {
+      "lng": 1.0630042,
+      "lat": 51.2967395
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Kentucky",
-    "url": "http://ezproxy.uky.edu/login?url=$@"
+    "url": "http://ezproxy.uky.edu/login?url=",
+    "location": {
+      "lng": -84.5039697,
+      "lat": 38.0306511
+    },
+    "country": "United States"
   },
   {
     "name": "University of KwaZulu Natal",
-    "url": "https://ezproxy.ukzn.ac.za:2443/login?url=$@"
+    "url": "https://ezproxy.ukzn.ac.za:2443/login?url=",
+    "location": {
+      "lng": 30.9807272,
+      "lat": -29.8674219
+    },
+    "country": "South Africa"
   },
   {
     "name": "University of Leeds",
-    "url": "https://go.openathens.net/redirector/leeds.ac.uk?url=$@"
+    "url": "https://go.openathens.net/redirector/leeds.ac.uk?url=",
+    "location": {
+      "lng": -1.5550328,
+      "lat": 53.8066815
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Leicester",
-    "url": "http://ezproxy.lib.le.ac.uk/login?url=$@"
+    "url": "http://ezproxy.lib.le.ac.uk/login?url=",
+    "location": {
+      "lng": -1.1246325,
+      "lat": 52.6211393
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Lethbridge",
-    "url": "https://ezproxy.uleth.ca/login?url=$@"
+    "url": "https://ezproxy.uleth.ca/login?url=",
+    "location": {
+      "lng": -112.8601177,
+      "lat": 49.6786156
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Limerick",
-    "url": "https://login.proxy.lib.ul.ie/login?url=$@"
+    "url": "https://login.proxy.lib.ul.ie/login?url=",
+    "location": {
+      "lng": -8.5719129,
+      "lat": 52.6737944
+    },
+    "country": "Ireland"
   },
   {
     "name": "University of Lincoln (UK)",
-    "url": "http://proxy.library.lincoln.ac.uk/login?url=$@"
+    "url": "http://proxy.library.lincoln.ac.uk/login?url=",
+    "location": {
+      "lng": -3.435973,
+      "lat": 55.378051
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Liverpool",
-    "url": "https://liverpool.idm.oclc.org/login?url=$@"
+    "url": "https://liverpool.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -2.965299,
+      "lat": 53.40478239999999
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Louisiana at Lafayette",
-    "url": "http://ezproxy.ucs.louisiana.edu:2048/login?url=$@"
+    "url": "http://ezproxy.ucs.louisiana.edu:2048/login?url=",
+    "location": {
+      "lng": -92.019914,
+      "lat": 30.211991
+    },
+    "country": "United States"
   },
   {
     "name": "University of Louisville",
-    "url": "http://echo.louisville.edu/login?url=$@"
+    "url": "http://echo.louisville.edu/login?url=",
+    "location": {
+      "lng": -85.75850229999999,
+      "lat": 38.2122761
+    },
+    "country": "United States"
   },
   {
     "name": "University of Macau",
-    "url": "http://libezproxy.umac.mo/login?url=$@"
+    "url": "http://libezproxy.umac.mo/login?url=",
+    "location": {
+      "lng": 113.5457795,
+      "lat": 22.130002
+    },
+    "country": "Macao"
   },
   {
     "name": "University of Maine System",
-    "url": "http://www.library.umaine.edu/auth/EZProxy/test/authej.asp?url=$@"
+    "url": "http://www.library.umaine.edu/auth/EZProxy/test/authej.asp?url=",
+    "location": {
+      "lng": -70.14744089999999,
+      "lat": 44.6675867
+    },
+    "country": "United States"
   },
   {
     "name": "University of Malta",
-    "url": "https://ejournals.um.edu.mt/login/?url=$@"
+    "url": "https://ejournals.um.edu.mt/login/?url=",
+    "location": {
+      "lng": 14.4847432,
+      "lat": 35.90232
+    },
+    "country": "Malta"
   },
   {
     "name": "University of Manitoba",
-    "url": "https://uml.idm.oclc.org/login?url=$@"
+    "url": "https://uml.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -98.81387629999999,
+      "lat": 53.7608608
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Maryland",
-    "url": "http://ezproxy.law.umaryland.edu/login?auth=Library&url=$@"
+    "url": "http://ezproxy.law.umaryland.edu/login?auth=Library&url=",
+    "location": {
+      "lng": -76.9425543,
+      "lat": 38.9869183
+    },
+    "country": "United States"
   },
   {
     "name": "University of Maryland University",
-    "url": "http://ezproxy.umuc.edu/login?url=$@"
+    "url": "http://ezproxy.umuc.edu/login?url=",
+    "location": {
+      "lng": -76.9425543,
+      "lat": 38.9869183
+    },
+    "country": "United States"
   },
   {
     "name": "University of Maryland, Baltimore County (UMBC)",
-    "url": "http://proxy-bc.researchport.umd.edu/login?url=$@"
+    "url": "http://proxy-bc.researchport.umd.edu/login?url=",
+    "location": {
+      "lng": -76.7114685,
+      "lat": 39.2497768
+    },
+    "country": "United States"
   },
   {
     "name": "University of Maryland, College Park",
-    "url": "http://proxy-um.researchport.umd.edu/login?url=$@"
+    "url": "http://proxy-um.researchport.umd.edu/login?url=",
+    "location": {
+      "lng": -76.9425543,
+      "lat": 38.9869183
+    },
+    "country": "United States"
   },
   {
     "name": "University of Massachusetts Amherst",
-    "url": "http://silk.library.umass.edu:2048/login?url=$@"
+    "url": "http://silk.library.umass.edu:2048/login?url=",
+    "location": {
+      "lng": -72.5300515,
+      "lat": 42.3867598
+    },
+    "country": "United States"
   },
   {
     "name": "University of Massachusetts Boston",
-    "url": "http://ezproxy.lib.umb.edu/login?url=$@"
+    "url": "http://ezproxy.lib.umb.edu/login?url=",
+    "location": {
+      "lng": -71.0419953,
+      "lat": 42.3141992
+    },
+    "country": "United States"
   },
   {
     "name": "University of Massachusetts Dartmouth",
-    "url": "http://libproxy.umassd.edu/login?url=$@"
+    "url": "http://libproxy.umassd.edu/login?url=",
+    "location": {
+      "lng": -71.0054336,
+      "lat": 41.6269122
+    },
+    "country": "United States"
   },
   {
     "name": "University of Massachusetts Lowell",
-    "url": "http://libproxy.uml.edu/login?url=$@"
+    "url": "http://libproxy.uml.edu/login?url=",
+    "location": {
+      "lng": -71.3247164,
+      "lat": 42.6552587
+    },
+    "country": "United States"
   },
   {
     "name": "University of Massachusetts Medical School",
-    "url": "http://ezproxy.umassmed.edu/login?url=$@"
+    "url": "http://ezproxy.umassmed.edu/login?url=",
+    "location": {
+      "lng": -71.7633073,
+      "lat": 42.2786007
+    },
+    "country": "United States"
   },
   {
     "name": "University of Massachusetts, Amherst",
-    "url": "http://silk.library.umass.edu/login?url=$@"
+    "url": "http://silk.library.umass.edu/login?url=",
+    "location": {
+      "lng": -72.5300515,
+      "lat": 42.3867598
+    },
+    "country": "United States"
   },
   {
     "name": "University of Melbourne",
-    "url": "https://ezp.lib.unimelb.edu.au/login?url=$@"
+    "url": "https://ezp.lib.unimelb.edu.au/login?url=",
+    "location": {
+      "lng": 144.960974,
+      "lat": -37.7983459
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Miami",
-    "url": "http://access.library.miami.edu/login?url=$@"
+    "url": "http://access.library.miami.edu/login?url=",
+    "location": {
+      "lng": -80.2781262,
+      "lat": 25.7173947
+    },
+    "country": "United States"
   },
   {
     "name": "University of Michigan",
-    "url": "http://proxy.lib.umich.edu/login?url=$@"
+    "url": "http://proxy.lib.umich.edu/login?url=",
+    "location": {
+      "lng": -83.74097979999999,
+      "lat": 42.2790522
+    },
+    "country": "United States"
   },
   {
     "name": "University of Michigan-Flint",
-    "url": "http://libproxy.umflint.edu/login?url=$@"
+    "url": "http://libproxy.umflint.edu/login?url=",
+    "location": {
+      "lng": -83.6894611,
+      "lat": 43.0194791
+    },
+    "country": "United States"
   },
   {
     "name": "University of Minnesota",
-    "url": "https://login.ezproxy.lib.umn.edu/login?url=$@"
+    "url": "https://login.ezproxy.lib.umn.edu/login?url=",
+    "location": {
+      "lng": -93.2277285,
+      "lat": 44.97399
+    },
+    "country": "United States"
   },
   {
     "name": "University of Minnesota Duluth",
-    "url": "https://login.libpdb.d.umn.edu:2443/login?url=$@"
+    "url": "https://login.libpdb.d.umn.edu:2443/login?url=",
+    "location": {
+      "lng": -92.0843306,
+      "lat": 46.8187754
+    },
+    "country": "United States"
   },
   {
     "name": "University of Minnesota Morris",
-    "url": "http://ezproxy.morris.umn.edu/login?url=$@"
+    "url": "http://ezproxy.morris.umn.edu/login?url=",
+    "location": {
+      "lng": -95.8969661,
+      "lat": 45.58903170000001
+    },
+    "country": "United States"
   },
   {
     "name": "University of Mississippi",
-    "url": "http://umiss.idm.oclc.org/login?url=$@"
+    "url": "http://umiss.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -89.5383818,
+      "lat": 34.3647349
+    },
+    "country": "United States"
   },
   {
     "name": "University of Mississippi Medial Center",
-    "url": "http://ezproxy2.umc.edu/login?url=$@"
+    "url": "http://ezproxy2.umc.edu/login?url=",
+    "location": {
+      "lng": -89.5383818,
+      "lat": 34.3647349
+    },
+    "country": "United States"
   },
   {
     "name": "University of Missouri",
-    "url": "http://proxy.mul.missouri.edu/login?url=$@"
+    "url": "http://proxy.mul.missouri.edu/login?url=",
+    "location": {
+      "lng": -92.32773750000001,
+      "lat": 38.9403808
+    },
+    "country": "United States"
   },
   {
     "name": "University of Missouri - St. Louis",
-    "url": "http://ezproxy.umsl.edu/login?url=$@"
+    "url": "http://ezproxy.umsl.edu/login?url=",
+    "location": {
+      "lng": -90.3083223,
+      "lat": 38.7092187
+    },
+    "country": "United States"
   },
   {
     "name": "University of Missouri-Kansas City",
-    "url": "http://proxy.library.umkc.edu/login?url=$@"
+    "url": "http://proxy.library.umkc.edu/login?url=",
+    "location": {
+      "lng": -94.58342739999999,
+      "lat": 39.0343551
+    },
+    "country": "United States"
   },
   {
     "name": "University of Montana",
-    "url": "http://weblib.lib.umt.edu:8080/login?url=$@"
+    "url": "http://weblib.lib.umt.edu:8080/login?url=",
+    "location": {
+      "lng": -113.9845969,
+      "lat": 46.8619309
+    },
+    "country": "United States"
   },
   {
     "name": "University of Montevallo",
-    "url": "http://ezproxy.montevallo.edu:2048/login?url=$@"
+    "url": "http://ezproxy.montevallo.edu:2048/login?url=",
+    "location": {
+      "lng": -86.86541679999999,
+      "lat": 33.1067187
+    },
+    "country": "United States"
   },
   {
     "name": "University of Nebraska - Lincoln",
-    "url": "https://login.libproxy.unl.edu/login?url=$@"
+    "url": "https://login.libproxy.unl.edu/login?url=",
+    "location": {
+      "lng": -96.70047629999999,
+      "lat": 40.8201966
+    },
+    "country": "United States"
   },
   {
     "name": "University of Nebraska Medical Center",
-    "url": "http://library1.unmc.edu:2048/login?url=$@"
+    "url": "http://library1.unmc.edu:2048/login?url=",
+    "location": {
+      "lng": -95.9759002,
+      "lat": 41.2548733
+    },
+    "country": "United States"
   },
   {
     "name": "University of Nevada Reno",
-    "url": "https://unr.idm.oclc.org/login?url=$@"
+    "url": "https://unr.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -119.8141582,
+      "lat": 39.5437205
+    },
+    "country": "United States"
   },
   {
     "name": "University of Nevada, Las Vegas",
-    "url": "https://login.ezproxy.library.unlv.edu/login?url=$@"
+    "url": "https://login.ezproxy.library.unlv.edu/login?url=",
+    "location": {
+      "lng": -115.1435252,
+      "lat": 36.107496
+    },
+    "country": "United States"
   },
   {
     "name": "University of New Brunswick",
-    "url": "https://login.proxy.hil.unb.ca/login?url=$@"
+    "url": "https://login.proxy.hil.unb.ca/login?url=",
+    "location": {
+      "lng": -66.64295761934224,
+      "lat": 45.944855857498474
+    },
+    "country": "Canada"
   },
   {
     "name": "University of New England",
-    "url": "https://une.idm.oclc.org/login?url=$@"
+    "url": "https://une.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -70.3865402,
+      "lat": 43.4582904
+    },
+    "country": "United States"
   },
   {
     "name": "University of New England (Australia)",
-    "url": "http://ezproxy.une.edu.au/login?url=$@"
+    "url": "http://ezproxy.une.edu.au/login?url=",
+    "location": {
+      "lng": 151.6410199,
+      "lat": -30.4899535
+    },
+    "country": "Australia"
   },
   {
     "name": "University of New Haven",
-    "url": "http://unh-proxy.newhaven.edu:2048/login?url=$@"
-  },
-  {
-    "name": "University of New Mexico",
-    "url": "http://libproxy.unm.edu/login?url=$@"
+    "url": "http://unh-proxy.newhaven.edu:2048/login?url=",
+    "location": {
+      "lng": -72.96189919999999,
+      "lat": 41.2921105
+    },
+    "country": "United States"
   },
   {
     "name": "University of New Orleans",
-    "url": "http://ezproxy.uno.edu/login?url=$@"
+    "url": "http://ezproxy.uno.edu/login?url=",
+    "location": {
+      "lng": -90.0680105,
+      "lat": 30.0273134
+    },
+    "country": "United States"
   },
   {
     "name": "University of New South Wales",
-    "url": "http://wwwproxy0.nun.unsw.edu.au/login?url=$@"
+    "url": "http://wwwproxy0.nun.unsw.edu.au/login?url=",
+    "location": {
+      "lng": 151.2312675,
+      "lat": -33.917347
+    },
+    "country": "Australia"
   },
   {
     "name": "University of New South Wales (UNSW)",
-    "url": "https://login.wwwproxy1.library.unsw.edu.au/login?qurl=$@"
+    "url": "https://login.wwwproxy1.library.unsw.edu.au/login?qurl=",
+    "location": {
+      "lng": 151.2312675,
+      "lat": -33.917347
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Newcastle",
-    "url": "http://ezproxy.newcastle.edu.au/login?url=$@"
+    "url": "http://ezproxy.newcastle.edu.au/login?url=",
+    "location": {
+      "lng": 151.7041775,
+      "lat": -32.8927718
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Newcastle, Australia",
-    "url": "https://login.ezproxy.newcastle.edu.au/login?url=$@"
+    "url": "https://login.ezproxy.newcastle.edu.au/login?url=",
+    "location": {
+      "lng": 151.7041775,
+      "lat": -32.8927718
+    },
+    "country": "Australia"
   },
   {
     "name": "University of North Alabama",
-    "url": "https://ezproxy.una.edu/login?url=$@"
+    "url": "https://ezproxy.una.edu/login?url=",
+    "location": {
+      "lng": -87.6804676,
+      "lat": 34.807836
+    },
+    "country": "United States"
   },
   {
     "name": "University of North Carolina at Chapel Hill",
-    "url": "http://libproxy.lib.unc.edu/login?url=$@"
+    "url": "http://libproxy.lib.unc.edu/login?url=",
+    "location": {
+      "lng": -79.0469134,
+      "lat": 35.9049122
+    },
+    "country": "United States"
   },
   {
     "name": "University of North Carolina at Charlotte",
-    "url": "https://librarylink.uncc.edu/login?url=$@"
+    "url": "https://librarylink.uncc.edu/login?url=",
+    "location": {
+      "lng": -80.735164,
+      "lat": 35.3070929
+    },
+    "country": "United States"
   },
   {
     "name": "University of North Carolina at Greensboro",
-    "url": "http://login.libproxy.uncg.edu/login?url=$@"
+    "url": "http://login.libproxy.uncg.edu/login?url=",
+    "location": {
+      "lng": -79.8101976,
+      "lat": 36.0689296
+    },
+    "country": "United States"
   },
   {
     "name": "University of North Carolina Wilmington",
-    "url": "http://liblink.uncw.edu/login?url=$@"
+    "url": "http://liblink.uncw.edu/login?url=",
+    "location": {
+      "lng": -77.8696036,
+      "lat": 34.223874
+    },
+    "country": "United States"
   },
   {
     "name": "University of North Dakota",
-    "url": "https://login.ezproxy.library.und.edu/login?url=$@"
+    "url": "https://login.ezproxy.library.und.edu/login?url=",
+    "location": {
+      "lng": -97.0768014,
+      "lat": 47.922891
+    },
+    "country": "United States"
   },
   {
     "name": "University of North Florida",
-    "url": "https://login.dax.lib.unf.edu/login?url=$@"
+    "url": "https://login.dax.lib.unf.edu/login?url=",
+    "location": {
+      "lng": -81.50723140000001,
+      "lat": 30.2661204
+    },
+    "country": "United States"
   },
   {
     "name": "University of North Texas",
-    "url": "https://libproxy.library.unt.edu/login?url=$@"
+    "url": "https://libproxy.library.unt.edu/login?url=",
+    "location": {
+      "lng": -97.1525862,
+      "lat": 33.207488
+    },
+    "country": "United States"
   },
   {
     "name": "University of North Texas Health Science Center",
-    "url": "https://proxy.hsc.unt.edu/login?url=$@"
+    "url": "https://proxy.hsc.unt.edu/login?url=",
+    "location": {
+      "lng": -97.3694771,
+      "lat": 32.7496982
+    },
+    "country": "United States"
   },
   {
     "name": "University of Northampton",
-    "url": "https://ezproxy.northampton.ac.uk/login?url=$@"
+    "url": "https://ezproxy.northampton.ac.uk/login?url=",
+    "location": {
+      "lng": -0.8869818,
+      "lat": 52.2304823
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Northern Iowa",
-    "url": "http://login.proxy.lib.uni.edu/login?url=$@"
+    "url": "http://login.proxy.lib.uni.edu/login?url=",
+    "location": {
+      "lng": -92.46464689999999,
+      "lat": 42.5121517
+    },
+    "country": "United States"
   },
   {
     "name": "University of Nottingham",
-    "url": "http://ezproxy.nottingham.ac.uk/login?url=$@"
+    "url": "http://ezproxy.nottingham.ac.uk/login?url=",
+    "location": {
+      "lng": -1.1981057,
+      "lat": 52.9387922
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Oklahoma",
-    "url": "http://ezproxy.lib.ou.edu/login?url=$@"
+    "url": "http://ezproxy.lib.ou.edu/login?url=",
+    "location": {
+      "lng": -97.4448963,
+      "lat": 35.1987162
+    },
+    "country": "United States"
   },
   {
     "name": "University of Oklahoma Health Sciences Center",
-    "url": "http://webproxy.ouhsc.edu/login?url=$@"
+    "url": "http://webproxy.ouhsc.edu/login?url=",
+    "location": {
+      "lng": -97.5006758,
+      "lat": 35.4796467
+    },
+    "country": "United States"
   },
   {
     "name": "University of Ontario Institute of Technology",
-    "url": "http://uproxy.library.dc-uoit.ca/login?url=$@"
+    "url": "http://uproxy.library.dc-uoit.ca/login?url=",
+    "location": {
+      "lng": -78.8967866,
+      "lat": 43.94564279999999
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Oregon",
-    "url": "https://uoregon.idm.oclc.org/login?url=$@"
+    "url": "https://uoregon.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -123.0726055,
+      "lat": 44.0448302
+    },
+    "country": "United States"
   },
   {
     "name": "University of Oslo",
-    "url": "https://login.ezproxy.uio.no/login?url=$@"
+    "url": "https://login.ezproxy.uio.no/login?url=",
+    "location": {
+      "lng": 10.7217496,
+      "lat": 59.9399586
+    },
+    "country": "Norway"
   },
   {
     "name": "University of Otago",
-    "url": "https://www.otago.ac.nz/library/ezproxy/ezproxy_auth.php?url=$@"
+    "url": "https://www.otago.ac.nz/library/ezproxy/ezproxy_auth.php?url=",
+    "location": {
+      "lng": 170.5144227,
+      "lat": -45.8646835
+    },
+    "country": "New Zealand"
   },
   {
     "name": "University of Otago Dunedin",
-    "url": "https://ezproxy.otago.ac.nz/login?url=$@"
+    "url": "https://ezproxy.otago.ac.nz/login?url=",
+    "location": {
+      "lng": 170.5005957,
+      "lat": -45.8795455
+    },
+    "country": "New Zealand"
   },
   {
     "name": "University of Otago Wellington",
-    "url": "https://wmezproxy.wnmeds.ac.nz/login?url=$@"
+    "url": "https://wmezproxy.wnmeds.ac.nz/login?url=",
+    "location": {
+      "lng": 174.7810326,
+      "lat": -41.3098922
+    },
+    "country": "New Zealand"
   },
   {
     "name": "University of Otago, Christchurch",
-    "url": "https://cmezproxy.chmeds.ac.nz/login?url=$@"
+    "url": "https://cmezproxy.chmeds.ac.nz/login?url=",
+    "location": {
+      "lng": 172.6259732,
+      "lat": -43.5345179
+    },
+    "country": "New Zealand"
   },
   {
     "name": "University of Ottawa",
-    "url": "https://login.proxy.bib.uottawa.ca/login?url=$@"
+    "url": "https://login.proxy.bib.uottawa.ca/login?url=",
+    "location": {
+      "lng": -75.68313289999999,
+      "lat": 45.42310639999999
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Oxford",
-    "url": "https://ezproxy-prd.bodleian.ox.ac.uk/login?url=$@"
+    "url": "https://ezproxy-prd.bodleian.ox.ac.uk/login?url=",
+    "location": {
+      "lng": -1.2543668,
+      "lat": 51.7548164
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Pennsylvania",
-    "url": "https://proxy.library.upenn.edu/login?url=$@"
+    "url": "https://proxy.library.upenn.edu/login?url=",
+    "location": {
+      "lng": -75.1932137,
+      "lat": 39.9522188
+    },
+    "country": "United States"
   },
   {
     "name": "University of Phoenix",
-    "url": "http://contentproxy.phoenix.edu/login?url=$@"
+    "url": "http://contentproxy.phoenix.edu/login?url=",
+    "location": {
+      "lng": -112.0128315,
+      "lat": 33.4113377
+    },
+    "country": "United States"
   },
   {
     "name": "University of Pittsburgh",
-    "url": "http://pitt.idm.oclc.org/login?url=$@"
+    "url": "http://pitt.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -79.960835,
+      "lat": 40.4443533
+    },
+    "country": "United States"
   },
   {
     "name": "University of Portland",
-    "url": "https://login.uportland.idm.oclc.org/login?url=$@"
+    "url": "https://login.uportland.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -122.7275712,
+      "lat": 45.5732046
+    },
+    "country": "United States"
   },
   {
     "name": "University of Pretoria",
-    "url": "https://uplib.idm.oclc.org/login?url=$@"
+    "url": "https://uplib.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 28.2314476,
+      "lat": -25.7545492
+    },
+    "country": "South Africa"
   },
   {
     "name": "University of Prince Edward Island",
-    "url": "http://proxy.library.upei.ca/login?url=$@"
+    "url": "http://proxy.library.upei.ca/login?url=",
+    "location": {
+      "lng": -63.13890780000001,
+      "lat": 46.2568931
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Puget Sound",
-    "url": "http://ezproxy.ups.edu/login?url=$@"
+    "url": "http://ezproxy.ups.edu/login?url=",
+    "location": {
+      "lng": -122.4814442,
+      "lat": 47.2617495
+    },
+    "country": "United States"
   },
   {
     "name": "University of Queensland",
-    "url": "http://ezproxy.library.uq.edu.au/login?url=$@"
+    "url": "http://ezproxy.library.uq.edu.au/login?url=",
+    "location": {
+      "lng": 153.0136905,
+      "lat": -27.4975028
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Regina",
-    "url": "http://libproxy.uregina.ca:2048/login?url=$@"
+    "url": "http://libproxy.uregina.ca:2048/login?url=",
+    "location": {
+      "lng": -104.5878302,
+      "lat": 50.4154542
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Rhode Island",
-    "url": "http://uri.idm.oclc.org/login?url=$@"
+    "url": "http://uri.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -71.53067879999999,
+      "lat": 41.4862328
+    },
+    "country": "United States"
   },
   {
     "name": "University of Richmond",
-    "url": "https://newman.richmond.edu/login?url=$@"
+    "url": "https://newman.richmond.edu/login?url=",
+    "location": {
+      "lng": -77.5397192,
+      "lat": 37.5758243
+    },
+    "country": "United States"
   },
   {
     "name": "University of Rochester",
-    "url": "http://ezp.lib.rochester.edu/login?url=$@"
+    "url": "http://ezp.lib.rochester.edu/login?url=",
+    "location": {
+      "lng": -77.6260033,
+      "lat": 43.1305531
+    },
+    "country": "United States"
   },
   {
     "name": "University of Saint Joseph (Macau)",
-    "url": "https://ezproxy.usj.edu.mo:9443/login?url=$@"
+    "url": "https://ezproxy.usj.edu.mo:9443/login?url=",
+    "location": {
+      "lng": 113.5389114,
+      "lat": 22.2111388
+    },
+    "country": "Macao"
   },
   {
     "name": "University of San Carlos",
-    "url": "https://ezproxy.usc.edu.ph/login?url=$@"
+    "url": "https://ezproxy.usc.edu.ph/login?url=",
+    "location": {
+      "lng": 123.9132676,
+      "lat": 10.3521222
+    },
+    "country": "Philippines"
   },
   {
     "name": "University of San Diego",
-    "url": "https://sandiego.idm.oclc.org/login?url=$@"
+    "url": "https://sandiego.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -117.1888625,
+      "lat": 32.7721681
+    },
+    "country": "United States"
   },
   {
     "name": "University of Santo Tomas",
-    "url": "http://ezproxy.ust.edu.ph/login?url=$@"
+    "url": "http://ezproxy.ust.edu.ph/login?url=",
+    "location": {
+      "lng": 120.9893297,
+      "lat": 14.6100492
+    },
+    "country": "Philippines"
   },
   {
     "name": "University of Saskatchewan",
-    "url": "http://cyber.usask.ca/login?url=$@"
+    "url": "http://cyber.usask.ca/login?url=",
+    "location": {
+      "lng": -106.6313582,
+      "lat": 52.1334003
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Sheffield",
-    "url": "https://sheffield.idm.oclc.org/login?url=$@"
+    "url": "https://sheffield.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -1.4884229,
+      "lat": 53.3813502
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Siena",
-    "url": "https://www.ezproxy.unisi.it/login?url=$@"
+    "url": "https://www.ezproxy.unisi.it/login?url=",
+    "location": {
+      "lng": 11.3328421,
+      "lat": 43.3191155
+    },
+    "country": "Italy"
   },
   {
     "name": "University of South Alabama",
-    "url": "https://libproxy.usouthal.edu/login?url=$@"
+    "url": "https://libproxy.usouthal.edu/login?url=",
+    "location": {
+      "lng": -88.184236,
+      "lat": 30.6959406
+    },
+    "country": "United States"
   },
   {
     "name": "University of South Australia",
-    "url": "https://access.library.unisa.edu.au/login?url=$@"
+    "url": "https://login.ezlibproxy.unisa.edu.au/login?url=",
+    "location": {
+      "lng": 136.2091547,
+      "lat": -30.0002315
+    },
+    "country": "Australia"
   },
   {
-    "name": "University of South Australia",
-    "url": "https://login.ezlibproxy.unisa.edu.au/login?url=$@"
+    "name": "University of South Australia ",
+    "url": "https://access.library.unisa.edu.au/login?url=",
+    "location": {
+      "lng": 136.2091547,
+      "lat": -30.0002315
+    },
+    "country": "Australia"
   },
   {
     "name": "University of South Carolina",
-    "url": "https://pallas2.tcl.sc.edu/login?url=$@"
+    "url": "https://pallas2.tcl.sc.edu/login?url=",
+    "location": {
+      "lng": -81.0299186,
+      "lat": 33.9937575
+    },
+    "country": "United States"
   },
   {
     "name": "University of South Carolina Upstate",
-    "url": "http://proxy.uscupstate.edu:2048/login?url=$@"
+    "url": "http://proxy.uscupstate.edu:2048/login?url=",
+    "location": {
+      "lng": -81.9711555,
+      "lat": 34.9996102
+    },
+    "country": "United States"
   },
   {
     "name": "University of South Dakota",
-    "url": "http://ezproxy.usd.edu/login?url=$@"
+    "url": "http://ezproxy.usd.edu/login?url=",
+    "location": {
+      "lng": -96.92533809999999,
+      "lat": 42.7883015
+    },
+    "country": "United States"
   },
   {
     "name": "University of South Florida",
-    "url": "http://ezproxy.lib.usf.edu/login?url=$@"
+    "url": "http://ezproxy.lib.usf.edu/login?url=",
+    "location": {
+      "lng": -82.41385389999999,
+      "lat": 28.0587031
+    },
+    "country": "United States"
   },
   {
     "name": "University of Southern California",
-    "url": "https://libproxy.usc.edu/login?url=$@"
+    "url": "https://libproxy.usc.edu/login?url=",
+    "location": {
+      "lng": -118.285117,
+      "lat": 34.0223519
+    },
+    "country": "United States"
   },
   {
     "name": "University of Southern Denmark",
-    "url": "http://proxy1-bib.sdu.dk:2048/login?url=$@"
+    "url": "http://proxy1-bib.sdu.dk:2048/login?url=",
+    "location": {
+      "lng": 10.4282364,
+      "lat": 55.3689827
+    },
+    "country": "Denmark"
   },
   {
     "name": "University of Southern Mississippi",
-    "url": "http://lynx.lib.usm.edu/login?url=$@"
+    "url": "http://lynx.lib.usm.edu/login?url=",
+    "location": {
+      "lng": -89.33345349999999,
+      "lat": 31.3298668
+    },
+    "country": "United States"
   },
   {
     "name": "University of Southern Queensland",
-    "url": "http://ezproxy.usq.edu.au/login?url=$@"
+    "url": "http://ezproxy.usq.edu.au/login?url=",
+    "location": {
+      "lng": 151.9302108,
+      "lat": -27.6045414
+    },
+    "country": "Australia"
   },
   {
     "name": "University of St Andrews",
-    "url": "http://ezproxy.st-andrews.ac.uk/login?url=$@"
+    "url": "http://ezproxy.st-andrews.ac.uk/login?url=",
+    "location": {
+      "lng": -2.7942674,
+      "lat": 56.3417136
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of St Francis",
-    "url": "http://ezproxy.stfrancis.edu/login?url=$@"
+    "url": "http://ezproxy.stfrancis.edu/login?url=",
+    "location": {
+      "lng": -88.09758579999999,
+      "lat": 41.5332096
+    },
+    "country": "United States"
   },
   {
     "name": "University of St Thomas Houston",
-    "url": "http://ezproxy.stthom.edu:2048/login?url=$@"
+    "url": "http://ezproxy.stthom.edu:2048/login?url=",
+    "location": {
+      "lng": -95.39346800000001,
+      "lat": 29.7366605
+    },
+    "country": "United States"
   },
   {
     "name": "University of St. Thomas",
-    "url": "https://login.ezproxy.stthomas.edu/login?url=$@"
+    "url": "https://login.ezproxy.stthomas.edu/login?url=",
+    "location": {
+      "lng": -93.1897082,
+      "lat": 44.943096
+    },
+    "country": "United States"
   },
   {
     "name": "University of Stavanger",
-    "url": "https://ezproxy.uis.no/login?url=$@"
+    "url": "https://ezproxy.uis.no/login?url=",
+    "location": {
+      "lng": 5.697201,
+      "lat": 58.93729899999999
+    },
+    "country": "Norway"
   },
   {
     "name": "University of Stirling",
-    "url": "http://ezproxy.stir.ac.uk/login?url=$@"
+    "url": "http://ezproxy.stir.ac.uk/login?url=",
+    "location": {
+      "lng": -3.9177579,
+      "lat": 56.146092
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Strathclyde",
-    "url": "http://proxy.lib.strath.ac.uk/login?url=$@"
+    "url": "http://proxy.lib.strath.ac.uk/login?url=",
+    "location": {
+      "lng": -4.2423901,
+      "lat": 55.8621114
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Sunshine Coast",
-    "url": "http://ezproxy.usc.edu.au:2048/login?url=$@"
+    "url": "http://ezproxy.usc.edu.au:2048/login?url=",
+    "location": {
+      "lng": 153.0658032,
+      "lat": -26.7169935
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Sussex",
-    "url": "http://ezproxy.sussex.ac.uk/login?url=$@"
+    "url": "http://ezproxy.sussex.ac.uk/login?url=",
+    "location": {
+      "lng": -0.0875492,
+      "lat": 50.8677123
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Sydney",
-    "url": "http://ezproxy.library.usyd.edu.au/login?url=$@"
+    "url": "http://ezproxy.library.usyd.edu.au/login?url=",
+    "location": {
+      "lng": 151.1873494,
+      "lat": -33.8885748
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Tartu",
-    "url": "http://ezproxy.utlib.ee/login?url=$@"
+    "url": "http://ezproxy.utlib.ee/login?url=",
+    "location": {
+      "lng": 26.7290383,
+      "lat": 58.37798299999999
+    },
+    "country": "Estonia"
   },
   {
     "name": "University of Tasmania",
-    "url": "http://ezproxy.utas.edu.au/login?url=$@"
+    "url": "http://ezproxy.utas.edu.au/login?url=",
+    "location": {
+      "lng": 147.3247503,
+      "lat": -42.9041118
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Technology, Sydney",
-    "url": "http://ezproxy.lib.uts.edu.au/login?url=$@"
+    "url": "http://ezproxy.lib.uts.edu.au/login?url=",
+    "location": {
+      "lng": 151.2006119,
+      "lat": -33.8836537
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Tennessee at Martin",
-    "url": "http://ezproxy.utm.edu/login?url=$@"
+    "url": "http://ezproxy.utm.edu/login?url=",
+    "location": {
+      "lng": -88.86433319999999,
+      "lat": 36.3429724
+    },
+    "country": "United States"
   },
   {
     "name": "University of Tennessee Chattanooga",
-    "url": "http://proxy.lib.utc.edu/login?url=$@"
+    "url": "http://proxy.lib.utc.edu/login?url=",
+    "location": {
+      "lng": -85.2953072,
+      "lat": 35.0458509
+    },
+    "country": "United States"
   },
   {
     "name": "University of Tennessee Health Science Center",
-    "url": "https://login.ezproxy.uthsc.edu/login?qurl=$@"
+    "url": "https://login.ezproxy.uthsc.edu/login?qurl=",
+    "location": {
+      "lng": -90.03061609999999,
+      "lat": 35.1408087
+    },
+    "country": "United States"
   },
   {
     "name": "University of Tennessee Health Science Center ( UTHSC )",
-    "url": "https://ezproxy.uthsc.edu/login?url=$@"
+    "url": "https://ezproxy.uthsc.edu/login?url=",
+    "location": {
+      "lng": -90.03061609999999,
+      "lat": 35.1408087
+    },
+    "country": "United States"
   },
   {
     "name": "University of Tennessee Knoxville",
-    "url": "https://login.proxy.lib.utk.edu:2050/login?url=$@"
+    "url": "https://login.proxy.lib.utk.edu:2050/login?url=",
+    "location": {
+      "lng": -83.92945639999999,
+      "lat": 35.9544013
+    },
+    "country": "United States"
   },
   {
     "name": "University of Tennessee, Knoxville",
-    "url": "https://login.proxy.lib.utk.edu/login?qurl=$@"
+    "url": "https://utk.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -83.92945639999999,
+      "lat": 35.9544013
+    },
+    "country": "United States"
   },
   {
-    "name": "University of Tennessee, Knoxville",
-    "url": "https://utk.idm.oclc.org/login?url=$@"
+    "name": "University of Tennessee, Knoxville (Alternative)",
+    "url": "https://login.proxy.lib.utk.edu/login?qurl=",
+    "location": {
+      "lng": -83.92945639999999,
+      "lat": 35.9544013
+    },
+    "country": "United States"
   },
   {
     "name": "University of Texas at Austin",
-    "url": "http://ezproxy.lib.utexas.edu/login?url=$@"
+    "url": "http://ezproxy.lib.utexas.edu/login?url=",
+    "location": {
+      "lng": -97.7340567,
+      "lat": 30.2849185
+    },
+    "country": "United States"
   },
   {
     "name": "University of Texas at Brownsville",
-    "url": "http://pathfinder.utb.edu:2048/login?url=$@"
+    "url": "http://pathfinder.utb.edu:2048/login?url=",
+    "location": {
+      "lng": -97.4974838,
+      "lat": 25.9017472
+    },
+    "country": "United States"
   },
   {
     "name": "University of Texas at Dallas",
-    "url": "http://libproxy.utdallas.edu:80/login?url=$@"
+    "url": "http://libproxy.utdallas.edu:80/login?url=",
+    "location": {
+      "lng": -96.75024739999999,
+      "lat": 32.9856974
+    },
+    "country": "United States"
   },
   {
     "name": "University of Texas at San Antonio",
-    "url": "https://login.libweb.lib.utsa.edu/login?url=$@"
+    "url": "https://login.libweb.lib.utsa.edu/login?url=",
+    "location": {
+      "lng": -98.4945922,
+      "lat": 29.4251905
+    },
+    "country": "United States"
   },
   {
     "name": "University of Texas at Tyler",
-    "url": "http://ezproxy.uttyler.edu:2048/login?url=$@"
+    "url": "http://ezproxy.uttyler.edu:2048/login?url=",
+    "location": {
+      "lng": -95.30106239999999,
+      "lat": 32.3512601
+    },
+    "country": "United States"
   },
   {
     "name": "University of Texas Medical Branch",
-    "url": "http://libux.utmb.edu/login?url=$@"
+    "url": "http://libux.utmb.edu/login?url=",
+    "location": {
+      "lng": -99.9018131,
+      "lat": 31.9685988
+    },
+    "country": "United States"
   },
   {
     "name": "University of Texas Pan American",
-    "url": "http://ezhost.panam.edu:2048/login?url=$@"
+    "url": "http://ezhost.panam.edu:2048/login?url=",
+    "location": {
+      "lng": -98.17401579999999,
+      "lat": 26.3081983
+    },
+    "country": "United States"
   },
   {
     "name": "University of Texas Rio Grande Valley",
-    "url": "http://ezhost.utrgv.edu:2048/login?url=$@"
+    "url": "http://ezhost.utrgv.edu:2048/login?url=",
+    "location": {
+      "lng": -98.17401579999999,
+      "lat": 26.3081983
+    },
+    "country": "United States"
   },
   {
     "name": "University of the Cumberlands",
-    "url": "http://uc2.ucumberlands.edu:2048/login?url=$@"
+    "url": "http://uc2.ucumberlands.edu:2048/login?url=",
+    "location": {
+      "lng": -84.1635877,
+      "lat": 36.7367315
+    },
+    "country": "United States"
   },
   {
     "name": "University of the Fraser Valley",
-    "url": "http://proxy.ufv.ca:2048/login?url=$@"
+    "url": "http://proxy.ufv.ca:2048/login?url=",
+    "location": {
+      "lng": -122.2852935,
+      "lat": 49.0286216
+    },
+    "country": "Canada"
   },
   {
     "name": "University of the Incarnate Word",
-    "url": "https://uiwtx.idm.oclc.org/login?url=$@"
+    "url": "https://uiwtx.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -98.4676824,
+      "lat": 29.4675393
+    },
+    "country": "United States"
   },
   {
     "name": "University of the Pacific",
-    "url": "http://ezproxy.pacific.edu/login?url=$@"
+    "url": "http://ezproxy.pacific.edu/login?url=",
+    "location": {
+      "lng": -121.3128577,
+      "lat": 37.9798869
+    },
+    "country": "United States"
   },
   {
     "name": "University of the Philippines College of Engineering",
-    "url": "http://ezproxy.engglib.upd.edu.ph/login?url=$@"
+    "url": "http://ezproxy.engglib.upd.edu.ph/login?url=",
+    "location": {
+      "lng": 121.0696293,
+      "lat": 14.6565387
+    },
+    "country": "Philippines"
   },
   {
     "name": "University of the West Indies at Mona",
-    "url": "http://rproxy.uwimona.edu.jm/login?url=$@"
+    "url": "http://rproxy.uwimona.edu.jm/login?url=",
+    "location": {
+      "lng": -66.4108475,
+      "lat": 18.2345027
+    },
+    "country": ""
   },
   {
     "name": "University of the West of England",
-    "url": "http://ezproxy.uwe.ac.uk/login?url=$@"
+    "url": "http://ezproxy.uwe.ac.uk/login?url=",
+    "location": {
+      "lng": -2.5474318,
+      "lat": 51.5006497
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of the Witwatersrand",
-    "url": "https://innopac.wits.ac.za/validate?url=$@"
+    "url": "https://innopac.wits.ac.za/validate?url=",
+    "location": {
+      "lng": 28.0304733,
+      "lat": -26.1928836
+    },
+    "country": "South Africa"
   },
   {
     "name": "University of Tokyo (UTOKYO)",
-    "url": "https://login.ezoris.lib.u-tokyo.ac.jp/login?url=$@"
+    "url": "https://login.ezoris.lib.u-tokyo.ac.jp/login?url=",
+    "location": {
+      "lng": 139.761989,
+      "lat": 35.7126775
+    },
+    "country": "Japan"
   },
   {
     "name": "University of Toronto",
-    "url": "http://myaccess.library.utoronto.ca/login?url=$@"
+    "url": "http://myaccess.library.utoronto.ca/login?url=",
+    "location": {
+      "lng": -79.39565640000001,
+      "lat": 43.6628917
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Tsukuba",
-    "url": "http://ezproxy.tulips.tsukuba.ac.jp/login?url=$@"
+    "url": "http://ezproxy.tulips.tsukuba.ac.jp/login?url=",
+    "location": {
+      "lng": 140.1020979,
+      "lat": 36.1038666
+    },
+    "country": "Japan"
   },
   {
     "name": "University of Utah",
-    "url": "https://login.ezproxy.lib.utah.edu/login?url=$@"
+    "url": "https://login.ezproxy.lib.utah.edu/login?url=",
+    "location": {
+      "lng": -111.8421021,
+      "lat": 40.7649368
+    },
+    "country": "United States"
   },
   {
     "name": "University of Vermont",
-    "url": "https://login.ezproxy.uvm.edu/login?url=$@"
+    "url": "https://login.ezproxy.uvm.edu/login?url=",
+    "location": {
+      "lng": -73.1964637,
+      "lat": 44.4778528
+    },
+    "country": "United States"
   },
   {
     "name": "University of Victoria",
-    "url": "http://login.ezproxy.library.uvic.ca/login?url=$@"
+    "url": "http://login.ezproxy.library.uvic.ca/login?url=",
+    "location": {
+      "lng": -123.3116935,
+      "lat": 48.4634067
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Virginia",
-    "url": "http://proxy.its.virginia.edu/login?url=$@"
+    "url": "http://proxy.its.virginia.edu/login?url=",
+    "location": {
+      "lng": -78.5079772,
+      "lat": 38.0335529
+    },
+    "country": "United States"
   },
   {
     "name": "University of Waikato",
-    "url": "http://ezproxy.waikato.ac.nz/login?url=$@"
+    "url": "http://ezproxy.waikato.ac.nz/login?url=",
+    "location": {
+      "lng": 175.3184579,
+      "lat": -37.7868611
+    },
+    "country": "New Zealand"
   },
   {
     "name": "University of Wales",
-    "url": "http://ezproxy.wales.ac.uk:2048/login?url=$@"
+    "url": "http://ezproxy.wales.ac.uk:2048/login?url=",
+    "location": {
+      "lng": -3.1809939,
+      "lat": 51.48559789999999
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Wales Trinity St Davids",
-    "url": "https://ezproxy.uwtsd.ac.uk/login?url=$@"
+    "url": "https://ezproxy.uwtsd.ac.uk/login?url=",
+    "location": {
+      "lng": -4.0753536,
+      "lat": 52.11439129999999
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Warwick",
-    "url": "https://pugwash.lib.warwick.ac.uk/wamvalidate?url=$@"
+    "url": "https://pugwash.lib.warwick.ac.uk/wamvalidate?url=",
+    "location": {
+      "lng": -1.5614704,
+      "lat": 52.3792525
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Washington",
-    "url": "http://offcampus.lib.washington.edu/login?url=$@"
+    "url": "http://offcampus.lib.washington.edu/login?url=",
+    "location": {
+      "lng": -122.30463761519987,
+      "lat": 47.6598432241655
+    },
+    "country": "United States"
   },
   {
     "name": "University of Waterloo",
-    "url": "http://proxy.lib.uwaterloo.ca/login?url=$@"
+    "url": "http://proxy.lib.uwaterloo.ca/login?url=",
+    "location": {
+      "lng": -80.5448576,
+      "lat": 43.4722854
+    },
+    "country": "Canada"
   },
   {
     "name": "University of West London",
-    "url": "https://ezproxy.uwl.ac.uk/login?url=$@"
+    "url": "https://ezproxy.uwl.ac.uk/login?url=",
+    "location": {
+      "lng": -0.3032026,
+      "lat": 51.5068853
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Western Australia",
-    "url": "http://ezproxy.library.uwa.edu.au/login?url=$@"
+    "url": "http://ezproxy.library.uwa.edu.au/login?url=",
+    "location": {
+      "lng": 115.8180721,
+      "lat": -31.9789061
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Western Cape",
-    "url": "http://ezproxy.uwc.ac.za/login?url=$@"
+    "url": "http://ezproxy.uwc.ac.za/login?url=",
+    "location": {
+      "lng": 18.627958,
+      "lat": -33.9335203
+    },
+    "country": "South Africa"
   },
   {
     "name": "University of Western Ontario",
-    "url": "https://www.lib.uwo.ca/cgi-bin/ezpauthn.cgi?url=$@"
+    "url": "https://www.lib.uwo.ca/cgi-bin/ezpauthn.cgi?url=",
+    "location": {
+      "lng": -81.2737336,
+      "lat": 43.0095971
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Western Sydney",
-    "url": "https://login.ezproxy.uws.edu.au/login?url=$@"
+    "url": "https://login.ezproxy.uws.edu.au/login?url=",
+    "location": {
+      "lng": 151.0673376972992,
+      "lat": -33.817815713497254
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Westminster",
-    "url": "https://ezproxy.westminster.ac.uk/login?url=$@"
+    "url": "https://ezproxy.westminster.ac.uk/login?url=",
+    "location": {
+      "lng": -0.143179,
+      "lat": 51.51698409999999
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Windsor",
-    "url": "http://ezproxy.uwindsor.ca/login?url=$@"
+    "url": "http://ezproxy.uwindsor.ca/login?url=",
+    "location": {
+      "lng": -83.06603899999999,
+      "lat": 42.3043142
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Winnipeg",
-    "url": "http://libproxy.uwinnipeg.ca/login?url=$@"
+    "url": "http://libproxy.uwinnipeg.ca/login?url=",
+    "location": {
+      "lng": -97.15355600000001,
+      "lat": 49.891786
+    },
+    "country": "Canada"
   },
   {
     "name": "University of Wisconsin",
-    "url": "https://ezproxy.uwc.edu/login?url=$@"
+    "url": "https://ezproxy.uwc.edu/login?url=",
+    "location": {
+      "lng": -89.4124875,
+      "lat": 43.076592
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin - Milwaukee",
-    "url": "https://ezproxy.lib.uwm.edu/login?url=$@"
+    "url": "https://ezproxy.lib.uwm.edu/login?url=",
+    "location": {
+      "lng": -87.8819686,
+      "lat": 43.078263
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin - Superior",
-    "url": "https://link.uwsuper.edu:9433/login?url=$@"
+    "url": "https://link.uwsuper.edu:9433/login?url=",
+    "location": {
+      "lng": -92.0881522,
+      "lat": 46.7177476
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin Madison",
-    "url": "http://ezproxy.library.wisc.edu/login?url=$@"
+    "url": "http://ezproxy.library.wisc.edu/login?url=",
+    "location": {
+      "lng": -89.4124875,
+      "lat": 43.076592
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin Oshkosh",
-    "url": "http://www.remote.uwosh.edu/login?url=$@"
+    "url": "http://www.remote.uwosh.edu/login?url=",
+    "location": {
+      "lng": -88.55081559999999,
+      "lat": 44.0262095
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin Whitewater",
-    "url": "https://libproxy.uww.edu:9443/login?url=$@"
+    "url": "https://libproxy.uww.edu:9443/login?url=",
+    "location": {
+      "lng": -88.7427628,
+      "lat": 42.8416843
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin-Eau Claire",
-    "url": "https://login.proxy.uwec.edu/login?qurl=$@"
+    "url": "https://login.proxy.uwec.edu/login?qurl=",
+    "location": {
+      "lng": -91.5038225,
+      "lat": 44.7956278
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin-Green Bay",
-    "url": "https://ezproxy.uwgb.edu:2443/login?url=$@"
+    "url": "https://ezproxy.uwgb.edu:2443/login?url=",
+    "location": {
+      "lng": -87.9210482,
+      "lat": 44.5313196
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin-La Crosse",
-    "url": "https://libweb.uwlax.edu/login?url=$@"
+    "url": "https://libweb.uwlax.edu/login?url=",
+    "location": {
+      "lng": -91.23115330000002,
+      "lat": 43.8159885
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin-Parkside",
-    "url": "http://libraryproxy.uwp.edu:2048/login?url=$@"
+    "url": "http://libraryproxy.uwp.edu:2048/login?url=",
+    "location": {
+      "lng": -87.85174099999999,
+      "lat": 42.6450059
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin-Platteville",
-    "url": "https://login.ezproxy.uwplatt.edu/login?url=$@"
+    "url": "https://login.ezproxy.uwplatt.edu/login?url=",
+    "location": {
+      "lng": -90.48782140000002,
+      "lat": 42.7331994
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wisconsin-River Falls",
-    "url": "http://ezproxy.uwrf.edu:2048/login?url=$@"
+    "url": "http://ezproxy.uwrf.edu:2048/login?url=",
+    "location": {
+      "lng": -92.6222324,
+      "lat": 44.8530003
+    },
+    "country": "United States"
   },
   {
     "name": "University of Wollongong",
-    "url": "http://ezproxy.uow.edu.au/login?url=$@"
+    "url": "http://ezproxy.uow.edu.au/login?url=",
+    "location": {
+      "lng": 150.87843,
+      "lat": -34.4054039
+    },
+    "country": "Australia"
   },
   {
     "name": "University of Wolverhampton",
-    "url": "http://ezproxy.wlv.ac.uk/login?url=$@"
+    "url": "http://ezproxy.wlv.ac.uk/login?url=",
+    "location": {
+      "lng": -2.1274831,
+      "lat": 52.5880528
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Wyoming",
-    "url": "http://libproxy.uwyo.edu/login?url=$@"
+    "url": "http://libproxy.uwyo.edu/login?url=",
+    "location": {
+      "lng": -105.5665744,
+      "lat": 41.3148754
+    },
+    "country": "United States"
   },
   {
     "name": "University of York",
-    "url": "http://ezproxy.york.ac.uk/login?url=$@"
+    "url": "http://ezproxy.york.ac.uk/login?url=",
+    "location": {
+      "lng": -1.0517718,
+      "lat": 53.9461089
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "University of Zaragoza",
-    "url": "http://roble.unizar.es:9090/login?url=$@"
+    "url": "http://roble.unizar.es:9090/login?url=",
+    "location": {
+      "lng": -0.9015065,
+      "lat": 41.6420639
+    },
+    "country": "Spain"
   },
   {
     "name": "University Rennes 1",
-    "url": "http://passerelle.univ-rennes1.fr/login?url=$@"
+    "url": "http://passerelle.univ-rennes1.fr/login?url=",
+    "location": {
+      "lng": -1.673112,
+      "lat": 48.11574599999999
+    },
+    "country": "France"
   },
   {
     "name": "University Teknologi Malaysia",
-    "url": "http://ezproxy.psz.utm.my/login?url=$@"
+    "url": "http://ezproxy.psz.utm.my/login?url=",
+    "location": {
+      "lng": 103.6378169,
+      "lat": 1.5584681
+    },
+    "country": "Malaysia"
   },
   {
     "name": "University West",
-    "url": "http://ezproxy.server.hv.se/login?url=$@"
+    "url": "http://ezproxy.server.hv.se/login?url=",
+    "location": {
+      "lng": 12.2939585,
+      "lat": 58.2832436
+    },
+    "country": "Sweden"
   },
   {
     "name": "Università degli Studi dell'Aquila",
-    "url": "https://login.univaq.idm.oclc.org/login?url=$@"
+    "url": "https://login.univaq.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 13.397299,
+      "lat": 42.3514296
+    },
+    "country": "Italy"
   },
   {
     "name": "Università degli Studi dell'Insubria",
-    "url": "https://login.insubria.idm.oclc.org/login?qurl=$@"
+    "url": "https://login.insubria.idm.oclc.org/login?qurl=",
+    "location": {
+      "lng": 8.8275388,
+      "lat": 45.8144164
+    },
+    "country": "Italy"
   },
   {
-    "name": "Università degli Studi di Bari Aldo Moro",
-    "url": "https://login.ezproxy.uniba.it/login?url=$@"
+    "name": "Università degli Studi di Bari Aldo Moro ",
+    "url": "https://login.ezproxy.uniba.it/login?url=",
+    "location": {
+      "lng": 16.8684745,
+      "lat": 41.1205546
+    },
+    "country": "Italy"
   },
   {
     "name": "Università della Calabria",
-    "url": "https://proxy.biblioteche.unical.it/login?url=$@"
+    "url": "https://proxy.biblioteche.unical.it/login?url=",
+    "location": {
+      "lng": 16.2261297,
+      "lat": 39.3617989
+    },
+    "country": "Italy"
   },
   {
     "name": "Università di Bologna - Alma Mater Studiorum",
-    "url": "https://www.ezproxy.unibo.it/login?url=$@"
+    "url": "https://www.ezproxy.unibo.it/login?url=",
+    "location": {
+      "lng": 11.354157,
+      "lat": 44.4962318
+    },
+    "country": "Italy"
   },
   {
     "name": "Università di Trento",
-    "url": "https://www.ezp.biblio.unitn.it/login?url=$@"
+    "url": "https://www.ezp.biblio.unitn.it/login?url=",
+    "location": {
+      "lng": 11.1231091,
+      "lat": 46.0668672
+    },
+    "country": "Italy"
   },
   {
     "name": "Università di Trieste",
-    "url": "http://px.units.it/login?url=$@"
+    "url": "http://px.units.it/login?url=",
+    "location": {
+      "lng": 13.7947478,
+      "lat": 45.6595455
+    },
+    "country": "Italy"
   },
   {
     "name": "Université Bretagne Sud",
-    "url": "http://ezproxy.univ-ubs.fr/login?url=$@"
+    "url": "http://ezproxy.univ-ubs.fr/login?url=",
+    "location": {
+      "lng": -2.9326435,
+      "lat": 48.2020471
+    },
+    "country": "France"
   },
   {
     "name": "Université Clermont Auvergne",
-    "url": "https://www.ezproxy.uca.fr/login?url=$@"
+    "url": "https://www.ezproxy.uca.fr/login?url=",
+    "location": {
+      "lng": 3.0917058,
+      "lat": 45.7757949
+    },
+    "country": "France"
   },
   {
     "name": "Université d'Artois",
-    "url": "http://ezproxy.univ-artois.fr/login?url=$@"
+    "url": "http://ezproxy.univ-artois.fr/login?url=",
+    "location": {
+      "lng": 2.792248,
+      "lat": 50.283639
+    },
+    "country": "France"
   },
   {
     "name": "Université de Bordeaux",
-    "url": "http://docelec.u-bordeaux.fr/login?url=$@"
+    "url": "http://docelec.u-bordeaux.fr/login?url=",
+    "location": {
+      "lng": -0.6059053,
+      "lat": 44.8244914
+    },
+    "country": "France"
   },
   {
     "name": "Université de Bretagne Occidentale (UBO)",
-    "url": "https://cas.univ-brest.fr/cas/login?url=$@"
+    "url": "https://cas.univ-brest.fr/cas/login?url=",
+    "location": {
+      "lng": -4.5074935,
+      "lat": 48.39806189999999
+    },
+    "country": "France"
   },
   {
     "name": "Université de Lille",
-    "url": "http://ressources-electroniques.univ-lille.fr/login?url=$@"
+    "url": "http://ressources-electroniques.univ-lille.fr/login?url=",
+    "location": {
+      "lng": 3.0752632,
+      "lat": 50.6320414
+    },
+    "country": "France"
   },
   {
     "name": "Université de Québec à Montréal",
-    "url": "http://proxy.bibliotheques.uqam.ca/login?url=$@"
+    "url": "http://proxy.bibliotheques.uqam.ca/login?url=",
+    "location": {
+      "lng": -73.5602937,
+      "lat": 45.5131547
+    },
+    "country": "Canada"
   },
   {
     "name": "Université de Rennes 2",
-    "url": "http://distant.bu.univ-rennes1.fr/connect?url=$@"
+    "url": "http://distant.bu.univ-rennes1.fr/connect?url=",
+    "location": {
+      "lng": -1.7028658,
+      "lat": 48.1179154
+    },
+    "country": "France"
   },
   {
     "name": "Université de Sherbrooke",
-    "url": "https://ezproxy.usherbrooke.ca/login?URL=$@"
+    "url": "https://ezproxy.usherbrooke.ca/login?URL=",
+    "location": {
+      "lng": -71.89367399999999,
+      "lat": 45.4042669
+    },
+    "country": "Canada"
   },
   {
     "name": "Université de Strasbourg",
-    "url": "https://scd-rproxy.u-strasbg.fr/login?url=$@"
+    "url": "https://scd-rproxy.u-strasbg.fr/login?url=",
+    "location": {
+      "lng": 7.766454499999999,
+      "lat": 48.5790692
+    },
+    "country": "France"
   },
   {
     "name": "Université Grenoble Alpes",
-    "url": "https://login.sid2nomade-1.grenet.fr/login?url=$@"
+    "url": "https://login.sid2nomade-1.grenet.fr/login?url=",
+    "location": {
+      "lng": 5.7672336,
+      "lat": 45.1915639
+    },
+    "country": "France"
   },
   {
     "name": "Université Gustave Eiffel (GHU-Paris)",
-    "url": "https://univ-eiffel.idm.oclc.org/login?url=$@"
+    "url": "https://univ-eiffel.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 2.5877098,
+      "lat": 48.8426391
+    },
+    "country": "France"
   },
   {
     "name": "Université Laval",
-    "url": "http://acces.bibl.ulaval.ca/login?url=$@"
+    "url": "http://acces.bibl.ulaval.ca/login?url=",
+    "location": {
+      "lng": -71.2747424,
+      "lat": 46.78174629999999
+    },
+    "country": "Canada"
   },
   {
     "name": "Université Libre de Bruxelles",
-    "url": "https://ezproxy.ulb.ac.be/login?url=$@"
+    "url": "https://ezproxy.ulb.ac.be/login?url=",
+    "location": {
+      "lng": 4.3822222,
+      "lat": 50.8132068
+    },
+    "country": "Belgium"
   },
   {
     "name": "Université Libre de Bruxelles (ULB)",
-    "url": "https://www.ezproxy.ulb.ac.be/login?url=$@"
+    "url": "https://www.ezproxy.ulb.ac.be/login?url=",
+    "location": {
+      "lng": 4.3822222,
+      "lat": 50.8132068
+    },
+    "country": "Belgium"
   },
   {
     "name": "Université Lille 1",
-    "url": "http://buproxy.univ-lille1.fr/login?url=$@"
+    "url": "http://buproxy.univ-lille1.fr/login?url=",
+    "location": {
+      "lng": 3.1417556,
+      "lat": 50.6085867
+    },
+    "country": "France"
   },
   {
     "name": "Université Paris 6 et 7 - Mathématiques Informatique Recherche",
-    "url": "http://ezproxy.math-info-paris.cnrs.fr/login?url=$@"
+    "url": "http://ezproxy.math-info-paris.cnrs.fr/login?url=",
+    "location": {
+      "lng": 2.357499,
+      "lat": 48.8471036
+    },
+    "country": "France"
   },
   {
     "name": "Université Paris Cité",
-    "url": "https://ezproxy.u-paris.fr/login?url=$@"
+    "url": "https://ezproxy.u-paris.fr/login?url=",
+    "location": {
+      "lng": 2.3318026778200607,
+      "lat": 48.85676231053687
+    },
+    "country": "France"
   },
   {
     "name": "Université Paris-Saclay",
-    "url": "http://ezproxy.universite-paris-saclay.fr/login?url=$@"
+    "url": "http://ezproxy.universite-paris-saclay.fr/login?url=",
+    "location": {
+      "lng": 2.1666978,
+      "lat": 48.7098718
+    },
+    "country": "France"
   },
   {
     "name": "Université Pierre et Marie Curie - Paris 6",
-    "url": "http://accesdistant.upmc.fr/login?url=$@"
+    "url": "http://accesdistant.upmc.fr/login?url=",
+    "location": {
+      "lng": 2.357499,
+      "lat": 48.8471036
+    },
+    "country": "France"
   },
   {
     "name": "Université Polytechnique Hauts-de-France",
-    "url": "https://login.ezproxy.uphf.fr/login?url=$@"
+    "url": "https://login.ezproxy.uphf.fr/login?url=",
+    "location": {
+      "lng": 3.5168432,
+      "lat": 50.3262594
+    },
+    "country": "France"
   },
   {
     "name": "Université Saint Jospeh Beirut",
-    "url": "https://ezproxy.usj.edu.lb/login?url=$@"
+    "url": "https://ezproxy.usj.edu.lb/login?url=",
+    "location": {
+      "lng": 35.508674,
+      "lat": 33.891593
+    },
+    "country": "Lebanon"
   },
   {
     "name": "Université Toulouse II Jean Jaurès",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
+    "url": "https://gorgone.univ-toulouse.fr/login?url=",
+    "location": {
+      "lng": 1.4020557,
+      "lat": 43.5763289
+    },
+    "country": "France"
   },
   {
     "name": "Univerza v Ljubljani",
-    "url": "http://cmk-proxy.mf.uni-lj.si:2048/login?url=$@"
+    "url": "http://cmk-proxy.mf.uni-lj.si:2048/login?url=",
+    "location": {
+      "lng": 14.5041552,
+      "lat": 46.0491938
+    },
+    "country": "Slovenia"
   },
   {
     "name": "Univerzita Karlova v Praze",
-    "url": "https://login.ezproxy.is.cuni.cz/login?url=$@"
+    "url": "https://login.ezproxy.is.cuni.cz/login?url=",
+    "location": {
+      "lng": 14.4234889,
+      "lat": 50.0871106
+    },
+    "country": "Czechia"
   },
   {
     "name": "Univerzita Tomase Bati ve Zline",
-    "url": "http://proxy.k.utb.cz/login?url=$@"
+    "url": "http://proxy.k.utb.cz/login?url=",
+    "location": {
+      "lng": 17.664866,
+      "lat": 49.222624
+    },
+    "country": "Czechia"
   },
   {
     "name": "Uppsala University",
-    "url": "http://ezproxy.its.uu.se/login?url=$@"
+    "url": "http://ezproxy.its.uu.se/login?url=",
+    "location": {
+      "lng": 17.6300093,
+      "lat": 59.85090049999999
+    },
+    "country": "Sweden"
   },
   {
     "name": "Ural Federal University (URFU)",
-    "url": "https://ezproxy.urfu.ru/login?url=$@"
+    "url": "https://ezproxy.urfu.ru/login?url=",
+    "location": {
+      "lng": 60.6160252,
+      "lat": 56.8403246
+    },
+    "country": "Russia"
   },
   {
     "name": "UT Health Center San Antonio",
-    "url": "http://libproxy.uthscsa.edu/login?url=$@"
+    "url": "http://libproxy.uthscsa.edu/login?url=",
+    "location": {
+      "lng": -98.4945922,
+      "lat": 29.4251905
+    },
+    "country": "United States"
   },
   {
     "name": "Utah State University",
-    "url": "http://dist.lib.usu.edu/login?url=$@"
+    "url": "http://dist.lib.usu.edu/login?url=",
+    "location": {
+      "lng": -111.8097425,
+      "lat": 41.745161
+    },
+    "country": "United States"
   },
   {
     "name": "Utah Valley",
-    "url": "https://ezproxy.uvu.edu/login?qurl=$@"
+    "url": "https://ezproxy.uvu.edu/login?qurl=",
+    "location": {
+      "lng": -111.7153739,
+      "lat": 40.2787626
+    },
+    "country": "United States"
   },
   {
     "name": "UTCC",
-    "url": "https://login.ezproxy.utcc.ac.th/login?url=$@"
+    "url": "https://login.ezproxy.utcc.ac.th/login?url=",
+    "location": {
+      "lng": 100.5600899,
+      "lat": 13.7785495
+    },
+    "country": "Thailand"
   },
   {
     "name": "Utica",
-    "url": "https://ezproxy.utica.edu/login?url=$@"
+    "url": "https://ezproxy.utica.edu/login?url=",
+    "location": {
+      "lng": -75.232664,
+      "lat": 43.100903
+    },
+    "country": "United States"
   },
   {
     "name": "Utrecht University",
-    "url": "https://login.proxy.library.uu.nl/login?url=$@"
+    "url": "https://login.proxy.library.uu.nl/login?url=",
+    "location": {
+      "lng": 5.1757062,
+      "lat": 52.08518249999999
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Valley City State",
-    "url": "https://library.vcsu.edu:2443/login?url=$@"
+    "url": "https://library.vcsu.edu:2443/login?url=",
+    "location": {
+      "lng": -98.0028198,
+      "lat": 46.9186274
+    },
+    "country": "United States"
   },
   {
     "name": "Valparaiso",
-    "url": "http://ezproxy.valpo.edu/login?url=$@"
+    "url": "http://ezproxy.valpo.edu/login?url=",
+    "location": {
+      "lng": -71.61268849999999,
+      "lat": -33.047238
+    },
+    "country": "Chile"
   },
   {
     "name": "Van Hall Larenstein",
-    "url": "http://hvhl.idm.oclc.org/login?url=$@"
+    "url": "http://hvhl.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 5.8042998,
+      "lat": 53.19421759999999
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Vancouver Island",
-    "url": "http://ezproxy.viu.ca/login?url=$@"
+    "url": "http://ezproxy.viu.ca/login?url=",
+    "location": {
+      "lng": -125.4493906,
+      "lat": 49.6506376
+    },
+    "country": "Canada"
   },
   {
     "name": "Vanderbilt University",
-    "url": "http://proxy.library.vanderbilt.edu/login?url=$@"
+    "url": "http://proxy.library.vanderbilt.edu/login?url=",
+    "location": {
+      "lng": -86.8026551,
+      "lat": 36.1447034
+    },
+    "country": "United States"
   },
   {
     "name": "Vanguard University",
-    "url": "https://vanguard.idm.oclc.org/login?url=$@"
+    "url": "https://vanguard.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -117.89434400590231,
+      "lat": 33.77516276589112
+    },
+    "country": "United States"
   },
   {
     "name": "Vassar",
-    "url": "http://libproxy.vassar.edu/login?url=$@"
+    "url": "http://libproxy.vassar.edu/login?url=",
+    "location": {
+      "lng": -73.8936812,
+      "lat": 41.68667809999999
+    },
+    "country": "United States"
   },
   {
     "name": "Victoria University",
-    "url": "http://wallaby.vu.edu.au:5678/login?url=$@"
+    "url": "http://wallaby.vu.edu.au:5678/login?url=",
+    "location": {
+      "lng": 144.96434503852703,
+      "lat": -37.81518569294075
+    },
+    "country": "Australia"
   },
   {
     "name": "Victoria University of Wellington",
-    "url": "https://login.helicon.vuw.ac.nz/login?url=$@"
+    "url": "https://login.helicon.vuw.ac.nz/login?url=",
+    "location": {
+      "lng": 174.7678789,
+      "lat": -41.2901075
+    },
+    "country": "New Zealand"
   },
   {
     "name": "Victoria University | Melbourne Australia",
-    "url": "http://wallaby.vu.edu.au:2048/login?url=$@"
+    "url": "http://wallaby.vu.edu.au:2048/login?url=",
+    "location": {
+      "lng": 144.9630576,
+      "lat": -37.8136276
+    },
+    "country": "Australia"
   },
   {
     "name": "VID vitenskapelige høgskole",
-    "url": "https://ezproxy.vid.no/login?url=$@"
+    "url": "https://ezproxy.vid.no/login?url=",
+    "location": {
+      "lng": 10.7051483,
+      "lat": 59.9366728
+    },
+    "country": "Norway"
   },
   {
-    "name": "Vienna University Library",
-    "url": "http://uaccess.univie.ac.at/login?url=$@"
+    "name": "Vienna University Library ",
+    "url": "http://uaccess.univie.ac.at/login?url=",
+    "location": {
+      "lng": 16.36027,
+      "lat": 48.2133938
+    },
+    "country": "Austria"
   },
   {
     "name": "Villanova",
-    "url": "http://ezp1.villanova.edu:80/login?url=$@"
+    "url": "http://ezp1.villanova.edu:80/login?url=",
+    "location": {
+      "lng": -75.3491813,
+      "lat": 40.0375832
+    },
+    "country": "United States"
   },
   {
     "name": "Virginia Commonwealth University",
-    "url": "https://proxy.library.vcu.edu/login?url=$@"
+    "url": "https://proxy.library.vcu.edu/login?url=",
+    "location": {
+      "lng": -77.4527359,
+      "lat": 37.5526695
+    },
+    "country": "United States"
   },
   {
     "name": "Virginia Tech",
-    "url": "https://login.ezproxy.lib.vt.edu/login?qurl=$@"
+    "url": "https://login.ezproxy.lib.vt.edu/login?qurl=",
+    "location": {
+      "lng": -80.42341669999999,
+      "lat": 37.22838429999999
+    },
+    "country": "United States"
   },
   {
     "name": "Vrije Universiteit Amsterdam",
-    "url": "https://vu-nl.idm.oclc.org/login?url=$@"
+    "url": "https://vu-nl.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 4.8657199,
+      "lat": 52.3337568
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Vrije Universiteit Brussel (VUB)",
-    "url": "https://myezproxy.vub.ac.be/login?url=$@"
+    "url": "https://myezproxy.vub.ac.be/login?url=",
+    "location": {
+      "lng": 4.3802052,
+      "lat": 50.8260453
+    },
+    "country": "Belgium"
   },
   {
     "name": "Wageningen UR",
-    "url": "http://ezproxy.library.wur.nl/login?url=$@"
+    "url": "http://ezproxy.library.wur.nl/login?url=",
+    "location": {
+      "lng": 5.6680191,
+      "lat": 51.9863475
+    },
+    "country": "Netherlands"
   },
   {
     "name": "Waiariki Bay of Plenty Polytechnic",
-    "url": "http://ezproxy.waiariki.ac.nz:2048/login?url=$@"
+    "url": "http://ezproxy.waiariki.ac.nz:2048/login?url=",
+    "location": {
+      "lng": 175.8743607845435,
+      "lat": -38.21747790944405
+    },
+    "country": "New Zealand"
   },
   {
     "name": "Wake Forest",
-    "url": "http://ezproxy.wfu.edu/login?url=$@"
+    "url": "http://ezproxy.wfu.edu/login?url=",
+    "location": {
+      "lng": -80.2792887,
+      "lat": 36.1354887
+    },
+    "country": "United States"
   },
   {
     "name": "Wake Technical",
-    "url": "http://ezproxy.waketech.edu/login?url=$@"
+    "url": "http://ezproxy.waketech.edu/login?url=",
+    "location": {
+      "lng": -78.70471789999999,
+      "lat": 35.6515968
+    },
+    "country": "United States"
   },
   {
     "name": "Walden University",
-    "url": "http://ezp.waldenulibrary.org/login?url=$@"
+    "url": "http://ezp.waldenulibrary.org/login?url=",
+    "location": {
+      "lng": -93.2655624,
+      "lat": 44.9811267
+    },
+    "country": "United States"
   },
   {
     "name": "Walla Walla",
-    "url": "http://ezproxy.wwcc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.wwcc.edu:2048/login?url=",
+    "location": {
+      "lng": -118.3430209,
+      "lat": 46.0645809
+    },
+    "country": "United States"
   },
   {
     "name": "Warner Pacific",
-    "url": "http://ezproxy.warnerpacific.edu:2048/login?url=$@"
+    "url": "http://ezproxy.warnerpacific.edu:2048/login?url=",
+    "location": {
+      "lng": -122.5932083,
+      "lat": 45.5062217
+    },
+    "country": "United States"
   },
   {
     "name": "Waseda University",
-    "url": "https://waseda.idm.oclc.org/login?url=$@"
+    "url": "https://waseda.idm.oclc.org/login?url=",
+    "location": {
+      "lng": 139.7196485,
+      "lat": 35.7087334
+    },
+    "country": "Japan"
   },
   {
     "name": "Washington State",
-    "url": "https://ntserver1.wsulibs.wsu.edu:6443/login?url=$@"
+    "url": "https://ntserver1.wsulibs.wsu.edu:6443/login?url=",
+    "location": {
+      "lng": -120.7401386,
+      "lat": 47.7510741
+    },
+    "country": "United States"
   },
   {
     "name": "Washington University in St. Louis",
-    "url": "http://libproxy.wustl.edu/login?url=$@"
+    "url": "http://libproxy.wustl.edu/login?url=",
+    "location": {
+      "lng": -90.31079620000001,
+      "lat": 38.6487895
+    },
+    "country": "United States"
   },
   {
     "name": "Washington University School of Medicine",
-    "url": "https://beckerproxy.wustl.edu/login?url=$@"
+    "url": "https://beckerproxy.wustl.edu/login?url=",
+    "location": {
+      "lng": -90.26292889999999,
+      "lat": 38.6351441
+    },
+    "country": "United States"
   },
   {
     "name": "Washtenaw",
-    "url": "https://login.ezproxy.wccnet.edu/login?url=$@"
+    "url": "https://login.ezproxy.wccnet.edu/login?url=",
+    "location": {
+      "lng": -83.8473015,
+      "lat": 42.3076493
+    },
+    "country": "United States"
   },
   {
     "name": "Waterford Institute of Technology",
-    "url": "http://ezproxy.wit.ie:2048/login?url=$@"
+    "url": "http://ezproxy.wit.ie:2048/login?url=",
+    "location": {
+      "lng": -7.138704499999999,
+      "lat": 52.2460592
+    },
+    "country": "Ireland"
   },
   {
     "name": "Waubonsee",
-    "url": "https://dewey.waubonsee.edu/login?url=$@"
+    "url": "https://dewey.waubonsee.edu/login?url=",
+    "location": {
+      "lng": -88.4584655,
+      "lat": 41.7952983
+    },
+    "country": "United States"
   },
   {
     "name": "Wayne Community College",
-    "url": "http://cgez.waynecc.edu:2048/login?url=$@"
+    "url": "http://cgez.waynecc.edu:2048/login?url=",
+    "location": {
+      "lng": -77.94535288180907,
+      "lat": 35.40320329467797
+    },
+    "country": "United States"
   },
   {
     "name": "Wayne State University",
-    "url": "http://proxy.lib.wayne.edu/login?url=$@"
+    "url": "http://proxy.lib.wayne.edu/login?url=",
+    "location": {
+      "lng": -83.06654619999999,
+      "lat": 42.3591388
+    },
+    "country": "United States"
   },
   {
     "name": "Webster University",
-    "url": "http://library3.webster.edu/login?url=$@"
+    "url": "http://library3.webster.edu/login?url=",
+    "location": {
+      "lng": -90.34398022210736,
+      "lat": 38.589540722949536
+    },
+    "country": "United States"
   },
   {
     "name": "Weill Cornell Medicine",
-    "url": "http://ezproxy.med.cornell.edu/login?url=$@"
+    "url": "http://ezproxy.med.cornell.edu/login?url=",
+    "location": {
+      "lng": -73.9555127,
+      "lat": 40.7664886
+    },
+    "country": "United States"
   },
   {
     "name": "Weizmann Institute of Science",
-    "url": "https://ezproxy.weizmann.ac.il/login?url=$@"
+    "url": "https://ezproxy.weizmann.ac.il/login?url=",
+    "location": {
+      "lng": 34.8080315,
+      "lat": 31.90375409999999
+    },
+    "country": "Israel"
   },
   {
     "name": "Wellesley College",
-    "url": "https://ezproxy.wellesley.edu/login?url=$@"
+    "url": "https://ezproxy.wellesley.edu/login?url=",
+    "location": {
+      "lng": -71.3059277,
+      "lat": 42.2935733
+    },
+    "country": "United States"
   },
   {
     "name": "Wentworth Institute of Technology",
-    "url": "http://ezproxywit.flo.org/login?url=$@"
+    "url": "http://ezproxywit.flo.org/login?url=",
+    "location": {
+      "lng": -71.0965415,
+      "lat": 42.3370447
+    },
+    "country": "United States"
   },
   {
     "name": "Wesleyan",
-    "url": "http://ezproxy.wesleyan.edu:7790/login?url=$@"
+    "url": "http://ezproxy.wesleyan.edu:7790/login?url=",
+    "location": {
+      "lng": -72.6568336,
+      "lat": 41.5567587
+    },
+    "country": "United States"
   },
   {
     "name": "West Chester University",
-    "url": "http://proxy-wcupa.klnpa.org/login?url=$@"
+    "url": "http://proxy-wcupa.klnpa.org/login?url=",
+    "location": {
+      "lng": -75.5981257,
+      "lat": 39.9523671
+    },
+    "country": "United States"
   },
   {
     "name": "West Texas A&M University",
-    "url": "https://login.databases.wtamu.edu/login?url=$@"
+    "url": "https://login.databases.wtamu.edu/login?url=",
+    "location": {
+      "lng": -101.9160329,
+      "lat": 34.9816909
+    },
+    "country": "United States"
   },
   {
     "name": "West Virginia",
-    "url": "https://wvu.idm.oclc.org/login?url=$@"
+    "url": "https://wvu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -80.4549026,
+      "lat": 38.5976262
+    },
+    "country": "United States"
   },
   {
     "name": "Western Governors",
-    "url": "http://wgu.idm.oclc.org/login?url=$@"
+    "url": "http://wgu.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -111.8699469,
+      "lat": 40.684929
+    },
+    "country": "United States"
   },
   {
     "name": "Western Illinois",
-    "url": "https://ezproxy.wiu.edu/login?url=$@"
+    "url": "https://ezproxy.wiu.edu/login?url=",
+    "location": {
+      "lng": -90.68435989999999,
+      "lat": 40.4766148
+    },
+    "country": "United States"
   },
   {
     "name": "Western Iowa Tech",
-    "url": "http://witcc.idm.oclc.org/login?url=$@"
+    "url": "http://witcc.idm.oclc.org/login?url=",
+    "location": {
+      "lng": -96.34792,
+      "lat": 42.483421
+    },
+    "country": "United States"
   },
   {
     "name": "Western Kentucky",
-    "url": "http://libsrv.wku.edu:2048/login?url=$@"
+    "url": "http://libsrv.wku.edu:2048/login?url=",
+    "location": {
+      "lng": -86.4559991,
+      "lat": 36.9847153
+    },
+    "country": "United States"
   },
   {
     "name": "Western Michigan",
-    "url": "http://libproxy.library.wmich.edu/login?url=$@"
+    "url": "http://libproxy.library.wmich.edu/login?url=",
+    "location": {
+      "lng": -85.6102506,
+      "lat": 42.2837337
+    },
+    "country": "United States"
   },
   {
     "name": "Western Montana College of The University of Montana",
-    "url": "http://proxyserver.umwestern.edu:2048/login?url=$@"
+    "url": "http://proxyserver.umwestern.edu:2048/login?url=",
+    "location": {
+      "lng": -112.6386268,
+      "lat": 45.208792
+    },
+    "country": "United States"
   },
   {
     "name": "Western Norway University of Applied Sciences (HVL)",
-    "url": "https://galanga.hvl.no/login?url=$@"
+    "url": "https://galanga.hvl.no/login?url=",
+    "location": {
+      "lng": 5.350094299999999,
+      "lat": 60.3689499
+    },
+    "country": "Norway"
   },
   {
     "name": "Western Oregon",
-    "url": "https://ezproxy.wou.edu/login?url=$@"
+    "url": "https://ezproxy.wou.edu/login?url=",
+    "location": {
+      "lng": -123.2405476,
+      "lat": 44.8538061
+    },
+    "country": "United States"
   },
   {
     "name": "Western Oregon University",
-    "url": "https://login.ezproxy.wou.edu/login?url=$@"
+    "url": "https://login.ezproxy.wou.edu/login?url=",
+    "location": {
+      "lng": -123.2405476,
+      "lat": 44.8538061
+    },
+    "country": "United States"
   },
   {
     "name": "Western Sydney University",
-    "url": "http://ezproxy.uws.edu.au/login?url=$@"
+    "url": "http://ezproxy.uws.edu.au/login?url=",
+    "location": {
+      "lng": 151.20764898180545,
+      "lat": -33.839881410614645
+    },
+    "country": "Australia"
   },
   {
     "name": "Western Technical",
-    "url": "http://ezproxy.westerntc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.westerntc.edu:2048/login?url=",
+    "location": {
+      "lng": -91.2460065,
+      "lat": 43.8154127
+    },
+    "country": "United States"
   },
   {
     "name": "Western Theological Seminary",
-    "url": "https://login.proxy.westernsem.edu:4443/login?url=$@"
+    "url": "https://login.proxy.westernsem.edu:4443/login?url=",
+    "location": {
+      "lng": -86.1033533,
+      "lat": 42.7861144
+    },
+    "country": "United States"
   },
   {
     "name": "Western University of Health Sciences",
-    "url": "https://proxy.westernu.edu/login?url=$@"
+    "url": "https://proxy.westernu.edu/login?url=",
+    "location": {
+      "lng": -117.7457873,
+      "lat": 34.0579319
+    },
+    "country": "United States"
   },
   {
     "name": "Western Washington University",
-    "url": "http://ezproxy.library.wwu.edu/login?url=$@"
+    "url": "http://ezproxy.library.wwu.edu/login?url=",
+    "location": {
+      "lng": -122.4866102,
+      "lat": 48.7342877
+    },
+    "country": "United States"
   },
   {
     "name": "Western Wyoming Community College",
-    "url": "http://library.westernwyoming.edu/login?url=$@"
+    "url": "http://library.westernwyoming.edu/login?url=",
+    "location": {
+      "lng": -109.23703,
+      "lat": 41.5911812
+    },
+    "country": "United States"
   },
   {
     "name": "Westminster",
-    "url": "http://ezproxy.westminstercollege.edu/login?url=$@"
+    "url": "http://ezproxy.westminstercollege.edu/login?url=",
+    "location": {
+      "lng": -0.1356583,
+      "lat": 51.4974948
+    },
+    "country": "United Kingdom"
   },
   {
     "name": "Westminster College, Salt Lake City",
-    "url": "https://login.ezproxy.westminstercollege.edu/login?url=$@"
+    "url": "https://login.ezproxy.westminstercollege.edu/login?url=",
+    "location": {
+      "lng": -111.8549815,
+      "lat": 40.7322206
+    },
+    "country": "United States"
   },
   {
     "name": "Westminster Seminary California",
-    "url": "http://ezproxy.wscal.edu/login?url=$@"
+    "url": "http://ezproxy.wscal.edu/login?url=",
+    "location": {
+      "lng": -117.046063,
+      "lat": 33.121678
+    },
+    "country": "United States"
   },
   {
     "name": "Westmont",
-    "url": "http://ezproxy.westmont.edu:2048/login?url=$@"
+    "url": "http://ezproxy.westmont.edu:2048/login?url=",
+    "location": {
+      "lng": -87.9756175,
+      "lat": 41.7958639
+    },
+    "country": "United States"
   },
   {
     "name": "Wheaton College",
-    "url": "http://ezproxy.wheaton.edu/login?url=$@"
+    "url": "http://ezproxy.wheaton.edu/login?url=",
+    "location": {
+      "lng": -88.0969325,
+      "lat": 41.8695424
+    },
+    "country": "United States"
   },
   {
     "name": "Whitman College",
-    "url": "http://ezproxy.whitman.edu:2048/login?url=$@"
+    "url": "http://ezproxy.whitman.edu:2048/login?url=",
+    "location": {
+      "lng": -117.93672801368764,
+      "lat": 47.148304723917335
+    },
+    "country": "United States"
   },
   {
     "name": "Whittier",
-    "url": "http://ezproxy.whittier.edu/login?url=$@"
+    "url": "http://ezproxy.whittier.edu/login?url=",
+    "location": {
+      "lng": -118.032844,
+      "lat": 33.9791793
+    },
+    "country": "United States"
   },
   {
     "name": "Wichita State",
-    "url": "http://proxy.wichita.edu/login?url=$@"
+    "url": "http://proxy.wichita.edu/login?url=",
+    "location": {
+      "lng": -97.28994209999999,
+      "lat": 37.7191442
+    },
+    "country": "United States"
   },
   {
     "name": "Wilfrid Laurier University",
-    "url": "http://libproxy.wlu.ca/login?url=$@"
+    "url": "http://libproxy.wlu.ca/login?url=",
+    "location": {
+      "lng": -80.5274701,
+      "lat": 43.4738499
+    },
+    "country": "Canada"
   },
   {
     "name": "Wilkes",
-    "url": "http://ezproxy.wilkescc.edu:2048/login?url=$@"
+    "url": "http://ezproxy.wilkescc.edu:2048/login?url=",
+    "location": {
+      "lng": -75.8883633,
+      "lat": 41.2449585
+    },
+    "country": "United States"
   },
   {
     "name": "William Jessup",
-    "url": "http://ezproxy.jessup.edu/login?url=$@"
+    "url": "http://ezproxy.jessup.edu/login?url=",
+    "location": {
+      "lng": -121.292457,
+      "lat": 38.8203949
+    },
+    "country": "United States"
   },
   {
     "name": "William Paterson",
-    "url": "http://ezproxy.wpunj.edu:2048/login?url=$@"
+    "url": "http://ezproxy.wpunj.edu:2048/login?url=",
+    "location": {
+      "lng": -74.19677949999999,
+      "lat": 40.9476318
+    },
+    "country": "United States"
   },
   {
     "name": "William Peace",
-    "url": "http://ezproxy.peace.edu:2048/login?url=$@"
+    "url": "http://ezproxy.peace.edu:2048/login?url=",
+    "location": {
+      "lng": -78.637391,
+      "lat": 35.78948099999999
+    },
+    "country": "United States"
   },
   {
     "name": "William Penn University",
-    "url": "http://library.wmpenn.edu:2048/login?url=$@"
+    "url": "http://library.wmpenn.edu:2048/login?url=",
+    "location": {
+      "lng": -92.64718599472059,
+      "lat": 41.308936447267165
+    },
+    "country": "United States"
   },
   {
     "name": "Williams College",
-    "url": "https://ezproxy2.williams.edu/login?url=$@"
+    "url": "https://ezproxy2.williams.edu/login?url=",
+    "location": {
+      "lng": -73.20313949999999,
+      "lat": 42.7128843
+    },
+    "country": "United States"
   },
   {
     "name": "Winona State",
-    "url": "http://wsuproxy.mnpals.net/login?url=$@"
+    "url": "http://wsuproxy.mnpals.net/login?url=",
+    "location": {
+      "lng": -91.6432837,
+      "lat": 44.0473997
+    },
+    "country": "United States"
   },
   {
     "name": "Woodbury University",
-    "url": "https://ezproxy.woodbury.edu:2443/login?url=$@"
+    "url": "https://ezproxy.woodbury.edu:2443/login?url=",
+    "location": {
+      "lng": -118.3412543,
+      "lat": 34.2076585
+    },
+    "country": "United States"
   },
   {
     "name": "Worcester Polytechnic Institute",
-    "url": "http://ezproxy.wpi.edu/login?url=$@"
+    "url": "http://ezproxy.wpi.edu/login?url=",
+    "location": {
+      "lng": -71.8068416,
+      "lat": 42.2746179
+    },
+    "country": "United States"
   },
   {
     "name": "World Maritime University",
-    "url": "http://proxy.wmu.se/login?url=$@"
+    "url": "http://proxy.wmu.se/login?url=",
+    "location": {
+      "lng": 12.9965185,
+      "lat": 55.6078138
+    },
+    "country": "Sweden"
   },
   {
     "name": "Wright State University",
-    "url": "http://ezproxy.libraries.wright.edu:2048/login?url=$@"
+    "url": "http://ezproxy.libraries.wright.edu:2048/login?url=",
+    "location": {
+      "lng": -84.0587338,
+      "lat": 39.7846274
+    },
+    "country": "United States"
   },
   {
     "name": "Xavier",
-    "url": "http://libproxy.xu.edu:2048/login?url=$@"
+    "url": "http://libproxy.xu.edu:2048/login?url=",
+    "location": {
+      "lng": -84.4740892,
+      "lat": 39.1499074
+    },
+    "country": "United States"
   },
   {
     "name": "Xavier University of Louisiana",
-    "url": "https://ezproxy.xula.edu/login?url=$@"
+    "url": "https://ezproxy.xula.edu/login?url=",
+    "location": {
+      "lng": -90.10616259999999,
+      "lat": 29.9632276
+    },
+    "country": "United States"
   },
   {
     "name": "Yeshiva University",
-    "url": "https://yulib002.mc.yu.edu:8443/login?url=$@"
+    "url": "https://yulib002.mc.yu.edu:8443/login?url=",
+    "location": {
+      "lng": -73.9297205,
+      "lat": 40.8506041
+    },
+    "country": "United States"
   },
   {
     "name": "Yonsei",
-    "url": "https://access.yonsei.ac.kr/link.n2s?url=$@"
+    "url": "https://access.yonsei.ac.kr/link.n2s?url=",
+    "location": {
+      "lng": 126.938572,
+      "lat": 37.565784
+    },
+    "country": "South Korea"
   },
   {
     "name": "York College",
-    "url": "https://login.york.ezproxy.cuny.edu/login?qurl=$@"
+    "url": "https://login.york.ezproxy.cuny.edu/login?qurl=",
+    "location": {
+      "lng": -73.7961103,
+      "lat": 40.7010415
+    },
+    "country": "United States"
   },
   {
     "name": "York University",
-    "url": "http://ezproxy.library.yorku.ca/login?url=$@"
+    "url": "http://ezproxy.library.yorku.ca/login?url=",
+    "location": {
+      "lng": -79.50186839999999,
+      "lat": 43.7734535
+    },
+    "country": "Canada"
   },
   {
     "name": "Youngstown State",
-    "url": "http://eps.maag.ysu.edu:2048/login?url=$@"
+    "url": "http://eps.maag.ysu.edu:2048/login?url=",
+    "location": {
+      "lng": -80.6480952,
+      "lat": 41.1066413
+    },
+    "country": "United States"
   },
   {
     "name": "Åbo Akademi University",
-    "url": "https://ezproxy.vasa.abo.fi/login?url=$@"
+    "url": "https://ezproxy.vasa.abo.fi/login?url=",
+    "location": {
+      "lng": 22.2776003,
+      "lat": 60.45098689999999
+    },
+    "country": "Finland"
   },
   {
     "name": "École des Mines d'Albi - Carmaux",
-    "url": "https://gorgone.univ-toulouse.fr/login?url=$@"
+    "url": "https://gorgone.univ-toulouse.fr/login?url=",
+    "location": {
+      "lng": 2.178954,
+      "lat": 43.922508
+    },
+    "country": "France"
   },
   {
     "name": "台湾新光医院 (Taiwan Xinguang Hospital)",
-    "url": "http://rpa.skh.org.tw:81/login?url=$@"
+    "url": "http://rpa.skh.org.tw:81/login?url=",
+    "location": {
+      "lng": 121.5201549,
+      "lat": 25.0964041
+    },
+    "country": "Taiwan"
   },
   {
     "name": "地质大学",
-    "url": "http://yc.hnadl.cn/login?url=$@"
+    "url": "http://yc.hnadl.cn/login?url=",
+    "location": {
+      "lng": 116.3471009,
+      "lat": 39.991253
+    },
+    "country": "China"
   }
 ]


### PR DESCRIPTION
I propose to add two new fields: location and country. The location target the main coordinated associated for each proxy, whereas the field shows a more approximate location for each proxy.

For instance, the following entry:
```  
  {
    "name": "University of Malta",
    "url": "https://ejournals.um.edu.mt/login/?url=$@"
  }
```
becomes
```
  {
    "name": "University of Malta",
    "url": "https://ejournals.um.edu.mt/login/?url=$@",
    "location": {
      "lng": 14.4847432,
      "lat": 35.90232
    },
    "country": "Malta"
  }
```

Known issues regarding this approach. Some proxies may have campuses across different countries. So, I chose the country of the main campus. Also, some institutions may not have a main campus/headquarters, so the location coordinates may be inaccurate. For instance, Alberta Health Services is spread throughout Alberta, and OSF HealthCare is spread through Illinois.
