### PR TITLE
CNRS INS2I proxy

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -1853,6 +1853,15 @@
     "country": "France"
   },
   {
+    "name": "CNRS INS2I",
+    "url": "http://ins2i.bib.cnrs.fr/login?url=$@",
+    "location": {
+      "lng": 2.2639934,
+      "lat": 48.8476037
+    },
+    "country": "France"
+  },
+  {
     "name": "CNRS INSB",
     "url": "http://insb.bib.cnrs.fr/login?url=$@",
     "location": {


### PR DESCRIPTION
Lib Proxy for the INS2I institute (computer science) for the CNRS -- one of the major French Research Institutes (more than 4,500 researchers) https://www.ins2i.cnrs.fr/en