### PR TITLE
Update proxies.json

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -730,7 +730,7 @@
   },
   {
     "name": "Ben Gurion University",
-    "url": "https://ezproxy.bgu.ac.il/login?url=$@",
+    "url": "https://bengurionu.idm.oclc.org/login?url=$@",
     "location": {
       "lng": 34.7995546,
       "lat": 31.261426


### PR DESCRIPTION
Hi,
Ben-Gurion University has moved to OCLC hosted EZproxy. Our new EZproxy prefix is:
https://bengurionu.idm.oclc.org/login?url= 

Thank you,
Yossi