### PR TITLE
Update proxies.json for HEC Montreal

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -3582,7 +3582,7 @@
   },
   {
     "name": "HEC Montreal",
-    "url": "http://proxy2.hec.ca/login?url=$@",
+    "url": "https://login.proxy2.hec.ca/login?url=$@",
     "location": {
       "lng": -73.6211174,
       "lat": 45.5035488


### PR DESCRIPTION
Fixed HEC Montreal's URL to match updated DNS certificate.

New certificate does not allow `proxy2.hec.ca`, only `*.proxy2.hec.ca` which causes issues on some browsers.