### PR TITLE
Update proxies.json – London School of Economics

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -9018,7 +9018,7 @@
   },
   {
     "name": "The London School of Economics and Political Science (LSE)",
-    "url": "https://gate2.library.lse.ac.uk/login?url=$@",
+    "url": "https://gate3.library.lse.ac.uk/login?url=$@",
     "location": {
       "lng": -0.1164513,
       "lat": 51.5144388


### PR DESCRIPTION
Updated London School of Economics URL from gate2 to gate3