### PR TITLE
Add Advocate Health entry to proxies.json

### DIFF
--- a/static/proxies.json
+++ b/static/proxies.json
@@ -72,6 +72,15 @@
     "country": "United States"
   },
   {
+    "name": "Advocate Health",
+    "url": "https://liblynxgateway.com/aah?url=$@",
+    "location": {
+      "lng": -87.9097,
+      "lat": 43.0410
+    },
+    "country": "United States"
+  },
+  {
     "name": "AFIT D'Azzo Research Library",
     "url": "https://login.afit.idm.oclc.org/login?url=$@",
     "location": {


### PR DESCRIPTION
Advocate Health ranks as the third-largest nonprofit integrated health system in the United States. This is the proxy to the system's medical library.